### PR TITLE
Eagle 556

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -165,8 +165,6 @@ export class Eagle {
         Eagle.shortcuts.push(new KeyboardShortcut("Create subgraph from selection", ["["], KeyboardShortcut.somethingIsSelected, (eagle): void => {eagle.createSubgraphFromSelection();}));
         Eagle.shortcuts.push(new KeyboardShortcut("Create construct from selection", ["]"], KeyboardShortcut.somethingIsSelected, (eagle): void => {eagle.createConstructFromSelection();}));
 
-        this.selectedObjects.subscribe(this.updateInspectorTooltips);
-
         this.globalOffsetX = 0;
         this.globalOffsetY = 0;
         this.globalScale = 1.0;
@@ -1491,18 +1489,6 @@ export class Eagle {
         GitLab.loadRepoList(this);
     };
 
-    static reloadTooltips = () : void => {
-        // destroy orphaned tooltips and initializing tooltip on document ready.
-        $('.tooltip[role="tooltip"]').remove();
-        $('[data-bs-toggle="tooltip"]').tooltip({
-            html : true,
-            boundary: document.body,
-            trigger : 'hover',
-            delay: { "show": 800, "hide": 100 }
-        });
-    }
-
-
     // TODO: move to Repository class?
     selectRepository = (repository : Repository) : void => {
         console.log("selectRepository(" + repository.name + ")");
@@ -1906,9 +1892,6 @@ export class Eagle {
         }
 
         this.leftWindow().shown(true);
-
-        // HACK to update the tooltips once the new palette has been rendered
-        setTimeout(Eagle.reloadTooltips, 100);
     }
 
     private updateLogicalGraphFileInfo = (repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, path : string, name : string) : void => {
@@ -3210,37 +3193,6 @@ export class Eagle {
         return true;
     }
 
-    // NOTE: enabling the tooltips must be delayed slightly to make sure the html has been generated (hence the setTimeout)
-    // NOTE: now needs a timeout longer that 1ms! UGLY HACK TODO
-    updateInspectorTooltips = () : void => {
-        const selectedNode = this.selectedNode();
-
-        setTimeout(function(){
-            // destroy orphaned tooltips
-            Eagle.reloadTooltips();
-
-            // update title on all right window component buttons
-            if (selectedNode !== null){
-                if (selectedNode.getInputApplication() !== null)
-                    $('.rightWindowDisplay .input-application inspector-component .input-group-prepend').attr('data-bs-original-title', selectedNode.getInputApplication().getHelpHTML());
-                if (selectedNode.getOutputApplication() !== null)
-                    $('.rightWindowDisplay .output-application inspector-component .input-group-prepend').attr('data-bs-original-title', selectedNode.getOutputApplication().getHelpHTML());
-                if (selectedNode.getExitApplication() !== null)
-                    $('.rightWindowDisplay .exit-application inspector-component .input-group-prepend').attr('data-bs-original-title', selectedNode.getExitApplication().getHelpHTML());
-            }
-        }, 150);
-    }
-
-    updatePaletteComponentTooltip = (nodes: any) : void => {
-        const node = $(nodes[1]);
-        node.tooltip({
-            html : true,
-            boundary: document.body,
-            trigger : 'hover',
-            delay: { "show": 800, "hide": 100 }
-        });
-    }
-
     paletteComponentClick = (node: Node, event:JQueryEventObject) : void => {
         if (event.shiftKey)
             this.editSelection(Eagle.RightWindowMode.Inspector, node, Eagle.FileType.Palette);
@@ -3622,7 +3574,6 @@ export class Eagle {
                }
 
                this.checkGraph();
-               this.updateInspectorTooltips();
             });
         } else {
             $("#editPortModalTitle").html("Edit Port");
@@ -3649,7 +3600,6 @@ export class Eagle {
                 port.copyWithKeyAndId(newPort, nodeKey, portId);
 
                 this.checkGraph();
-                this.updateInspectorTooltips();
             });
         }
     }
@@ -3750,7 +3700,6 @@ export class Eagle {
             if (userChoiceIndex === applicationNames.length - 1){
                 console.log("User selected no application");
                 callback(null);
-                this.updateInspectorTooltips();
                 return;
             }
 
@@ -3764,7 +3713,6 @@ export class Eagle {
             clone.setKey(newKey);
 
             callback(clone);
-            this.updateInspectorTooltips();
         });
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -921,8 +921,6 @@ export class Eagle {
 
             this._loadPaletteJSON(data, showErrors, fileFullPath);
         });
-        setTimeout(Eagle.reloadTooltips, 500);
-
     }
 
     private _loadPaletteJSON = (data: string, showErrors: boolean, fileFullPath: string) => {
@@ -1026,8 +1024,6 @@ export class Eagle {
 
             // add to palettes
             this.palettes.unshift(p);
-            setTimeout(Eagle.reloadTooltips, 100);
-
         });
     }
 
@@ -1044,7 +1040,6 @@ export class Eagle {
             const showErrors: boolean = Eagle.findSetting(Utils.SHOW_FILE_LOADING_ERRORS).value();
 
             this._loadPaletteJSON(userText, showErrors, "");
-            setTimeout(Eagle.reloadTooltips, 100);
         });
     }
 

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -152,7 +152,6 @@ export class GitHub {
 
                 repository.folders.push(GitHub.parseFolder(repository, path, data[path]));
             }
-            Eagle.reloadTooltips();
         });
     }
 

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -140,7 +140,6 @@ export class GitLab {
 
                 repository.folders.push(GitLab.parseFolder(repository, path, data[path]));
             }
-            Eagle.reloadTooltips();
         });
     }
 

--- a/src/bindingHandlers/eagleTooltip.ts
+++ b/src/bindingHandlers/eagleTooltip.ts
@@ -1,0 +1,23 @@
+import * as ko from "knockout";
+
+ko.bindingHandlers.eagleTooltip = {
+    init: function(element, valueAccessor, allBindings, viewModel, bindingContext : ko.BindingContext) {
+        const jQueryElement = $(element);
+
+        jQueryElement.attr("data-bs-toggle", "tooltip");
+        jQueryElement.attr("data-html", "true");
+        jQueryElement.attr("data-bs-placement", "right");
+    },
+    update: function (element, valueAccessor) {
+        const jQueryElement = $(element);
+
+        jQueryElement.attr("data-bs-original-title", ko.unwrap(valueAccessor()));
+
+        jQueryElement.tooltip({
+            html : true,
+            boundary: document.body,
+            trigger : 'hover',
+            delay: { "show": 800, "hide": 100 }
+        });
+    }
+};

--- a/src/bindingHandlers/eagleTooltip.ts
+++ b/src/bindingHandlers/eagleTooltip.ts
@@ -6,7 +6,12 @@ ko.bindingHandlers.eagleTooltip = {
 
         jQueryElement.attr("data-bs-toggle", "tooltip");
         jQueryElement.attr("data-html", "true");
-        jQueryElement.attr("data-bs-placement", "right");
+
+        // optionally set data-bs-placement attribute to 'right', if not already set for this element
+        const placement = jQueryElement.attr("data-bs-placement");
+        if (typeof placement === 'undefined'){
+            jQueryElement.attr("data-bs-placement", "right");
+        }
     },
     update: function (element, valueAccessor) {
         const jQueryElement = $(element);

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,9 +77,6 @@ $(function(){
                 }
             }
             eagle.leftWindow().shown(true);
-
-            // destroy orphaned tooltips and initializing tooltip on document ready.
-            Eagle.reloadTooltips();
         });
     }
 

