### PR TITLE
Eagle 715 - Add expert mode and hide uncommon parameters unless enabled

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -40,6 +40,16 @@ export class Config {
         "simple"
     ];
 
+    static readonly EXPERT_MODE_PARAMETER_NAMES = [
+        "data_volume",
+        "execution_time",
+        "num_cpus",
+        "group_start",
+        "group_end",
+        "input_error_threshold",
+        "n_tries"
+    ];
+
     static readonly defaultRightWindowWidth : number = 400;
     static readonly defaultLeftWindowWidth : number = 310;
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -251,6 +251,10 @@ export class Eagle {
         return Eagle.findSetting(Utils.DISPLAY_NODE_KEYS).value();
     }
 
+    expertModeEnabled = () : boolean => {
+        return Eagle.findSetting(Utils.ENABLE_EXPERT_MODE).value();
+    }
+
     // TODO: remove?
     flagActiveFileModified = () : void => {
         if (this.logicalGraph()){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -151,7 +151,8 @@ export class Eagle {
                 new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, false),
                 new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, false),
                 new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, true),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, false)
+                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, false),
+                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, false)
             ],
             "External Services" : [
                 new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, "http://localhost:8084/gen_pgt"),

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -1,6 +1,7 @@
 import * as ko from "knockout";
 
 import {Eagle} from './Eagle';
+import {Config} from './Config';
 
 export class Field {
     private text : ko.Observable<string>; // external user-facing name
@@ -172,13 +173,9 @@ export class Field {
         return this.text().toLowerCase().indexOf(Eagle.tableSearchString().toLowerCase()) >= 0;
     }, this);
 
-    // TODO: this probably isn't required any more, we can safely assume that
-    //       any field in node.fields is a DALiuGE field, and conversely,
-    //       if a field is in node.applicationArgs, it isn't a DALiuGE field
-    isDaliugeField : ko.PureComputed<boolean> = ko.pureComputed(() => {
-        return this.name() === "execution_time" || this.name() === "num_cpus" || this.name() === "group_start" || this.name() === "group_end" || this.name() === "data_volume";
+    isExpertModeField : ko.PureComputed<boolean> = ko.pureComputed(() => {
+        return Config.EXPERT_MODE_PARAMETER_NAMES.indexOf(this.name()) > -1;
     }, this);
-
 
     select = (selection:any,selectionName:string, readOnlyState:boolean, selectionParent:Field, selectionIndex:number, event:any) : void => {
         Eagle.parameterTableSelectionName(selectionName);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -82,6 +82,7 @@ export class Utils {
     static readonly USE_SIMPLIFIED_TRANSLATOR_OPTIONS: string = "UseSimplifiedTranslatorOptions";
 
     static readonly GRAPH_ZOOM_DIVISOR: string = "GraphZoomDivisor";
+    static readonly ENABLE_EXPERT_MODE: string = "EnableExpertMode";
 
     static ojsGraphSchema : object = {};
     static v3GraphSchema : object = {};

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -577,58 +577,60 @@
                         </thead>
                             <tbody data-bind="foreach: $root.currentParamsArray()">
                             <!-- ko if: $data.fitsTableSearchQuery() -->
-                            <tr>
-                                <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'text' }"><input class="tableParameter" type="string" data-bind="value: text, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
-                                <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'name' }"><input class="tableParameter" type="string" data-bind="value: name, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
+                                <!-- ko if: !$data.isExpertModeField() || $root.expertModeEnabled() -->
+                                <tr>
+                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'text' }"><input class="tableParameter" type="string" data-bind="value: text, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
+                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'name' }"><input class="tableParameter" type="string" data-bind="value: name, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
 
-                                <!-- value fields -->
-                                <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'password' -->
-                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), readonly: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.value, 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}, click: function(event, data){select($data.value, 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}}"></td>
-                                <!-- /ko -->
-                                <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'checkbox' -->
-                                <td><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                <!-- /ko -->
-
-                                <!-- ko ifnot: $root.selectedNode().isLocked() -->
-                                    <td><input class="tableParameter" data-bind="checked: readonly, disabled: $root.selectedNode().isLocked(), event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr: {type: 'checkbox'}"></td>
-                                <!-- /ko -->
-                                <!-- ko if: $root.selectedNode().isLocked() -->
-                                    <!-- ko if: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
-                                        <td><i class="material-icons md-20" data-bind="eagleTooltip: $root.getReadOnlyText">lock</i></td>
+                                    <!-- value fields -->
+                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'password' -->
+                                        <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), readonly: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.value, 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}, click: function(event, data){select($data.value, 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}}"></td>
                                     <!-- /ko -->
