### PR TITLE
Fix Chrome developer console warning about password input fields not contained in a form

### DIFF
--- a/templates/modals.html
+++ b/templates/modals.html
@@ -279,6 +279,7 @@
                 </button>
             </div>
             <div class="modal-body">
+                <form>
                 <!-- ko foreach: getSettings() -->
                     <!-- ko if: $data.getType() === 0 -->
                     <div class="input-group mb-1">
@@ -304,7 +305,7 @@
                         <div class="input-group-prepend">
                             <span class="input-group-text" data-bind="attr:{id:'setting'+$index(),title:$data.getDescription()},text:$data.getName()" data-toggle="tooltip" data-html="true" data-placement="left"></span>
                         </div>
-                        <input type="password" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$index()+'Value'}">
+                        <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$index()+'Value'}">
                         <div class="input-group-append">
                             <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.copy, attr:{id:'setting'+$index()+'Copy'}">
                                 <i class="material-icons md-18">content_copy</i>
@@ -313,6 +314,7 @@
                     </div>
                     <!-- /ko -->
                 <!-- /ko -->
+                </form>
                 <button class="btn btn-danger btn-block" id="resetSettingsDefaults" type="button" data-bind="click: $root.resetSettingsDefaults">Reset Defaults</button>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
Added form around password entry fields in the settings modal. 
Added autocomplete='off' attribute to password fields.