--- a/src/require-config.ts
+++ b/src/require-config.ts
@@ -15,6 +15,7 @@ require.config({
         "bindingHandlers/disabled":"./static/built/bindingHandlers/disabled",
         "bindingHandlers/graphRenderer":"./static/built/bindingHandlers/graphRenderer",
         "bindingHandlers/nodeDataProperty":"./static/built/bindingHandlers/nodeDataProperty",
+        "bindingHandlers/eagleTooltip":"./static/built/bindingHandlers/eagleTooltip",
         "components":"./static/built/components",
         "main":"./static/built/main",
         "Config": "./static/built/Config",

--- a/static/components/field.html
+++ b/static/components/field.html
@@ -1,17 +1,17 @@
 <div class="input-group mb-1">
 
     <div class="input-group-prepend">
-        <span class="input-group-text" id="group-addon" data-bind="text: $data.text, eagleTooltip: $data.getDescriptionText()"></span>
+        <span class="input-group-text" id="group-addon" data-bind="text: $data.text, eagleTooltip: $data.getDescriptionText()" data-bs-placement="left"></span>
     </div>
 
     <!-- ko if: getType() !== Eagle.DataType.Boolean -->
-    <input class="form-control " placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-toggle="tooltip" data-html="true" data-bs-placement="bottom" title data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: $data.ro, attr: {title: getFieldValue(), type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+    <input class="form-control" placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: $data.ro, attr: {type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
     <!-- /ko -->
 
 
     <!-- ko if: getType() === Eagle.DataType.Boolean -->
     <div class="form-control checkboxParent">
-        <input class="inspectorCheckbox form-check-input btn-check" placeholder="" aria-label="Label" onclick="$(this).val(this.checked ? true : false)" aria-describedby="group-addon" data-bs-toggle="tooltip" data-html="true" data-bs-placement="bottom" title data-bind="value: $data.value, checked: valIsTrue($data.value()), valueUpdate: ['afterkeydown', 'input'], readonly: $data.ro, attr: {title: getFieldValue(), type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+        <input class="inspectorCheckbox form-check-input btn-check" placeholder="" aria-label="Label" onclick="$(this).val(this.checked ? true : false)" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, checked: valIsTrue($data.value()), valueUpdate: ['afterkeydown', 'input'], readonly: $data.ro, attr: {type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
         <label class="btn btn-outline-primary" data-bind="attr:{for: 'nodeInspectorFieldValue' + $index()}, html: $data.value() "></label><br>
     </div>
     <!-- /ko -->
@@ -19,7 +19,7 @@
 
     <!-- ko ifnot: $data.ro -->
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.showFieldValuePicker($index(), $data.input);}, attr: {id: 'nodeInspectorEditField' + $index(), title: 'Open Field Value Wizard'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.showFieldValuePicker($index(), $data.input);}, attr: {id: 'nodeInspectorEditField' + $index()}, eagleTooltip: 'Open Field Value Wizard'" data-bs-placement="left">
             <i class="material-icons md-18">link</i>
         </button>
     </div>
@@ -27,7 +27,7 @@
 
     <!-- ko ifnot: $data.ro -->
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.editField(null, 'Edit', $data.fieldType, $index());}, attr: {id: 'nodeInspectorEditField' + $index(), title: 'Edit'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.editField(null, 'Edit', $data.fieldType, $index());}, attr: {id: 'nodeInspectorEditField' + $index()}, eagleTooltip: 'Edit'" data-bs-placement="left">
             <i class="material-icons md-18">edit</i>
         </button>
     </div>
@@ -35,7 +35,7 @@
 
     <!-- ko ifnot: $root.selectedNode().isLocked() -->
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.selectedNode().removeFieldByIndex($data.fieldType, $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, attr: {id: 'nodeInspectorRemoveField' + $index(), title:'Remove parameter'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.selectedNode().removeFieldByIndex($data.fieldType, $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, attr: {id: 'nodeInspectorRemoveField' + $index()}, eagleTooltip:'Remove parameter'" data-bs-placement="left">
             <i class="material-icons md-18">delete</i>
         </button>
     </div>

--- a/static/components/field.html
+++ b/static/components/field.html
@@ -1,7 +1,7 @@
 <div class="input-group mb-1">
 
     <div class="input-group-prepend">
-        <span class="input-group-text" id="group-addon" data-bind="text: $data.text, attr: {'data-bs-original-title': $data.getDescriptionText()}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left"></span>
+        <span class="input-group-text" id="group-addon" data-bind="text: $data.text, eagleTooltip: $data.getDescriptionText()"></span>
     </div>
 
     <!-- ko if: getType() !== Eagle.DataType.Boolean -->

--- a/static/components/inspector-component.html
+++ b/static/components/inspector-component.html
@@ -2,13 +2,13 @@
     <div class="col">
         <div class="input-group mb-1">
             <!-- ko if: $data.node() === null -->
-                <button class="btn btn-secondary btn-block btn_wide" type="button" data-bind="click: $data.selectCallback, attr:{title:'Select application', id:$data.selectId}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left" >
+                <button class="btn btn-secondary btn-block btn_wide" type="button" data-bind="click: $data.selectCallback, attr:{id:$data.selectId}, eagleTooltip:'Select application'" data-bs-placement="left" >
                     <i class="material-icons md-18">add</i>
                 </button>
             <!-- /ko -->
 
             <!-- ko ifnot: $data.node() === null -->
-                <div class="input-group-prepend" data-bind="attr: {title: $data.node().getHelpHTML()}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+                <div class="input-group-prepend" data-bind="eagleTooltip: $data.node().getHelpHTML()" data-bs-placement="left">
                     <span class="input-group-text" data-bind="style: {'background-color': $data.node().color}">
                         <i data-bind="class: $data.node().getIcon()"></i>
                     </span>
@@ -17,13 +17,13 @@
                 <input type="text" class="form-control" readonly data-bind="value: $data.node().getDisplayName()">
 
                 <div class="input-group-append">
-                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.selectCallback, attr: {title: 'Change application', id:$data.changeId}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.selectCallback, attr: {id:$data.changeId}, eagleTooltip: 'Change application'" data-bs-placement="left">
                         <i class="material-icons md-18">edit</i>
                     </button>
                 </div>
 
                 <div class="input-group-append">
-                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.inspectCallback, attr: {title: 'Inspect application', id:$data.inspectId}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.inspectCallback, attr: {id:$data.inspectId}, eagleTooltip: 'Inspect application'" data-bs-placement="left">
                         <i class="material-icons md-18">search</i>
                     </button>
                 </div>

--- a/static/components/palette-component.html
+++ b/static/components/palette-component.html
@@ -1,6 +1,6 @@
 <div class="row">
-    <div class="col"  draggable="true" data-bind="event: {dragstart: $root.nodeDragStart,dragend: $root.nodeDragEnd}, childrenComplete: $root.updatePaletteComponentTooltip, attr: {'data-palette-index': $parentContext.$parentContext.$index, 'data-component-index': $index}">
-        <div class="input-group mb-1"  data-bind="attr: {'data-bs-original-title': $data.getHelpHTML(), id: 'palette_'  + $parentContext.$parentContext.$index() + '_' + $data.getPaletteComponentId()}, click: $root.paletteComponentClick" data-bs-toggle="tooltip" data-html="true" data-bs-placement="right">
+    <div class="col"  draggable="true" data-bind="event: {dragstart: $root.nodeDragStart,dragend: $root.nodeDragEnd}, attr: {'data-palette-index': $parentContext.$parentContext.$index, 'data-component-index': $index}">
+        <div class="input-group mb-1"  data-bind="attr: {id: 'palette_'  + $parentContext.$parentContext.$index() + '_' + $data.getPaletteComponentId()}, click: $root.paletteComponentClick, eagleTooltip: $data.getHelpHTML()">
             <div class="input-group-prepend">
                 <button class="nodeBtn" type="button" data-bind="click: function(){$root.addNodeToLogicalGraph($data)}, clickBubble: false, attr: {id: 'addPaletteNode' + $data.getNoWhiteSpaceName()}">
                     <span class="input-group-text" data-bind="style: {'background-color': $data.color}">

--- a/static/components/port.html
+++ b/static/components/port.html
@@ -1,21 +1,21 @@
 <div class="input-group mb-1">
 
 
-    <input type="text" class="form-control" placeholder="" readonly data-bind="value: name, eagleTooltip: description">
+    <input type="text" class="form-control" placeholder="" readonly data-bind="value: name, eagleTooltip: description" data-bs-placement="left">
 
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="attr: {title: 'Port multiplicity'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="eagleTooltip: 'Port multiplicity'" data-bs-placement="left">
             <span data-bind="text: multiplicity"></span>
         </button>
     </div>
     <div class="input-group-append">
         <!-- ko if: $root.logicalGraph().portIsLinked($root.selectedNode().getKey(), id()) -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="attr: {id: 'nodeInspectorSelectEdge' + id, title: 'Port is connected'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="attr: {id: 'nodeInspectorSelectEdge' + id}, eagleTooltip: 'Port is connected'" data-bs-placement="left">
                 <i class="material-icons md-18">link</i>
             </button>
         <!-- /ko -->
         <!-- ko ifnot: $root.logicalGraph().portIsLinked($root.selectedNode().getKey(), id()) -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="attr: {title: 'Port is not connected'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="eagleTooltip: 'Port is not connected'" data-bs-placement="left">
                 <i class="material-icons md-18">link_off</i>
             </button>
         <!-- /ko -->
@@ -23,18 +23,18 @@
 
     <div class="input-group-append">
         <!-- ko if: isEventPort -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){toggleEvent();$root.hackNodeUpdate();}, attr: {title: 'Port is event port<br/>Click to toggle'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){toggleEvent();$root.hackNodeUpdate();}, eagleTooltip: 'Port is event port<br/>Click to toggle'" data-bs-placement="left">
                 <i class="material-icons md-18">alarm_on</i>
             </button>
         <!-- /ko -->
         <!-- ko ifnot: isEventPort -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){toggleEvent();$root.hackNodeUpdate();}, attr: {title: 'Port is not event port<br/>Click to toggle'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){toggleEvent();$root.hackNodeUpdate();}, eagleTooltip: 'Port is not event port<br/>Click to toggle'" data-bs-placement="left">
                 <i class="material-icons md-18">alarm_off</i>
             </button>
         <!-- /ko -->
     </div>
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.editPort(null, 'Edit', $index(), input);}, attr: {id: 'nodeInspectorEditPort' + $index(), title: 'Edit'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.editPort(null, 'Edit', $index(), input);}, attr: {id: 'nodeInspectorEditPort' + $index()}, eagleTooltip: 'Edit'" data-bs-placement="left">
             <i class="material-icons md-18">edit</i>
         </button>
     </div>
@@ -42,12 +42,12 @@
     <!-- ko ifnot: $root.selectedNode().isLocked() -->
     <div class="input-group-append">
         <!-- ko if: input -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.removePortFromNodeByIndex($root.selectedNode(), $index(), true);$root.logicalGraph.valueHasMutated();$root.selectedObjects.valueHasMutated();}, attr: {id: 'nodeInspectorRemoveInputPort' + $index(), title: 'Remove port'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.removePortFromNodeByIndex($root.selectedNode(), $index(), true);$root.logicalGraph.valueHasMutated();$root.selectedObjects.valueHasMutated();}, attr: {id: 'nodeInspectorRemoveInputPort' + $index()}, eagleTooltip: 'Remove port'" data-bs-placement="left">
                 <i class="material-icons md-18">delete</i>
             </button>
         <!-- /ko -->
         <!-- ko if: !input -->
-            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.removePortFromNodeByIndex($root.selectedNode(), $index(), false);$root.logicalGraph.valueHasMutated();$root.selectedObjects.valueHasMutated();}, attr: {id: 'nodeInspectorRemoveOutputPort' + $index(), title: 'Remove port'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.removePortFromNodeByIndex($root.selectedNode(), $index(), false);$root.logicalGraph.valueHasMutated();$root.selectedObjects.valueHasMutated();}, attr: {id: 'nodeInspectorRemoveOutputPort' + $index()}, eagleTooltip: 'Remove port'" data-bs-placement="left">
                 <i class="material-icons md-18">delete</i>
             </button>
         <!-- /ko -->