-                                    <!-- ko ifnot: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
-                                        <td><i class="material-icons md-20" data-bind="eagleTooltip: 'value is readwrite'">lock_open</i></td>
-                                    <!-- /ko -->
-                                <!-- /ko -->
-
-                                <!-- default value fields -->
-                                <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'password' -->
-                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.defaultValue, 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}, click: function(event, data){select($data.defaultValue, 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
-                                <!-- /ko -->
-                                <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'checkbox' -->
-                                    <td><input class="tableParameter" onclick="$(this).val(this.checked ? true : false)" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                <!-- /ko -->
-
-                                <!-- selection input -->
-                                <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'select' -->
+                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'checkbox' -->
                                     <td><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                    <td><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                <!-- /ko -->
+                                    <!-- /ko -->
 
-                                <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'description' }"><input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.description, 'description', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.description, 'description', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
-                                <td>
-                                    <select data-bind="html: $root.fillParamentersTable($data.type()), value: type, disabled: $root.selectedNode().isLocked()">
-                                    <!-- options are added dynamically -->
-                                    </select>
-                                </td>
-                                <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: precious, valueUpdate: ['afterkeydown', 'input'], event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
-                                <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: positional, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
-                                <td>
-                                    <button class="resetDefaults" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$data.resetToDefault();$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), eagleTooltip:'Reset To Default'"><i class="material-icons">upload_file</i></button>
-                                    <button class="duplicate" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.duplicateParameter($index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Duplicate'"><i class="material-icons">content_copy</i></button>
-                                    <button class="delete" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.selectedNode().removeParamByIndex($data.fieldType, $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
-                                </td>
-                            </tr>
+                                    <!-- ko ifnot: $root.selectedNode().isLocked() -->
+                                        <td><input class="tableParameter" data-bind="checked: readonly, disabled: $root.selectedNode().isLocked(), event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr: {type: 'checkbox'}"></td>
+                                    <!-- /ko -->
+                                    <!-- ko if: $root.selectedNode().isLocked() -->
+                                        <!-- ko if: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
+                                            <td><i class="material-icons md-20" data-bind="eagleTooltip: $root.getReadOnlyText">lock</i></td>
+                                        <!-- /ko -->
+                                        <!-- ko ifnot: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
+                                            <td><i class="material-icons md-20" data-bind="eagleTooltip: 'value is readwrite'">lock_open</i></td>
+                                        <!-- /ko -->
+                                    <!-- /ko -->
+
+                                    <!-- default value fields -->
+                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'password' -->
+                                        <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.defaultValue, 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}, click: function(event, data){select($data.defaultValue, 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
+                                    <!-- /ko -->
+                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'checkbox' -->
+                                        <td><input class="tableParameter" onclick="$(this).val(this.checked ? true : false)" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+                                    <!-- /ko -->
+
+                                    <!-- selection input -->
+                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value()) === 'select' -->
+                                        <td><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+                                        <td><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+                                    <!-- /ko -->
+
+                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'description' }"><input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.description, 'description', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.description, 'description', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
+                                    <td>
+                                        <select data-bind="html: $root.fillParamentersTable($data.type()), value: type, disabled: $root.selectedNode().isLocked()">
+                                        <!-- options are added dynamically -->
+                                        </select>
+                                    </td>
+                                    <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: precious, valueUpdate: ['afterkeydown', 'input'], event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
+                                    <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: positional, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
+                                    <td>
+                                        <button class="resetDefaults" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$data.resetToDefault();$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), eagleTooltip:'Reset To Default'"><i class="material-icons">upload_file</i></button>
+                                        <button class="duplicate" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.duplicateParameter($index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Duplicate'"><i class="material-icons">content_copy</i></button>
+                                        <button class="delete" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.selectedNode().removeParamByIndex($data.fieldType, $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
+                                    </td>
+                                </tr>
+                                <!-- /ko -->
                             <!-- /ko -->
                         </tbody>
                     </table>

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -18,10 +18,7 @@
             </div>
             <!-- ko foreach: selectedNode().getFields() -->
                 <!-- ko if: $data.fitsComponentSearchQuery() -->
-                    <!-- ko ifnot: $data.isDaliugeField -->
-                        <field params="data: $data, ro: $parent.selectedNode().getFieldReadonly($index()), fieldType: Eagle.FieldType.Field"></field>
-                    <!-- /ko -->
-                    <!-- ko if: $data.isDaliugeField -->
+                    <!-- ko if: !$data.isExpertModeField() || $root.expertModeEnabled() -->
                         <field params="data: $data, ro: $parent.selectedNode().getFieldReadonly($index()), fieldType: Eagle.FieldType.Field"></field>
                     <!-- /ko -->
                 <!-- /ko -->

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -26,6 +26,9 @@ test('Edit node parameter', async t =>{
         // enable 'allow palette editing'
         .click('#settingAllowPaletteEditingButton')
 
+        // enable 'expert mode'
+        .click('#settingEnableExpertModeButton')
+
         // close settings modal
         .click('#settingsModalAffirmativeButton')
 


### PR DESCRIPTION
This change adds a setting called "expert mode", which is disabled by default. If "expert mode" is disabled, then uncommonly-used component parameters, such as "data_volume" and "execution_time" are hidden from the component parameters list.

When "expert mode" is enabled, the parameters become visible and can be edited as usual.

The list of parameters shown by expert mode is stored in Config.EXPERT_MODE_PARAMETER_NAMES