### PR TITLE
Use no white-space name as suffix for palette button id's, instead of…

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -160,6 +160,10 @@ export class Node {
         }
     }
 
+    getNoWhiteSpaceName = () : string => {
+        return this.getDisplayName().replace(' ', '');
+    }
+
     getDescription = () : string => {
         return this.description;
     }

--- a/static/components/palette-component.html
+++ b/static/components/palette-component.html
@@ -2,7 +2,7 @@
     <div class="col"  draggable="true" data-bind="event: {dragstart: $root.nodeDragStart,dragend: $root.nodeDragEnd} ">
         <div class="input-group mb-1"  data-bind="attr: {title: $data.getHelpHTML()}" data-toggle="tooltip" data-html="true" data-placement="right">
             <div class="input-group-prepend">
-                <button class="nodeBtn" type="button" data-bind="click: function(){$root.addNodeToLogicalGraph($data)}, attr: {id: 'addPaletteNode' + $data.index()}">
+                <button class="nodeBtn" type="button" data-bind="click: function(){$root.addNodeToLogicalGraph($data)}, attr: {id: 'addPaletteNode' + $data.getNoWhiteSpaceName()}">
                     <span class="input-group-text" data-bind="style: {'background-color': $data.getColor()}">
                         <i class="material-icons" data-bind="text: $data.getIcon()"></i>
                     </span>

--- a/tests/drag-and-drop.js
+++ b/tests/drag-and-drop.js
@@ -3,10 +3,8 @@ import { Selector } from 'testcafe';
 /*
     run with:
 
-    export EAGLE_GITHUB_ACCESS_TOKEN="<token>";testcafe chrome tests/drag-and-drop.js
+    testcafe chrome tests/drag-and-drop.js
 */
-
-var EAGLE_GITHUB_ACCESS_TOKEN = process.env.EAGLE_GITHUB_ACCESS_TOKEN;
 
 fixture `EAGLE Drag and Drop Node`
     .page `http://localhost:8888/`
@@ -17,7 +15,7 @@ test('Drag and drop node', async t =>{
         .wait(3000)
 
         // drag a File node from the palette into the graph
-        .drag(Selector('#addPaletteNode9'), 250, 0, {
+        .drag(Selector('#addPaletteNodeFile'), 250, 0, {
             offsetX: 40,
             offsetY: 40
         })

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -3,10 +3,9 @@ import { Selector } from 'testcafe';
 /*
     run with:
 
-    export EAGLE_GITHUB_ACCESS_TOKEN="<token>";testcafe chrome tests/edit-node-parameter.js
+    testcafe chrome tests/edit-node-parameter.js
 */
 
-var EAGLE_GITHUB_ACCESS_TOKEN = process.env.EAGLE_GITHUB_ACCESS_TOKEN;
 var DUMMY_VALUE = "0sdvh5gb8v7r4";
 
 fixture `EAGLE Edit Node Parameter`
@@ -18,7 +17,7 @@ test('Edit node parameter', async t =>{
         .wait(3000)
 
         // add a python node to the graph
-        .click("#addPaletteNode7")
+        .click("#addPaletteNodePythonApp")
 
         // check that a file node has been created
         .expect(Selector("#nodeNameValue").value).eql("Python App")


### PR DESCRIPTION
… numerical indices