--- a/static/components/port.html
+++ b/static/components/port.html
@@ -1,7 +1,7 @@
 <div class="input-group mb-1">
 
 
-    <input type="text" class="form-control" placeholder="" readonly data-bind="value: name, attr: {'data-bs-original-title': description}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+    <input type="text" class="form-control" placeholder="" readonly data-bind="value: name, eagleTooltip: description">
 
     <div class="input-group-append">
         <button class="btn btn-secondary btn-sm" type="button" data-bind="attr: {title: 'Port multiplicity'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">

--- a/static/components/repository-file.html
+++ b/static/components/repository-file.html
@@ -10,13 +10,13 @@
             <!-- /ko -->
         </div>
         <div class="col col-10">
-            <a href="#" data-bind="click: $root.selectFile, attr: {id: htmlId}, attr:{title: $data.name}" data-bs-toggle="tooltip" data-bs-placement="left" >
+            <a href="#" data-bind="click: $root.selectFile, attr: {id: htmlId}, eagleTooltip: $data.name" data-bs-placement="left">
                 <span data-bind="text: $data.name"></span>
             </a>
         </div>
         <!-- ko if: getIconUrl() === "device_hub" -->
             <div class="col col-1">
-                <i class="material-icons md-18" data-bs-toggle="tooltip" data-bs-placement="left" title="Insert" style="cursor:pointer;top:3px;" data-bind="click: $root.insertFile">add_box</i>
+                <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.insertFile, eagleTooltip: 'Insert'">add_box</i>
             </div>
         <!-- /ko -->
     </div>

--- a/static/components/repository-folder.html
+++ b/static/components/repository-folder.html
@@ -9,7 +9,7 @@
             <!-- /ko -->
         </div>
         <div class="col col-10">
-            <a href="#" data-bind="attr: {id: htmlId}, click: function(folder){$root.selectFolder(folder); eagle.updateInspectorTooltips();}">
+            <a href="#" data-bind="attr: {id: htmlId}, click: $root.selectFolder">
                 <span data-bind="text: $data.name"></span>
             </a>
         </div>

--- a/static/components/repository.html
+++ b/static/components/repository.html
@@ -7,7 +7,7 @@
             <!-- /ko -->
             <!-- ko ifnot: isFetching -->
             <i class="material-icons md-18 interactive" data-bind="click: refresh,visible: folders().length == 0 && files().length==0 && fetched">cloud_off</i>
