### PR TITLE
LIU-216 Add shared memory size param

### DIFF
--- a/static/template.palette
+++ b/static/template.palette
@@ -344,7 +344,7 @@
                 "text": "Shared Memory Size",
                 "name": "shmSize",
                 "value": "",
-                "description": "",
+                "description": "The amount of shared memory at at /dev/shm to reserve with the docker host machine",
                 "readonly": false,
                 "type": "String",
                 "default": "1G"

--- a/static/template.palette
+++ b/static/template.palette
@@ -339,6 +339,15 @@
                 "readonly": false,
                 "type": "String",
                 "default": ""
+            },
+            {
+                "text": "Shared Memory Size",
+                "name": "shmSize",
+                "value": "",
+                "description": "",
+                "readonly": false,
+                "type": "String",
+                "default": "1G"
             }],
             "key": -8,
             "text": "Docker",


### PR DESCRIPTION
After some testing with plasma stores I noticed that writing to plasma starts to fail when objects exceed the default docker shared memory size (even though the plasma store accepts a memory argument bigger than this). In Daliuge 2.1.0 I've added this extra argument to docker containers and tested that large objects can now be written to plasma. 