### PR TITLE
Renamed templatePalette.json and builtinPalette.json to template.pale…

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -24,8 +24,8 @@
 
 export class Config {
     // File name of the palette template.
-    static readonly templatePaletteFileName : string = "templatePalette.json";
-    static readonly builtinPaletteFileName : string = "builtinPalette.json";
+    static readonly templatePaletteFileName : string = "template.palette";
+    static readonly builtinPaletteFileName : string = "builtin.palette";
 
     // schemas
     static readonly graphSchemaFileName : string = "assets/schema/dlg-lg.graph.schema";

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1167,7 +1167,7 @@ export class Eagle {
             var showErrors: boolean = Eagle.findSetting(Utils.SHOW_FILE_LOADING_ERRORS).value();
 
             let errors: string[] = [];
-            this.templatePalette(Palette.fromOJSJson(JSON.stringify(data), new RepositoryFile(Repository.DUMMY, "", Config.templatePaletteFileName), errors));
+            this.templatePalette(Palette.fromOJSJson(data, new RepositoryFile(Repository.DUMMY, "", Config.templatePaletteFileName), errors));
 
             // show errors (if required)
             if (errors.length > 0 && showErrors){
@@ -1199,7 +1199,7 @@ export class Eagle {
                     console.error(error);
                     errors.push(error);
                 } else {
-                    let palette: Palette = Palette.fromOJSJson(JSON.stringify(data), new RepositoryFile(Repository.DUMMY, "", paletteList[index].name), errors);
+                    let palette: Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.DUMMY, "", paletteList[index].name), errors);
                     palette.fileInfo().clear();
                     palette.fileInfo().name = paletteList[index].name;
                     palette.fileInfo().readonly = paletteList[index].readonly;

--- a/static/builtin.palette
+++ b/static/builtin.palette
@@ -4,8 +4,7 @@
         "repoService": "Unknown",
         "repoBranch": "master",
         "repo": "",
-        "readonly": true,
-        "filePath": "builtinPalette.json",
+        "filePath": "builtin.palette",
         "sha": "",
         "git_url": "",
         "readonly": true

--- a/static/template.palette
+++ b/static/template.palette
@@ -2,9 +2,9 @@
     "modelData": {
         "fileType": "palette",
         "repoService": "Unknown",
-        "repoBranch": "",
+        "repoBranch": "master",
         "repo": "",
-        "filePath": "templatePalette.json",
+        "filePath": "template.palette",
         "sha": "",
         "git_url": "",
         "readonly": false


### PR DESCRIPTION
…tte and builtin.palette respectively. Minor modification to code since files are no longer served as JSON, and now an extra call to JSON.stringify() can be removed, the data already arrives as a string.