-            <i class="material-icons md-18 interactive" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Refresh" data-bind="click: refresh, visible: (folders().length != 0 || files().length != 0)&& fetched">cloud_done</i>
+            <i class="material-icons md-18 interactive" data-bs-placement="bottom" data-bind="click: refresh, visible: (folders().length != 0 || files().length != 0)&& fetched, eagleTooltip: 'Refresh'">cloud_done</i>
 
             <!-- ko ifnot: fetched -->
             <!-- ko if: service === Eagle.RepositoryService.GitHub -->
@@ -20,14 +20,14 @@
             <!-- /ko -->
         </div>
         <div class="col-10 col">
-            <a href="" data-bind="attr: {id: htmlId}, click: select, attr:{title: name + ' (' + branch + ')'}" data-bs-toggle="tooltip" data-bs-placement="left">
+            <a href="" data-bind="attr: {id: htmlId}, click: select, eagleTooltip: name + ' (' + branch + ')'" data-bs-placement="left">
                 <span data-bind="text: name + ' (' + branch + ')'"></span>
             </a>
         </div>
         <!-- ko ifnot: isBuiltIn -->
         <div class="col col-1">
             <i class="material-icons md-18 interactive" data-bind="click: remove">eject</i>
-        </div>  
+        </div>
         <!-- /ko -->
         <!-- ko if: expanded -->
         <ul class="folders" data-bind="foreach: folders">

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,6 +27,7 @@
             require(["bindingHandlers/disabled"]);
             require(["bindingHandlers/graphRenderer"]);
             require(["bindingHandlers/nodeDataProperty"]);
+            require(["bindingHandlers/eagleTooltip"]);
             require(["components"]);
             require(["main"]);
 
@@ -114,13 +115,13 @@
                     <div id="nodeInspectorKOWrapper" data-bind="visible: rightWindow().mode() === Eagle.RightWindowMode.Inspector">
                         <div class="rightWindowDisplay nodeInspector" data-bind="visible: selectedNode() === null && selectedObjects().length > 1">
                             Select a single node or edge
-                        </div> 
+                        </div>
                         <div class="rightWindowDisplay nodeInspector" data-bind="visible: selectedNode() !== null">
                             {% include 'node_inspector.html' %}
-                        </div> 
+                        </div>
                         <div class="rightWindowDisplay edgeInspector" data-bind="visible: selectedEdge() !== null">
                             {% include 'edge_inspector.html' %}
-                        </div>  
+                        </div>
                     </div>
                     <div class="rightWindowDisplay translationMenu" data-bind="visible: rightWindow().mode() === Eagle.RightWindowMode.TranslationMenu">
                         {% include 'translation_menu.html' %}

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -309,7 +309,7 @@
                                                 <!-- ko if: $data.getType() === 0 -->
                                                     <div class="input-group mb-1">
                                                         <div class="input-group-prepend">
-                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey(),title:$data.getDescription()},text:$data.getName()" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left"></span>
+                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
                                                         </div>
                                                         <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                                     </div>
@@ -317,7 +317,7 @@
                                                 <!-- ko if: $data.getType() === 1 -->
                                                     <div class="input-group mb-1">
                                                         <div class="input-group-prepend">
-                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey(),title:$data.getDescription()},text:$data.getName()" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left"></span>
+                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
                                                         </div>
                                                         <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                                     </div>
@@ -325,7 +325,7 @@
                                                 <!-- ko if: $data.getType() === 2 -->
                                                     <div class="settingSm col-6">
                                                         <div class="input-group mb-1">
-                                                            <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName(),title:$data.getDescription()}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left" readonly>
+                                                            <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
                                                             <div class="input-group-append">
                                                                 <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.toggle, attr:{id:'setting'+$data.getKey()+'Button'}">
                                                                     <i class="material-icons md-18" data-bind="visible: $data.value">radio_button_checked</i>
@@ -338,7 +338,7 @@
                                                 <!-- ko if: $data.getType() === 3 -->
                                                     <div class="input-group mb-1">
                                                         <div class="input-group-prepend">
-                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey(),title:$data.getDescription()},text:$data.getName()" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left"></span>
+                                                            <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip:$data.getDescription()" data-bs-placement="left"></span>
                                                         </div>
                                                         <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                                         <div class="input-group-append">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -18,45 +18,45 @@
         <ul class="nav navbar-nav navbar-center">
             <div class="btn-group" role="group" aria-label="Basic example">
                 <!--
-                <button class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Zoom To Fit" data-bind="click: zoomToFit">
+                <button class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: zoomToFit, eagleTooltip: 'Zoom To Fit'">
                     <i class="material-icons md-18">zoom_out_map</i>
                 </button>
-                <button class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Toggle Grid" data-bind="click: toggleGrid">
+                <button class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: toggleGrid, eagleTooltip: 'Toggle Grid'">
                     <i class="material-icons md-18">grid_on</i>
                 </button>
                 -->
-                <!-- <button id="saveAsPNG" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Save as PNG" data-bind="click: saveAsPNG" data-intro="Save a PNG of the current graph.">
+                <!-- <button id="saveAsPNG" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: saveAsPNG, eagleTooltip: 'Save as PNG'" data-intro="Save a PNG of the current graph.">
                     <i class="material-icons md-18">image</i>
                 </button> -->
-                <button id="centerGraph" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Center Graph" data-bind="click: centerGraph" data-intro="Center the current graph within the graph rendering area.">
+                <button id="centerGraph" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: centerGraph, eagleTooltip: 'Center Graph'" data-intro="Center the current graph within the graph rendering area.">
                     <i class="material-icons md-18">filter_center_focus</i>
                 </button>
-                <button id="zoomIn" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Zoom In" data-bind="click: zoomIn" data-intro="Zoom in on the graph within the graph rendering area.">
+                <button id="zoomIn" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: zoomIn, eagleTooltip: 'Zoom In'" data-intro="Zoom in on the graph within the graph rendering area.">
                     <i class="material-icons md-18">zoom_in</i>
                 </button>
-                <button id="zoomOut" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Zoom Out" data-bind="click: zoomOut" data-intro="Zoom out from the graph within the graph rendering area.">
+                <button id="zoomOut" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: zoomOut, eagleTooltip: 'Zoom Out'" data-intro="Zoom out from the graph within the graph rendering area.">
                     <i class="material-icons md-18">zoom_out</i>
                 </button>
                 <!-- ko if: allowPaletteEditing() -->
-                <button id="addGraphNodesToPalette" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Add Graph Nodes to Palette" data-bind="click: addGraphNodesToPalette" data-intro="Add all nodes in the current graph to the a new or existing palette.">
+                <button id="addGraphNodesToPalette" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: addGraphNodesToPalette, eagleTooltip: 'Add Graph Nodes to Palette'" data-intro="Add all nodes in the current graph to the a new or existing palette.">
                     <i class="material-icons md-18">palette</i>
                 </button>
                 <!-- /ko -->
-                <button id="toggleCollapseAllGroups" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Collapse/Expand All Groups" data-bind="click: toggleCollapseAllGroups" data-intro="Toggle all groups between collapsed and expanded states.">
+                <button id="toggleCollapseAllGroups" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: toggleCollapseAllGroups, eagleTooltip: 'Collapse/Expand All Groups'" data-intro="Toggle all groups between collapsed and expanded states.">
                     <i class="material-icons md-18">tab_unselected</i>
                 </button>
