### PR TITLE
Fix Palette Uploading

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -705,7 +705,7 @@ export class Eagle {
      * Loads a custom palette from a file.
      */
     uploadPaletteFile = () : void => {
-        const uploadedPaletteFileInputElement : HTMLInputElement = <HTMLInputElement> document.getElementById("uploadedPaletteFile");
+        const uploadedPaletteFileInputElement : HTMLInputElement = <HTMLInputElement> document.getElementById("uploadedPaletteFileToLoad");
         const fileFullPath : string = uploadedPaletteFileInputElement.value;
         const showErrors: boolean = Eagle.findSetting(Utils.SHOW_FILE_LOADING_ERRORS).value();
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,7 +45,7 @@
         <div style="display:none;">
             <input id="uploadedGraphFileToLoad" class="fileSelector" type="file" name="file" data-bind="event: { change: uploadGraphFile }">
             <input id="uploadedGraphFileToInsert" class="fileSelector" type="file" name="file" data-bind="event: { change: insertGraphFile }">
-            <input id="uploadedPaletteFileToLoad" class="fileSelector" type="file" name="file" data-bind="event: { change: function(){uploadPaletteFile();} }">
+            <input id="uploadedPaletteFileToLoad" class="fileSelector" type="file" name="file" data-bind="event: { change: uploadPaletteFile }">
         </div>
 
         {% include 'navbar.html' %}


### PR DESCRIPTION
I noticed a small bug with a simple correction when uploading palette files where the `uploadedPaletteFile` element id does not exist. Since uploading graphs works fine this change simply updates the palette upload to follow the same pattern. Also checked no console errors occur after uploading.