-                <button id="toggleCollapseAllNodes" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Collapse/Expand All Nodes" data-bind="click: toggleCollapseAllNodes" data-intro="Toggle all nodes between collapsed and expanded states.">
+                <button id="toggleCollapseAllNodes" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: toggleCollapseAllNodes, eagleTooltip: 'Collapse/Expand All Nodes'" data-intro="Toggle all nodes between collapsed and expanded states.">
                     <i class="material-icons md-18">vertical_align_center</i>
                 </button>
-                <button id="copyGraphUrl" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Copy Graph Url" data-bind="click: copyGraphUrl" data-intro="Create a url that points to the current graph and copy the url to the clipboard.">
+                <button id="copyGraphUrl" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: copyGraphUrl, eagleTooltip: 'Copy Graph Url'" data-intro="Create a url that points to the current graph and copy the url to the clipboard.">
                     <i class="material-icons md-18">content_copy</i>
                 </button>
             </div>
             <ul class="nav navbar-nav ms-4">
-                <button id="checkGraph" class="btn btn-outline-success navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Check Graph for Errors" data-bind="click: showGraphErrors, visible: graphWarnings().length === 0 && graphErrors().length === 0" data-intro="Check the graph for common issues and missing information.">
+                <button id="checkGraph" class="btn btn-outline-success navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: showGraphErrors, visible: graphWarnings().length === 0 && graphErrors().length === 0, eagleTooltip: 'Check Graph for Errors'" data-intro="Check the graph for common issues and missing information.">
                     <i class="material-icons md-18">done_all</i>
                 </button>
-                <button id="checkGraph" class="btn navbar-btn" type="button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Check Graph for Errors" style="display: none;" data-bind="click: showGraphErrors, visible: graphWarnings().length > 0 || graphErrors().length > 0, css: {'btn-outline-warning': graphWarnings().length > 0, 'btn-outline-danger': graphErrors().length > 0}" data-intro="Check the graph for common issues and missing information.">
+                <button id="checkGraph" class="btn navbar-btn" type="button" data-bs-placement="bottom" style="display: none;" data-bind="click: showGraphErrors, visible: graphWarnings().length > 0 || graphErrors().length > 0, css: {'btn-outline-warning': graphWarnings().length > 0, 'btn-outline-danger': graphErrors().length > 0}, eagleTooltip: 'Check Graph for Errors'" data-intro="Check the graph for common issues and missing information.">
                     <span class="badge bg-warning" data-bind="text: graphWarnings().length, visible: graphWarnings().length > 0"></span>
                     <span class="badge bg-danger" data-bind="text: graphErrors().length, visible: graphErrors().length > 0"></span>
                 </button>
@@ -142,7 +142,7 @@
                     <a class="dropdown-item" id="keyboardShortcuts" href="#" data-bind="click: openShortcuts">Keyboard Shortcuts</a>
                 </div>
             </li>
-            <a class="nav-link" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Settings" id="settings" href="#" data-bind="click: openSettings"><img src="/static/assets/img/settings_white_24dp.svg" alt=""></a>
+            <a class="nav-link" data-bs-placement="bottom" id="settings" href="#" data-bind="click: openSettings, eagleTooltip: 'Settings'"><img src="/static/assets/img/settings_white_24dp.svg" alt=""></a>
         </ul>
 
     </div>

--- a/templates/node_inspector.html
+++ b/templates/node_inspector.html
@@ -12,16 +12,16 @@
     <!-- ko if: selectedNode() != null -->
     <div class="row card-header mb-1" id="nodeInspectorHeading" data-bind="style: {backgroundColor: selectedNode().color}, click: inspectorState().toggleAll">
         <div class="col-8 headerBtns">
-            <button type="button" class="btn btn-secondary btn-sm" data-bind="click: inspectorState().toggleAll" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-original-title="Expand/Collapse All">
+            <button type="button" class="btn btn-secondary btn-sm" data-bind="click: inspectorState().toggleAll, eagleTooltip: 'Expand/Collapse All'">
                 <i class="material-icons md-24" data-bind="css:{closedIcon: inspectorState().all}">keyboard_arrow_down</i>
             </button>
             <!-- ko if: selectedNode().isLocked() -->
-            <button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-original-title="readonly">
+            <button type="button" class="btn btn-secondary btn-sm" data-bind="eagleTooltip: 'readonly'">
                 <i class="material-icons md-24">lock</i>
             </button>
             <!-- /ko -->
             <!-- ko ifnot: selectedNode().isLocked() -->
-            <button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-original-title="readwrite">
+            <button type="button" class="btn btn-secondary btn-sm" data-bind="eagleTooltip: 'readwrite'">
                 <i class="material-icons md-24">lock_open</i>
             </button>
             <!-- /ko -->
@@ -29,7 +29,7 @@
         </div>
         <div class="col-4 text-right headerBtns">
             <!-- ko if: selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
-            <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-original-title="Duplicate Selection [d]">
+            <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false, eagleTooltip: 'Duplicate Selection [d]'" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-original-title="">
                 <i  class="material-icons md-24">content_copy</i>
             </button>
             <!-- /ko -->

--- a/templates/node_inspector.html
+++ b/templates/node_inspector.html
@@ -29,17 +29,17 @@
         </div>
         <div class="col-4 text-right headerBtns">
             <!-- ko if: selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
-            <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false, eagleTooltip: 'Duplicate Selection [d]'" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-original-title="">
+            <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false, eagleTooltip: 'Duplicate Selection [d]'" data-bs-placement="left">
                 <i  class="material-icons md-24">content_copy</i>
             </button>
             <!-- /ko -->
             <!-- ko if: allowPaletteEditing() -->
-            <button type="button" id="addSelectedNodeToPalette" class="btn btn-secondary btn-sm" data-bind="click: addSelectedNodeToPalette, clickBubble: false" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-original-title="Add Selected Node To Palette">
+            <button type="button" id="addSelectedNodeToPalette" class="btn btn-secondary btn-sm" data-bind="click: addSelectedNodeToPalette, clickBubble: false, eagleTooltip: 'Add Selected Node To Palette'" data-bs-placement="left">
                 <i  class="material-icons md-24">library_add</i>
             </button>
             <!-- /ko -->
             <!-- ko if: selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
-            <button type="button" id="deleteSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: function(){deleteSelection(false);}, clickBubble: false" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-original-title="Delete Selected Node [backspace]">
+            <button type="button" id="deleteSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: function(){deleteSelection(false);}, clickBubble: false, eagleTooltip: 'Delete Selected Node [backspace]'" data-bs-placement="left">
                 <i class="material-icons md-24">delete</i>
             </button>
             <!-- /ko -->

--- a/templates/node_inspector.html
+++ b/templates/node_inspector.html
@@ -57,7 +57,7 @@
                 <!-- /ko -->
             </div>
             <div class="col-2 text-right">
-                <i class="material-icons interactive me-2" data-bs-toggle="tooltip" data-bs-placement="left" data-html="true" data-bind="attr:{title: selectedNode().getGitHTML() }">info</i>
+                <i class="material-icons interactive me-2" data-bs-placement="left" data-bind="eagleTooltip: selectedNode().getGitHTML()">info</i>
             </div>
 
         </div>

--- a/templates/node_inspector_application_parameters.html
+++ b/templates/node_inspector_application_parameters.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse11" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Application Parameters">
-        <i class="material-icons interactive nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().applicationParameters}">keyboard_arrow_down</i>
+        <i class="material-icons interactive nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().applicationParameters}">keyboard_arrow_down</i>
         <i class="material-icons">settings_applications</i>
         <span class="nodeInspectorSubsectionTitle">Application Parameters</span>
     </h5>
@@ -20,7 +20,7 @@
             <!-- /ko -->
 
             <!-- ko ifnot: selectedNode().isLocked()-->
-                <button class="btn btn-secondary btn-block nodeInspectorDropDown btn_wide" id="nodeInspectorAddApplicationParam" type="button" data-bind="click: $root.addApplicationParamHTML, attr:{title:'Add application parameter'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+                <button class="btn btn-secondary btn-block nodeInspectorDropDown btn_wide" id="nodeInspectorAddApplicationParam" type="button" data-bind="click: $root.addApplicationParamHTML, eagleTooltip:'Add application parameter'" data-bs-placement="left">
                     <i class="material-icons md-18">add</i>
                 </button>
                 <div id="nodeInspectorAddApplicationParamDiv" class="nodeInspectorDropdownDiv">

--- a/templates/node_inspector_description.html
+++ b/templates/node_inspector_description.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse10" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Description">
-        <i class="material-icons interactive nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().description}">keyboard_arrow_down</i>
+        <i class="material-icons interactive nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().description}">keyboard_arrow_down</i>
         <i class="material-icons">note</i>
         <span class="nodeInspectorSubsectionTitle" >Description</span>
     </h5>

--- a/templates/node_inspector_description.html
+++ b/templates/node_inspector_description.html
@@ -6,7 +6,7 @@
     </h5>
     <div class="collapse nodeInspectorCollapseAll" id="nodeCategoryCollapse10">
         <div class="card-body">
-            <textarea class="form-control" rows="3" data-bind="value: selectedNode().description, readonly: selectedNode().isLocked(), event: {change: Eagle.updateTooltips}"></textarea>
+            <textarea class="form-control" rows="3" data-bind="value: selectedNode().description, readonly: selectedNode().isLocked()"></textarea>
         </div>
     </div>
 </div>

--- a/templates/node_inspector_display_options.html
+++ b/templates/node_inspector_display_options.html
@@ -10,7 +10,7 @@
             <!-- ko if: selectedNode().getCategory() !== Eagle.Category.Description && selectedNode().getCategory() !== Eagle.Category.Comment -->
                     <div class="input-group mb-1">
                         <div class="input-group-prepend">
-                            <span class="input-group-text" id="node-name">Name</span>
+                            <span class="input-group-text" id="node-name" data-bind="eagleTooltip:'The name of this component'" data-bs-placement="left">Name</span>
                         </div>
                         <input type="text" class="form-control" id="nodeNameValue" placeholder="" aria-label="Name" aria-describedby="node-name" data-bind="value: selectedNode().name, readonly: selectedNode().isLocked()">
                     </div>
@@ -18,7 +18,7 @@
 
             <div class="input-group mb-1">
                 <div class="input-group-prepend">
-                    <span class="input-group-text" id="node-parent">Parent</span>
+                    <span class="input-group-text" id="node-parent" data-bind="eagleTooltip:'The key of the parent component of this component'" data-bs-placement="left">Parent</span>
                 </div>
                 <input type="text" class="form-control" id="nodeParentValue" placeholder="" aria-label="Name" aria-describedby="node-parent" data-bind="value: selectedNode().getParentKey()" readonly>
                 <div class="input-group-append">
@@ -30,7 +30,7 @@
 
             <div class="input-group mb-1">
                 <div class="input-group-prepend">
-                    <span class="input-group-text" id="node-draw-order-hint">Draw Order Hint</span>
+                    <span class="input-group-text" id="node-draw-order-hint" data-bind="eagleTooltip:'A user-specified hint to influence the depth of this component in the graph display. Greater values will move the component towards the front.'" data-bs-placement="left">Draw Order Hint</span>
                 </div>
                 <input type="text" class="form-control" id="nodeDrawOrderHintValue" placeholder="" aria-label="Name" aria-describedby="node-draw-order-hint" data-bind="value: selectedNode().drawOrderHint" readonly>
                 <div class="input-group-append">
@@ -48,7 +48,7 @@
             <!-- ko if: selectedNode().getCategory() === Eagle.Category.Comment -->
             <div class="input-group mb-1">
                 <div class="input-group-prepend">
-                    <span class="input-group-text" id="node-subject">Subject</span>
+                    <span class="input-group-text" id="node-subject" data-bind="eagleTooltip:'The subject of the comment text specified by this component'" data-bs-placement="left">Subject</span>
                 </div>
                 <input type="text" class="form-control" id="nodeSubjectValue" placeholder="" aria-label="Name" aria-describedby="node-subject" data-bind="value: selectedNode().getSubjectKey()" readonly>
                 <div class="input-group-append">
@@ -61,7 +61,7 @@
 
             <!-- ko if: selectedNode().isData() -->
             <div class="input-group mb-1">
-                <input type="text" class="form-control" id="nodeStreamingValue" placeholder="" aria-label="Streaming" aria-describedby="node-streaming" value="Streaming" readonly>
+                <input type="text" class="form-control" id="nodeStreamingValue" placeholder="" aria-label="Streaming" aria-describedby="node-streaming" value="Streaming" readonly data-bind="eagleTooltip:'Specifies whether this data component streams input and output data'" data-bs-placement="left">
                 <div class="input-group-append">
                     <button class="btn btn-secondary btn-sm" id="nodeInspectorToggleStreaming" type="button" data-bind="click: function(){selectedNode().toggleStreaming();selectedObjects.valueHasMutated();eagle.logicalGraph.valueHasMutated();}">
                         <i class="material-icons md-18" data-bind="visible: selectedNode().isStreaming()">radio_button_checked</i>
@@ -71,7 +71,7 @@
             </div>
 
             <div class="input-group mb-1">
-                <input type="text" class="form-control" id="nodePreciousValue" placeholder="" aria-label="Precious" aria-describedby="node-precious" value="Precious" readonly>
+                <input type="text" class="form-control" id="nodePreciousValue" placeholder="" aria-label="Precious" aria-describedby="node-precious" value="Precious" readonly data-bind="eagleTooltip:'Specifies whether this data component contains precious data. Precious data will not be deleted at the conclusion of a workflow'" data-bs-placement="left">
                 <div class="input-group-append">
                     <button class="btn btn-secondary btn-sm" id="nodeInspectorTogglePrecious" type="button" data-bind="click: function(){selectedNode().togglePrecious();selectedObjects.valueHasMutated();eagle.logicalGraph.valueHasMutated();}">
                         <i class="material-icons md-18" data-bind="visible: selectedNode().isPrecious()">radio_button_checked</i>
@@ -82,7 +82,7 @@
             <!-- /ko -->
 
             <div class="input-group mb-1">
-                <input type="text" class="form-control" id="nodeCollapsedValue" placeholder="" aria-label="Collapsed" aria-describedby="node-collapsed" value="Collapsed" readonly>
+                <input type="text" class="form-control" id="nodeCollapsedValue" placeholder="" aria-label="Collapsed" aria-describedby="node-collapsed" value="Collapsed" readonly data-bind="eagleTooltip:'Specifies whether this component will be displayed collapsed or expanded in the graph display'" data-bs-placement="left">
                 <div class="input-group-append">
                     <button class="btn btn-secondary btn-sm" id="nodeInspectorToggleCollapsed" type="button" data-bind="click: function(){selectedNode().toggleCollapsed();selectedObjects.valueHasMutated();eagle.logicalGraph.valueHasMutated();}">
                         <i class="material-icons md-18" data-bind="visible: selectedNode().isCollapsed()">radio_button_checked</i>
@@ -93,7 +93,7 @@
 
             <!-- ko ifnot: selectedNode().isGroup() || selectedNode().isBranch() || selectedNode().isService() -->
             <div class="input-group mb-1">
-                <input type="text" class="form-control" id="nodeFlipPortsValue" placeholder="" aria-label="Flip Ports" aria-describedby="node-flip-ports" value="Flip Ports" readonly>
+                <input type="text" class="form-control" id="nodeFlipPortsValue" placeholder="" aria-label="Flip Ports" aria-describedby="node-flip-ports" value="Flip Ports" readonly data-bind="eagleTooltip:'Specifies whether this component will be rendered horizontally flipped in the graph display, with the inputs on the right, and outputs on the left'" data-bs-placement="left">
                 <div class="input-group-append">
                     <button class="btn btn-secondary btn-sm" id="nodeInspectorToggleFlipPorts" type="button" data-bind="click: function(){selectedNode().toggleFlipPorts();selectedObjects.valueHasMutated();eagle.logicalGraph.valueHasMutated();}">
                         <i class="material-icons md-18" data-bind="visible: selectedNode().isFlipPorts()">radio_button_checked</i>

--- a/templates/node_inspector_display_options.html
+++ b/templates/node_inspector_display_options.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Display Options">
-        <i class="material-icons interactive nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().displayOptions}">keyboard_arrow_down</i>
+        <i class="material-icons interactive nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().displayOptions}">keyboard_arrow_down</i>
         <i class="material-icons">image</i>
         <span class="nodeInspectorSubsectionTitle">Display Options</span>
     </h5>

--- a/templates/node_inspector_exit_application.html
+++ b/templates/node_inspector_exit_application.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse2" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Exit Application">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().exitApplication}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().exitApplication}">keyboard_arrow_down</i>
         <i class="material-icons">apps</i>
         <span class="nodeInspectorSubsectionTitle">Exit Application</span>
     </h5>

--- a/templates/node_inspector_graph_comment.html
+++ b/templates/node_inspector_graph_comment.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse3" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Graph Comment">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().graphComment}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().graphComment}">keyboard_arrow_down</i>
         <i class="material-icons">device_hub</i>
         <span class="nodeInspectorSubsectionTitle">Graph Comment</span>
     </h5>

--- a/templates/node_inspector_graph_description.html
+++ b/templates/node_inspector_graph_description.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse4" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Graph Description">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().graphDescription}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().graphDescription}">keyboard_arrow_down</i>
         <i class="material-icons">device_hub</i>
         <span class="nodeInspectorSubsectionTitle">Graph Description</span>
     </h5>

--- a/templates/node_inspector_input_application.html
+++ b/templates/node_inspector_input_application.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse5" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Input Application">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().inputApplication}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().inputApplication}">keyboard_arrow_down</i>
         <i class="material-icons">apps</i>
         <span class="nodeInspectorSubsectionTitle">Input Application</span>
     </h5>

--- a/templates/node_inspector_inputs.html
+++ b/templates/node_inspector_inputs.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse6" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Inputs">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().inputPorts}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().inputPorts}">keyboard_arrow_down</i>
         <i class="material-icons">arrow_back</i>
         <span class="nodeInspectorSubsectionTitle">Input Ports</span>
     </h5>
@@ -12,7 +12,7 @@
             <!-- /ko -->
 
             <!-- ko ifnot: selectedNode().isLocked() -->
-            <button class="btn btn-secondary btn-block btn_wide" id="nodeInspectorAddInputPort" type="button" data-bind="click: $root.addInputPortHTML, attr:{title:'Add port'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-block btn_wide" id="nodeInspectorAddInputPort" type="button" data-bind="click: $root.addInputPortHTML, eagleTooltip:'Add port'" data-bs-placement="left">
                 <i class="material-icons md-18">add</i>
             </button>
             <div id="nodeInspectorAddInputPortDiv" class="nodeInspectorDropdownDiv">

--- a/templates/node_inspector_output_application.html
+++ b/templates/node_inspector_output_application.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse7" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Output Application">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().outputApplication}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().outputApplication}">keyboard_arrow_down</i>
         <i class="material-icons">apps</i>
         <span class="nodeInspectorSubsectionTitle">Output Application</span>
     </h5>

--- a/templates/node_inspector_outputs.html
+++ b/templates/node_inspector_outputs.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse8" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Outputs">
-        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().outputPorts}">keyboard_arrow_down</i>
+        <i class="material-icons interactive closedIcon nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().outputPorts}">keyboard_arrow_down</i>
         <i class="material-icons">arrow_forward</i>
         <span class="nodeInspectorSubsectionTitle">Output Ports</span>
     </h5>
@@ -12,7 +12,7 @@
             <!-- /ko -->
 
             <!-- ko ifnot: selectedNode().isLocked() -->
-            <button class="btn btn-secondary btn-block btn_wide" id="nodeInspectorAddOutputPort" type="button" data-bind="click: $root.addOutputPortHTML, attr:{title:'Add port'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+            <button class="btn btn-secondary btn-block btn_wide" id="nodeInspectorAddOutputPort" type="button" data-bind="click: $root.addOutputPortHTML, eagleTooltip:'Add port'" data-bs-placement="left">
                 <i class="material-icons md-18">add</i>
             </button>
             <div id="nodeInspectorAddOutputPortDiv" class="nodeInspectorDropdownDiv">

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -1,6 +1,6 @@
 <div class="card">
     <h5 class="card-header" data-bs-toggle="collapse" href="#nodeCategoryCollapse9" role="button" aria-expanded="false" aria-controls="multiCollapseExample1" data-bind="click: inspectorState().toggleSection" data-section-name="Component Parameters">
-        <i class="material-icons interactive nodeMenuIndicator" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'Expand/Collapse'}, css:{closedIcon:inspectorState().componentParameters}">keyboard_arrow_down</i>
+        <i class="material-icons interactive nodeMenuIndicator" data-bs-placement="top" data-bind="eagleTooltip:'Expand/Collapse', css:{closedIcon:inspectorState().componentParameters}">keyboard_arrow_down</i>
         <i class="material-icons">archive</i>
         <span class="nodeInspectorSubsectionTitle">Component Parameters</span>
     </h5>
@@ -25,7 +25,7 @@
             <!-- /ko -->
 
             <!-- ko ifnot: selectedNode().isLocked()-->
-                <button class="btn btn-secondary btn-block nodeInspectorDropDown btn_wide" id="nodeInspectorAddField" type="button" data-bind="click: $root.addFieldHTML, attr:{title:'Add parameter'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">
+                <button class="btn btn-secondary btn-block nodeInspectorDropDown btn_wide" id="nodeInspectorAddField" type="button" data-bind="click: $root.addFieldHTML, eagleTooltip:'Add parameter'" data-bs-placement="left">
                     <i class="material-icons md-18">add</i>
                 </button>
                 <div id="nodeInspectorAddFieldDiv" class="nodeInspectorDropdownDiv">
@@ -38,7 +38,7 @@
                     </div>
                 </div>
                 <!-- ko if: selectedNode().category() === Eagle.Category.Docker -->
-                    <button class="btn btn-secondary btn-block mt-1 btn_wide" id="nodeInspectorFetchDocker" type="button" data-bind="click: $root.fetchDockerHTML, attr:{title:'Fetch docker image data from Docker Hub'}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="left">Fetch from Docker Hub</button>
+                    <button class="btn btn-secondary btn-block mt-1 btn_wide" id="nodeInspectorFetchDocker" type="button" data-bind="click: $root.fetchDockerHTML, eagleTooltip:'Fetch docker image data from Docker Hub'" data-bs-placement="left">Fetch from Docker Hub</button>
                 <!-- /ko -->
             <!-- /ko -->
         </div>

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -1,7 +1,7 @@
 <div id="paletteList">
     <div class="card">
         <div class="card-body">
-            <button class="btn btn-primary btn-block btn_wide" data-bind="click: showExplorePalettes, attr:{title: 'Retrieve information on all palettes in ' + Config.DEFAULT_PALETTE_REPOSITORY}" data-bs-toggle="tooltip" data-html="true" data-bs-placement="bottom">Explore Palettes</button>
+            <button class="btn btn-primary btn-block btn_wide" data-bind="click: showExplorePalettes, eagleTooltip: 'Retrieve information on all palettes in ' + Config.DEFAULT_PALETTE_REPOSITORY" data-bs-placement="bottom">Explore Palettes</button>
             <div class="searchBarContainer">
                 <i class="material-icons md-18 searchBarIcon">search</i>
                 <a href="#" data-bind="click:function(event){$root.emptySearchBar(Eagle.paletteComponentSearchString)}">
@@ -24,16 +24,16 @@
                     <div class="headerIcons">
                         <div class="paletteHeaderIcon">
                             <!-- ko if: $data.fileInfo().readonly -->
-                            <i class="material-icons interactive" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'readonly'}">lock</i>
+                            <i class="material-icons interactive" data-bs-placement="top" data-bind="eagleTooltip:'readonly'">lock</i>
                             <!-- /ko -->
                             <!-- ko ifnot: $data.fileInfo().readonly -->
-                            <i class="material-icons interactive" data-bs-toggle="tooltip" data-bs-placement="top" data-html="true" data-bind="attr:{title:'readwrite'}">lock_open</i>
+                            <i class="material-icons interactive" data-bs-placement="top" data-bind="eagleTooltip:'readwrite'">lock_open</i>
                             <!-- /ko -->
                         </div>
                     </div>
                     <div class="accordion-button" type="button" data-bs-toggle="collapse" aria-expanded="true" data-bind="attr:{id:'palette' + $index(), 'data-bs-target':'#collapse' + $index(), 'aria-controls':'collapse' + $index()}">
                         <span>&nbsp;</span>
-                        <h5 class="template-title" data-bs-toggle="tooltip" data-bs-placement="right" data-html="true" data-bind="text: fileInfo().nameAndModifiedIndicator(), attr:{title:fileInfo().getSummaryHTML(fileInfo().nameAndModifiedIndicator())}"></h5>
+                        <h5 class="template-title" data-bs-placement="right" data-bind="text: fileInfo().nameAndModifiedIndicator()}, eagleTooltip: fileInfo().getSummaryHTML(fileInfo().nameAndModifiedIndicator())"></h5>
                     </div>
                 </div>
                 <div class="collapse show accordion-collapse" aria-labelledby="headingOne" data-bind="attr:{id:'collapse' + $index()}">

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -33,7 +33,7 @@
                     </div>
                     <div class="accordion-button" type="button" data-bs-toggle="collapse" aria-expanded="true" data-bind="attr:{id:'palette' + $index(), 'data-bs-target':'#collapse' + $index(), 'aria-controls':'collapse' + $index()}">
                         <span>&nbsp;</span>
-                        <h5 class="template-title" data-bs-placement="right" data-bind="text: fileInfo().nameAndModifiedIndicator()}, eagleTooltip: fileInfo().getSummaryHTML(fileInfo().nameAndModifiedIndicator())"></h5>
+                        <h5 class="template-title" data-bs-placement="right" data-bind="text: fileInfo().nameAndModifiedIndicator(), eagleTooltip: fileInfo().getSummaryHTML(fileInfo().nameAndModifiedIndicator())"></h5>
                     </div>
                 </div>
                 <div class="collapse show accordion-collapse" aria-labelledby="headingOne" data-bind="attr:{id:'collapse' + $index()}">

--- a/templates/translation_menu.html
+++ b/templates/translation_menu.html
@@ -15,7 +15,7 @@
                 <div class="accordion-body">
                     <p class="card-text">Base PGT Generation</p>
                     <button id="alg0PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(0, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test0PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(0, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test0PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(0, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -63,7 +63,7 @@
                     <p class="card-text"></p>
 
                     <button id="alg1PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(1, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test1PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(1, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test1PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(1, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -102,7 +102,7 @@
                     <p class="card-text"></p>
 
                     <button id="alg2PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(2, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test2PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(2, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test2PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(2, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -159,7 +159,7 @@
                     <p class="card-text"></p>
 
                     <button id="alg3PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(3, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test3PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(3, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test3PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(3, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -219,7 +219,7 @@
                     <p class="card-text"></p>
 
                     <button id="alg4PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(4, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test4PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(4, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test4PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(4, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -251,7 +251,7 @@
                     <p class="card-text"></p>
 
                     <button id="alg5PGT" class="btn btn-primary btn_wide" data-bind="click: function(){genPGT(5, false, Eagle.DALiuGESchemaVersion.Unknown);}">Generate PGT</button>
-                    <button id="test5PGT" class="btn btn-secondary btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(5, true, Eagle.DALiuGESchemaVersion.Unknown);}">Test PGT</button>
+                    <button id="test5PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){genPGT(5, true, Eagle.DALiuGESchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                 </div>
             </div>
         </div>
@@ -294,7 +294,7 @@
                 </div>
             </div>
             <button id="alg1PGT" class="btn btn-primary btn-block mt-2 btn_wide" data-bind="click: function(){genPGT(1, false, Eagle.DALiuGESchemaVersion.OJS);}">Generate PGT</button>
-            <button id="test1PGT" class="btn btn-secondary btn-block mt-2 btn_wide" data-bs-toggle="tooltip" data-bs-placement="right" title="Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging." data-bind="click: function(){genPGT(1, true, Eagle.DALiuGESchemaVersion.OJS);}">Test PGT</button>
+            <button id="test1PGT" class="btn btn-secondary btn-block mt-2 btn_wide" data-bind="click: function(){genPGT(1, true, Eagle.DALiuGESchemaVersion.OJS);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
         </div>
     </div>
     <!-- /ko -->

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "./src/bindingHandlers/disabled.ts",
         "./src/bindingHandlers/graphRenderer.ts",
         "./src/bindingHandlers/nodeDataProperty.ts",
+        "./src/bindingHandlers/eagleTooltip.ts",
         "./src/components.ts",
         "./src/main.ts",
         "./src/Config.ts",


### PR DESCRIPTION
A new approach for handling tooltips throughout the code. It defines a knockout "custom binding", so that you can do:

`<span data-bind="eagleTooltip:'This is the tooltip text'">blah</span>`

By default, the custom binding will place the data-bs-toggle='tooltip', data-bs-placement='right' and data-html='true' attributes on the bound element. However, if data-bs-placement is already specified in the template HTML, that attribute will not be overwritten.

Thankfully, this approach removes the need to call reloadTooltips, and solves the timing issues that forced us to call setTimeout() to leave enough time for the HTML to be rendered. Now the init() and update() functions in the custom binding happen at the correct time by default.