### PR TITLE
Eagle 721 - Combine expert mode and advanced editing settings

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -40,7 +40,7 @@ export class Config {
         "simple"
     ];
 
-    static readonly EXPERT_MODE_PARAMETER_NAMES = [
+    static readonly DALIUGE_PARAMETER_NAMES = [
         "data_volume",
         "execution_time",
         "num_cpus",

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -145,12 +145,12 @@ export class Eagle {
                 new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, 1000)
             ],
             "Advanced Editing" : [
-                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.true, false),
+                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false)
+                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, false),
                 new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, false),
                 new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, false),
                 new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, false),
                 new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, false),
-                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false)
             ],
             "External Services" : [
                 new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, "http://localhost:8084/gen_pgt"),

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -46,7 +46,7 @@ import {Port} from './Port';
 import {Edge} from './Edge';
 import {Field} from './Field';
 import {FileInfo} from './FileInfo';
-import {Setting} from './Setting';
+import {Setting, SettingsGroup} from './Setting';
 import {KeyboardShortcut} from './KeyboardShortcut';
 import {SideWindow} from './SideWindow';
 import {InspectorState} from './InspectorState';
@@ -98,7 +98,7 @@ export class Eagle {
     static applicationArgsSearchString : ko.Observable<string>;
     static tableSearchString : ko.Observable<string>;
 
-    static settings : {[category:string] : Setting[]}
+    static settings : SettingsGroup[];
     static shortcuts : ko.ObservableArray<KeyboardShortcut>;
 
     static dragStartX : number;
@@ -129,42 +129,58 @@ export class Eagle {
         Eagle.applicationArgsSearchString = ko.observable("");
         Eagle.tableSearchString = ko.observable("");
 
-        Eagle.settings = {
-            "User Options" : [
-                new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.true, Setting.noop, true),
-                new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.true, Setting.noop, true),
-                new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.true, Setting.noop, true),
-                new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.true, Setting.noop, true),
-                new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.true, Setting.noop, true),
-                new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.true, Setting.noop, false),
-                new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.true, Setting.noop, false),
-                new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.true, Setting.noop, true),
-                new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.true, Setting.noop, false),
-                new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.true, Setting.noop, true),
-                new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.true, Setting.noop, false),
-                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, Setting.noop, 1000),
-                new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
-            ],
-            "Advanced Editing" : [
-                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.expertModeEnabled, Setting.noop, false),
-            ],
-            "External Services" : [
-                new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, Setting.noop, "http://localhost:8084/gen_pgt"),
-                new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.true, Setting.noop, ""),
-                new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.true, Setting.noop, ""),
-                new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.true, Setting.noop, "icrar")
-            ],
-            "Workarounds" : [
-                new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.expertModeEnabled, Setting.noop, true),
-                new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.expertModeEnabled, Setting.noop, true),
-            ]
-        };
+        Eagle.settings = [
+            new SettingsGroup(
+                "User Options",
+                (eagle) => {return true;},
+                [
+                    new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.noop, true),
+                    new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.noop, true),
+                    new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.noop, true),
+                    new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.noop, true),
+                    new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.noop, true),
+                    new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.noop, false),
+                    new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.noop, false),
+                    new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.noop, true),
+                    new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.noop, false),
+                    new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.noop, true),
+                    new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.noop, false),
+                    new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.toggleExpertMode, false),
+                    new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.noop, 1000),
+                ]
+            ),
+            new SettingsGroup(
+                "Advanced Editing",
+                (eagle) => {return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);},
+                [
+                    new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.noop, false),
+                    new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.noop, false),
+                    new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.noop, false),
+                    new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.noop, false),
+                    new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.noop, false),
+                    new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.noop, false),
+                ]
+            ),
+            new SettingsGroup(
+                "External Services",
+                (eagle) => {return true;},
+                [
+                    new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.noop, "http://localhost:8084/gen_pgt"),
+                    new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.noop, ""),
+                    new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.noop, ""),
+                    new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.noop, "icrar")
+                ]
+            ),
+            new SettingsGroup(
+                "Workarounds",
+                (eagle) => {return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);},
+                [
+                    new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.noop, false),
+                    new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.noop, true),
+                    new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.noop, true),
+                ]
+            )
+        ];
 
         Eagle.shortcuts = ko.observableArray();
         Eagle.shortcuts.push(new KeyboardShortcut("new_graph", "New Graph", ["n"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, this.allowPaletteEditing, (eagle): void => {eagle.newLogicalGraph();}));
@@ -2552,12 +2568,6 @@ export class Eagle {
         }
     }
 
-    //used by the settings modal html to generate an id from the title
-    getSettingCategoryId = (title:string) : string => {
-        title = title.split(' ').join('')
-        return 'settingCategory' + title;
-    }
-
     toggleSettingsTab = (btn:any, target:any) :void => {
         //deselect and deactivate current tab content and buttons
         $(".settingsModalButton").removeClass("settingCategoryBtnActive");
@@ -2582,14 +2592,14 @@ export class Eagle {
             return null;
         }
 
-        for (const categoryName of Object.keys(Eagle.settings)){
-            const category = Eagle.settings[categoryName];
-            for (const setting of category){
+        for (const group of Eagle.settings){
+            for (const setting of group.getSettings()){
                 if (setting.getKey() === key){
                     return setting;
                 }
             }
         }
+
         return null;
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -183,8 +183,8 @@ export class Eagle {
         ];
 
         Eagle.shortcuts = ko.observableArray();
-        Eagle.shortcuts.push(new KeyboardShortcut("new_graph", "New Graph", ["n"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, this.allowPaletteEditing, (eagle): void => {eagle.newLogicalGraph();}));
-        Eagle.shortcuts.push(new KeyboardShortcut("new_palette", "New palette", ["n"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, this.allowPaletteEditing, (eagle): void => {eagle.newPalette();}));
+        Eagle.shortcuts.push(new KeyboardShortcut("new_graph", "New Graph", ["n"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, Eagle.allowPaletteEditing, (eagle): void => {eagle.newLogicalGraph();}));
+        Eagle.shortcuts.push(new KeyboardShortcut("new_palette", "New palette", ["n"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, Eagle.allowPaletteEditing, (eagle): void => {eagle.newPalette();}));
         Eagle.shortcuts.push(new KeyboardShortcut("open_graph_from_repo", "Open graph from repo", ["g"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.rightWindow().mode(Eagle.RightWindowMode.Repository);eagle.rightWindow().shown(true);}));
         Eagle.shortcuts.push(new KeyboardShortcut("open_graph_from_local_disk", "Open graph from local disk", ["g"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.getGraphFileToLoad();}));
         Eagle.shortcuts.push(new KeyboardShortcut("open_palette_from_repo", "Open palette from repo", ["p"], "keydown", KeyboardShortcut.Modifier.None,KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.rightWindow().mode(Eagle.RightWindowMode.Repository);eagle.rightWindow().shown(true);}));
@@ -259,20 +259,32 @@ export class Eagle {
         return false;
     }
 
-    allowPaletteEditing = () : boolean => {
-        return Eagle.findSetting(Utils.ALLOW_PALETTE_EDITING).value();
+    static allowInvalidEdges = () : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.ALLOW_INVALID_EDGES);
     }
 
-    allowComponentEditing = () : boolean => {
-        return Eagle.findSetting(Utils.ALLOW_COMPONENT_EDITING).value();
+    static allowPaletteEditing = () : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.ALLOW_PALETTE_EDITING);
+    }
+
+    static allowReadonlyPaletteEditing = () : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.ALLOW_READONLY_PALETTE_EDITING);
+    }
+
+    static allowComponentEditing = () : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.ALLOW_COMPONENT_EDITING);
+    }
+
+    static allowEdgeEditing = (): boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.ALLOW_EDGE_EDITING);
+    }
+
+    static showDaliugeRuntimeParameters = () : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE) && Eagle.findSettingValue(Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS);
     }
 
     displayNodeKeys = () :boolean => {
         return Eagle.findSetting(Utils.DISPLAY_NODE_KEYS).value();
-    }
-
-    showDaliugeRuntimeParameters = () : boolean => {
-        return Eagle.findSetting(Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS).value();
     }
 
     // TODO: remove?
@@ -2546,7 +2558,7 @@ export class Eagle {
         }
 
         if(Eagle.selectedLocation() === Eagle.FileType.Palette){
-            if(this.allowPaletteEditing()){
+            if(Eagle.allowPaletteEditing()){
                     return false;
             }else{
                 if (type === Eagle.FieldType.Field){
@@ -2556,7 +2568,7 @@ export class Eagle {
                 }
             }
         }else{
-            if(this.allowComponentEditing()){
+            if(Eagle.allowComponentEditing()){
                 return false
             }else{
                 if (type === Eagle.FieldType.Field){
@@ -3648,7 +3660,7 @@ export class Eagle {
         const destinationPaletteIndex : number = parseInt($(e.currentTarget)[0].getAttribute('data-palette-index'), 10);
         const destinationPalette: Palette = this.palettes()[destinationPaletteIndex];
 
-        const allowReadonlyPaletteEditing = Eagle.findSetting(Utils.ALLOW_READONLY_PALETTE_EDITING).value();
+        const allowReadonlyPaletteEditing = Eagle.allowReadonlyPaletteEditing();
 
         // check user can write to destination palette
         if (destinationPalette.fileInfo().readonly && !allowReadonlyPaletteEditing){
@@ -4207,10 +4219,6 @@ export class Eagle {
                 this.undo().pushSnapshot(this, "Edit Port");
             });
         }
-    }
-
-    allowEdgeEditing = (): boolean => {
-        return Eagle.findSettingValue(Utils.ALLOW_EDGE_EDITING);
     }
 
     explorePalettesClickHelper = (data: PaletteInfo, event:any): void => {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -153,12 +153,12 @@ export class Eagle {
                 "Advanced Editing",
                 (eagle) => {return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);},
                 [
-                    new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.noop, false),
-                    new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.noop, false),
-                    new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.noop, false),
-                    new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.noop, false),
-                    new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.noop, false),
-                    new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.noop, false),
+                    new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.noop, true),
+                    new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.noop, true),
+                    new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.noop, true),
+                    new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.noop, true),
+                    new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.noop, true),
+                    new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.noop, true),
                 ]
             ),
             new SettingsGroup(
@@ -2709,7 +2709,7 @@ export class Eagle {
             }
         }
     }
-    
+
     addEdgeToLogicalGraph = () : void => {
         // check that there is at least one node in the graph, otherwise it is difficult to create an edge
         if (this.logicalGraph().getNumNodes() === 0){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2685,10 +2685,8 @@ export class Eagle {
     }
 
     resetSettingsDefaults = () : void => {
-        for (const categoryName of Object.keys(Eagle.settings)){
-            const category = Eagle.settings[categoryName];
-
-            for (const setting of category){
+        for (const group of Eagle.settings){
+            for (const setting of group.getSettings()){
                 setting.resetDefault();
             }
         }
@@ -2696,10 +2694,8 @@ export class Eagle {
 
     //copies currently set settings in case the user wishes to cancel chenges in the setting modal
     copyCurrentSettings = () : void => {
-        for (const categoryName of Object.keys(Eagle.settings)){
-            const category = Eagle.settings[categoryName];
-
-            for (const setting of category){
+        for (const group of Eagle.settings){
+            for (const setting of group.getSettings()){
                 setting.copyCurrentSettings();
             }
         }
@@ -2707,15 +2703,13 @@ export class Eagle {
 
     //returns settings values to the previously copied settings, cancelling the settings editing
     cancelSettingChanges = () : void => {
-        for (const categoryName of Object.keys(Eagle.settings)){
-            const category = Eagle.settings[categoryName];
-
-            for (const setting of category){
+        for (const group of Eagle.settings){
+            for (const setting of group.getSettings()){
                 setting.cancelChanges();
             }
         }
     }
-
+    
     addEdgeToLogicalGraph = () : void => {
         // check that there is at least one node in the graph, otherwise it is difficult to create an edge
         if (this.logicalGraph().getNumNodes() === 0){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -131,37 +131,37 @@ export class Eagle {
 
         Eagle.settings = {
             "User Options" : [
-                new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, true),
-                new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, true),
-                new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, true),
-                new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, true),
-                new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, true),
-                new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, false),
-                new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, false),
-                new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, true),
-                new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, false),
-                new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, true),
-                new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, false),
-                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, 1000)
+                new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.true, true),
+                new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.true, true),
+                new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.true, true),
+                new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.true, true),
+                new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.true, true),
+                new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.true, false),
+                new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.true, false),
+                new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.true, true),
+                new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.true, false),
+                new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.true, true),
+                new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.true, false),
+                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, 1000)
             ],
             "Advanced Editing" : [
-                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, false),
-                new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, false),
-                new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, false),
-                new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, false),
-                new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, false),
-                new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, true),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, false),
-                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, false)
+                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.true, false),
+                new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, false),
+                new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, false),
+                new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, false),
+                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, false),
+                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false)
             ],
             "External Services" : [
-                new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, "http://localhost:8084/gen_pgt"),
-                new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, ""),
-                new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, ""),
-                new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, "icrar")
+                new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, "http://localhost:8084/gen_pgt"),
+                new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.true, ""),
+                new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.true, ""),
+                new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.true, "icrar")
             ],
             "Workarounds" : [
-                new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, true),
+                new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.expertModeEnabled, false),
+                new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.expertModeEnabled, true),
+                new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.expertModeEnabled, true),
             ]
         };
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -255,8 +255,8 @@ export class Eagle {
         return Eagle.findSetting(Utils.DISPLAY_NODE_KEYS).value();
     }
 
-    expertModeEnabled = () : boolean => {
-        return Eagle.findSetting(Utils.ENABLE_EXPERT_MODE).value();
+    showDaliugeRuntimeParameters = () : boolean => {
+        return Eagle.findSetting(Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS).value();
     }
 
     // TODO: remove?

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -145,12 +145,13 @@ export class Eagle {
                 new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, Setting.noop, 1000)
             ],
             "Advanced Editing" : [
-                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
+                new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
                 new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, Setting.noop, false),
                 new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, Setting.noop, false),
                 new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
                 new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, Setting.noop, false)
+                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.expertModeEnabled, Setting.noop, false),
             ],
             "External Services" : [
                 new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, Setting.noop, "http://localhost:8084/gen_pgt"),

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -145,12 +145,12 @@ export class Eagle {
                 new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, 1000)
             ],
             "Advanced Editing" : [
-                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false)
+                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false),
                 new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, false),
                 new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, false),
                 new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, false),
                 new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, false),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, false),
+                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, false)
             ],
             "External Services" : [
                 new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, "http://localhost:8084/gen_pgt"),

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -142,10 +142,10 @@ export class Eagle {
                 new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.true, Setting.noop, false),
                 new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.true, Setting.noop, true),
                 new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.true, Setting.noop, false),
-                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, Setting.noop, 1000)
+                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, Setting.noop, 1000),
+                new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
             ],
             "Advanced Editing" : [
-                new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
                 new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, Setting.noop, false),
                 new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, Setting.noop, false),
                 new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2697,6 +2697,18 @@ export class Eagle {
     }
 
     resetSettingsDefaults = () : void => {
+        // if a reset would turn off the expert mode setting,
+        // AND we are currently on the 'advanced editing' or 'workarounds' tabs of the setting modal,
+        // then those tabs will disappear and we'll be left looking at nothing, so switch to the 'User Options' tab
+        const expertModeSetting: Setting = Eagle.findSetting(Utils.ENABLE_EXPERT_MODE);
+        const turningOffExpertMode = expertModeSetting.value() && !expertModeSetting.getOldValue();
+        const currentSettingsTab: string = $('.settingsModalButton.settingCategoryBtnActive').attr('id');
+
+        if (turningOffExpertMode && (currentSettingsTab === "settingCategoryAdvancedEditing" || currentSettingsTab === "settingCategoryWorkarounds")){
+            // switch back to "User Options" tab
+            $('#settingCategoryUserOptions').click();
+        }
+
         for (const group of Eagle.settings){
             for (const setting of group.getSettings()){
                 setting.resetDefault();

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -131,37 +131,37 @@ export class Eagle {
 
         Eagle.settings = {
             "User Options" : [
-                new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.true, true),
-                new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.true, true),
-                new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.true, true),
-                new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.true, true),
-                new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.true, true),
-                new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.true, false),
-                new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.true, false),
-                new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.true, true),
-                new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.true, false),
-                new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.true, true),
-                new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.true, false),
-                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, 1000)
+                new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.true, Setting.noop, true),
+                new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.true, Setting.noop, true),
+                new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.true, Setting.noop, true),
+                new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.true, Setting.noop, true),
+                new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.true, Setting.noop, true),
+                new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.true, Setting.noop, false),
+                new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.true, Setting.noop, false),
+                new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.true, Setting.noop, true),
+                new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.true, Setting.noop, false),
+                new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.true, Setting.noop, true),
+                new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.true, Setting.noop, false),
+                new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.true, Setting.noop, 1000)
             ],
             "Advanced Editing" : [
-                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, false),
-                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, false),
-                new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, false),
-                new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, false),
-                new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, false),
-                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, false)
+                new Setting("Enable Expert Mode", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.true, Setting.toggleExpertMode, false),
+                new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.expertModeEnabled, Setting.noop, false)
             ],
             "External Services" : [
-                new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, "http://localhost:8084/gen_pgt"),
-                new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.true, ""),
-                new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.true, ""),
-                new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.true, "icrar")
+                new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.true, Setting.noop, "http://localhost:8084/gen_pgt"),
+                new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.true, Setting.noop, ""),
+                new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.true, Setting.noop, ""),
+                new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.true, Setting.noop, "icrar")
             ],
             "Workarounds" : [
-                new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.expertModeEnabled, false),
-                new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.expertModeEnabled, true),
-                new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.expertModeEnabled, true),
+                new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.expertModeEnabled, Setting.noop, false),
+                new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.expertModeEnabled, Setting.noop, true),
+                new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.expertModeEnabled, Setting.noop, true),
             ]
         };
 
@@ -2645,6 +2645,17 @@ export class Eagle {
         }
 
         return setting.value();
+    }
+
+    static setSettingValue = (key : string, value : any) : void => {
+        const setting = Eagle.findSetting(key);
+
+        if (setting === null){
+            console.warn("No setting", key);
+            return;
+        }
+
+        return setting.value(value);
     }
 
     getShortcutDisplay = () : {description:string, shortcut : string}[] => {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -134,50 +134,50 @@ export class Eagle {
                 "User Options",
                 (eagle) => {return true;},
                 [
-                    new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, Setting.noop, true),
-                    new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, Setting.noop, true),
-                    new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, Setting.noop, true),
-                    new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, Setting.noop, true),
-                    new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, Setting.noop, true),
-                    new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, Setting.noop, false),
-                    new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, Setting.noop, false),
-                    new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, Setting.noop, true),
-                    new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, Setting.noop, false),
-                    new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, Setting.noop, true),
-                    new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, Setting.noop, false),
-                    new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, Setting.toggleExpertMode, false),
-                    new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, Setting.noop, 1000),
+                    new Setting("Confirm Discard Changes", "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.", Setting.Type.Boolean, Utils.CONFIRM_DISCARD_CHANGES, true),
+                    new Setting("Confirm Remove Repositories", "Prompt user to confirm removing a repository from the list of known repositories.", Setting.Type.Boolean, Utils.CONFIRM_REMOVE_REPOSITORES, true),
+                    new Setting("Confirm Reload Palettes", "Prompt user to confirm when loading a palette that is already loaded.", Setting.Type.Boolean, Utils.CONFIRM_RELOAD_PALETTES, true),
+                    new Setting("Open Default Palette on Startup", "Open a default palette on startup. The palette contains an example of all known node categories", Setting.Type.Boolean, Utils.OPEN_DEFAULT_PALETTE, true),
+                    new Setting("Confirm Delete", "Prompt user to confirm when deleting node(s) or edge(s) from a graph.", Setting.Type.Boolean, Utils.CONFIRM_DELETE_OBJECTS, true),
+                    new Setting("Display Node Keys","Display Node Keys", Setting.Type.Boolean, Utils.DISPLAY_NODE_KEYS, false),
+                    new Setting("Disable JSON Validation", "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", Setting.Type.Boolean, Utils.DISABLE_JSON_VALIDATION, false),
+                    new Setting("Spawn Translation Tab", "When translating a graph, display the output of the translator in a new tab", Setting.Type.Boolean, Utils.SPAWN_TRANSLATION_TAB, true),
+                    new Setting("Enable Performance Display", "Display the frame time of the graph renderer", Setting.Type.Boolean, Utils.ENABLE_PERFORMANCE_DISPLAY, false),
+                    new Setting("Use Simplified Translator Options", "Hide the complex and rarely used translator options", Setting.Type.Boolean, Utils.USE_SIMPLIFIED_TRANSLATOR_OPTIONS, true),
+                    new Setting("Show File Loading Warnings", "Display list of issues with files encountered during loading.", Setting.Type.Boolean, Utils.SHOW_FILE_LOADING_ERRORS, false),
+                    new Setting("Enable Expert Mode", "Expert Mode enables the display of additional settings usually reserved for advanced users", Setting.Type.Boolean, Utils.ENABLE_EXPERT_MODE, false),
+                    new Setting("Graph Zoom Divisor", "The number by which zoom inputs are divided before being applied. Larger divisors reduce the amount of zoom.", Setting.Type.Number, Utils.GRAPH_ZOOM_DIVISOR, 1000),
                 ]
             ),
             new SettingsGroup(
                 "Advanced Editing",
                 (eagle) => {return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);},
                 [
-                    new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, Setting.noop, true),
-                    new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, Setting.noop, true),
-                    new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, Setting.noop, true),
-                    new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, Setting.noop, true),
-                    new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, Setting.noop, true),
-                    new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, Setting.noop, true),
+                    new Setting("Allow Invalid edges", "Allow the user to create edges even if they would normally be determined invalid.", Setting.Type.Boolean, Utils.ALLOW_INVALID_EDGES, true),
+                    new Setting("Allow Component Editing", "Allow the user to add/remove ports and parameters from components.", Setting.Type.Boolean, Utils.ALLOW_COMPONENT_EDITING, true),
+                    new Setting("Allow Palette Editing", "Allow the user to edit palettes.", Setting.Type.Boolean, Utils.ALLOW_PALETTE_EDITING, true),
+                    new Setting("Allow Readonly Palette Editing", "Allow the user to modify palettes that would otherwise be readonly.", Setting.Type.Boolean, Utils.ALLOW_READONLY_PALETTE_EDITING, true),
+                    new Setting("Allow Edge Editing", "Allow the user to edit edge attributes.", Setting.Type.Boolean, Utils.ALLOW_EDGE_EDITING, true),
+                    new Setting("Show DALiuGE runtime parameters", "Show additional component arguments that modify the behaviour of the DALiuGE runtime. For example: Data Volume, Execution Time, Num CPUs, Group Start/End", Setting.Type.Boolean, Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, true),
                 ]
             ),
             new SettingsGroup(
                 "External Services",
                 (eagle) => {return true;},
                 [
-                    new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, Setting.noop, "http://localhost:8084/gen_pgt"),
-                    new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, Setting.noop, ""),
-                    new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, Setting.noop, ""),
-                    new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, Setting.noop, "icrar")
+                    new Setting("Translator URL", "The URL of the translator server", Setting.Type.String, Utils.TRANSLATOR_URL, "http://localhost:8084/gen_pgt"),
+                    new Setting("GitHub Access Token", "A users access token for GitHub repositories.", Setting.Type.Password, Utils.GITHUB_ACCESS_TOKEN_KEY, ""),
+                    new Setting("GitLab Access Token", "A users access token for GitLab repositories.", Setting.Type.Password, Utils.GITLAB_ACCESS_TOKEN_KEY, ""),
+                    new Setting("Docker Hub Username", "The username to use when retrieving data on images stored on Docker Hub", Setting.Type.String, Utils.DOCKER_HUB_USERNAME, "icrar")
                 ]
             ),
             new SettingsGroup(
                 "Workarounds",
                 (eagle) => {return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);},
                 [
-                    new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, Setting.noop, false),
-                    new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, Setting.noop, true),
-                    new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, Setting.noop, true),
+                    new Setting("Translate with New Categories", "Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.", Setting.Type.Boolean, Utils.TRANSLATE_WITH_NEW_CATEGORIES, false),
+                    new Setting("Create Applications for Construct Ports", "When loading old graph files with ports on construct nodes, move the port to an embedded application", Setting.Type.Boolean, Utils.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, true),
+                    new Setting("Skip 'closes loop' edges in JSON output", "We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.", Setting.Type.Boolean, Utils.SKIP_CLOSE_LOOP_EDGES, true),
                 ]
             )
         ];

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -174,8 +174,8 @@ export class Field {
         return this.text().toLowerCase().indexOf(Eagle.tableSearchString().toLowerCase()) >= 0;
     }, this);
 
-    isExpertModeField : ko.PureComputed<boolean> = ko.pureComputed(() => {
-        return Config.EXPERT_MODE_PARAMETER_NAMES.indexOf(this.name()) > -1;
+    isDaliugeField : ko.PureComputed<boolean> = ko.pureComputed(() => {
+        return Config.DALIUGE_PARAMETER_NAMES.indexOf(this.name()) > -1;
     }, this);
 
     select = (selection:any,selectionName:string, readOnlyState:boolean, selectionParent:Field, selectionIndex:number, event:any) : void => {

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -337,10 +337,10 @@ export class Node {
 
     isLocked : ko.PureComputed<boolean> = ko.pureComputed(() => {
         if(Eagle.selectedLocation() === Eagle.FileType.Graph){
-            const allowComponentEditing : boolean = Eagle.findSettingValue(Utils.ALLOW_COMPONENT_EDITING);
+            const allowComponentEditing : boolean = Eagle.allowComponentEditing();
             return !allowComponentEditing;
         }else{
-            const allowPaletteEditing : boolean = Eagle.findSettingValue(Utils.ALLOW_PALETTE_EDITING);
+            const allowPaletteEditing : boolean = Eagle.allowPaletteEditing();
             return !allowPaletteEditing;
         }
     }, this);
@@ -434,7 +434,7 @@ export class Node {
     }
 
     getDescriptionReadonly = () : boolean => {
-        const allowParam : boolean = Eagle.findSettingValue(Utils.ALLOW_COMPONENT_EDITING);
+        const allowParam : boolean = Eagle.allowComponentEditing();
 
         return !allowParam;
     }
@@ -483,8 +483,7 @@ export class Node {
         const param: Field = this.applicationArgs()[index];
 
         // modify using settings and node readonly
-        const allowParam : boolean = Eagle.findSettingValue(Utils.ALLOW_COMPONENT_EDITING);
-
+        const allowParam : boolean = Eagle.allowComponentEditing();
         return (param.isReadonly()) && !allowParam;
     }
 

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -86,11 +86,6 @@ export class Setting {
         return this.key;
     }
 
-    // TODO: do we need this?
-    getSettings = () :any => {
-        console.log("bop")
-    }
-
     save = () : void => {
         localStorage.setItem(this.key, this.valueToString(this.value()));
     }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -3,23 +3,46 @@ import * as ko from "knockout";
 import {Eagle} from './Eagle';
 import {Utils} from './Utils';
 
+export class SettingsGroup {
+    private name : string;
+    private displayFunc : (eagle: Eagle) => boolean;
+    private settings : Setting[];
+
+    constructor(name: string, displayFunc: (eagle:Eagle) => boolean, settings: Setting[]){
+        this.name = name;
+        this.displayFunc = displayFunc;
+        this.settings = settings;
+    }
+
+    isVisible = (eagle: Eagle) : boolean => {
+        return this.displayFunc(eagle);
+    }
+
+    getSettings = () : Setting[] => {
+        return this.settings;
+    }
+
+    // used by the settings modal html to generate an id from the name
+    getHtmlId = () : string => {
+        return 'settingCategory' + this.name.split(' ').join('');
+    }
+}
+
 export class Setting {
     value : ko.Observable<any>;
     private name : string;
     private description : string;
     private type : Setting.Type;
     private key : string;
-    private displayFunc : (eagle: Eagle) => boolean;
     private toggleFunc : (value: boolean) => void;
     private defaultValue : any;
     private oldValue : any;
 
-    constructor(name : string, description : string, type : Setting.Type, key : string, displayFunc: (eagle:Eagle) => boolean, toggleFunc: (value: boolean) => void, defaultValue : any){
+    constructor(name : string, description : string, type : Setting.Type, key : string, toggleFunc: (value: boolean) => void, defaultValue : any){
         this.name = name;
         this.description = description;
         this.type = type;
         this.key = key;
-        this.displayFunc = displayFunc;
         this.toggleFunc = toggleFunc;
         this.value = ko.observable(defaultValue);
         this.defaultValue = defaultValue;
@@ -31,14 +54,6 @@ export class Setting {
         this.value.subscribe(function(){
             that.save();
         });
-    }
-
-    static expertModeEnabled = (eagle: Eagle) : boolean => {
-        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);
-    }
-
-    static true = (eagle: Eagle) : boolean => {
-        return true;
     }
 
     static noop = (value: boolean) : void => {
@@ -69,10 +84,6 @@ export class Setting {
 
     getKey = () : string => {
         return this.key;
-    }
-
-    getDisplay = (eagle: Eagle) : boolean => {
-        return this.displayFunc(eagle);
     }
 
     // TODO: do we need this?

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -1,22 +1,24 @@
 import * as ko from "knockout";
 
+import {Eagle} from './Eagle';
 import {Utils} from './Utils';
 
 export class Setting {
-
     value : ko.Observable<any>;
     private name : string;
     private description : string;
     private type : Setting.Type;
     private key : string;
+    private display : (eagle: Eagle) => boolean;
     private defaultValue : any;
     private oldValue : any;
 
-    constructor(name : string, description : string, type : Setting.Type, key : string, defaultValue : any){
+    constructor(name : string, description : string, type : Setting.Type, key : string, display: (eagle:Eagle) => boolean, defaultValue : any){
         this.name = name;
         this.description = description;
         this.type = type;
         this.key = key;
+        this.display = display;
         this.value = ko.observable(defaultValue);
         this.defaultValue = defaultValue;
         this.oldValue = "";
@@ -43,6 +45,10 @@ export class Setting {
 
     getKey = () : string => {
         return this.key;
+    }
+
+    getDisplay = (eagle: Eagle) : boolean => {
+        return this.display(eagle);
     }
 
     // TODO: do we need this?

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -52,6 +52,7 @@ export class Setting {
         Eagle.setSettingValue(Utils.ALLOW_PALETTE_EDITING, value);
         Eagle.setSettingValue(Utils.ALLOW_READONLY_PALETTE_EDITING, value);
         Eagle.setSettingValue(Utils.ALLOW_EDGE_EDITING, value);
+        Eagle.setSettingValue(Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, value);
     }
 
     getName = () : string => {
@@ -59,7 +60,7 @@ export class Setting {
     }
 
     getDescription = () : string => {
-        return this.description;
+        return this.description + " (default value: " + this.defaultValue + ")";
     }
 
     getType = () : Setting.Type => {

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -70,6 +70,10 @@ export class Setting {
         return this.key;
     }
 
+    getOldValue = () : any => {
+        return this.oldValue;
+    }
+
     save = () : void => {
         localStorage.setItem(this.key, this.valueToString(this.value()));
     }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -34,16 +34,14 @@ export class Setting {
     private description : string;
     private type : Setting.Type;
     private key : string;
-    private toggleFunc : (value: boolean) => void;
     private defaultValue : any;
     private oldValue : any;
 
-    constructor(name : string, description : string, type : Setting.Type, key : string, toggleFunc: (value: boolean) => void, defaultValue : any){
+    constructor(name : string, description : string, type : Setting.Type, key : string, defaultValue : any){
         this.name = name;
         this.description = description;
         this.type = type;
         this.key = key;
-        this.toggleFunc = toggleFunc;
         this.value = ko.observable(defaultValue);
         this.defaultValue = defaultValue;
         this.oldValue = "";
@@ -54,20 +52,6 @@ export class Setting {
         this.value.subscribe(function(){
             that.save();
         });
-    }
-
-    static noop = (value: boolean) : void => {
-        return;
-    }
-
-    static toggleExpertMode = (value: boolean) : void => {
-        // enable some other settings
-        Eagle.setSettingValue(Utils.ALLOW_INVALID_EDGES, value);
-        Eagle.setSettingValue(Utils.ALLOW_COMPONENT_EDITING, value);
-        Eagle.setSettingValue(Utils.ALLOW_PALETTE_EDITING, value);
-        Eagle.setSettingValue(Utils.ALLOW_READONLY_PALETTE_EDITING, value);
-        Eagle.setSettingValue(Utils.ALLOW_EDGE_EDITING, value);
-        Eagle.setSettingValue(Utils.SHOW_DALIUGE_RUNTIME_PARAMETERS, value);
     }
 
     getName = () : string => {
@@ -107,8 +91,6 @@ export class Setting {
 
         // update the value
         this.value(!this.value());
-
-        this.toggleFunc(this.value());
     }
 
     copy = () : void => {

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -31,6 +31,14 @@ export class Setting {
         });
     }
 
+    static expertModeEnabled = (eagle: Eagle) : boolean => {
+        return Eagle.findSettingValue(Utils.ENABLE_EXPERT_MODE);
+    }
+
+    static true = (eagle: Eagle) : boolean => {
+        return true;
+    }
+
     getName = () : string => {
         return this.name;
     }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -9,16 +9,18 @@ export class Setting {
     private description : string;
     private type : Setting.Type;
     private key : string;
-    private display : (eagle: Eagle) => boolean;
+    private displayFunc : (eagle: Eagle) => boolean;
+    private toggleFunc : (value: boolean) => void;
     private defaultValue : any;
     private oldValue : any;
 
-    constructor(name : string, description : string, type : Setting.Type, key : string, display: (eagle:Eagle) => boolean, defaultValue : any){
+    constructor(name : string, description : string, type : Setting.Type, key : string, displayFunc: (eagle:Eagle) => boolean, toggleFunc: (value: boolean) => void, defaultValue : any){
         this.name = name;
         this.description = description;
         this.type = type;
         this.key = key;
-        this.display = display;
+        this.displayFunc = displayFunc;
+        this.toggleFunc = toggleFunc;
         this.value = ko.observable(defaultValue);
         this.defaultValue = defaultValue;
         this.oldValue = "";
@@ -39,6 +41,19 @@ export class Setting {
         return true;
     }
 
+    static noop = (value: boolean) : void => {
+        return;
+    }
+
+    static toggleExpertMode = (value: boolean) : void => {
+        // enable some other settings
+        Eagle.setSettingValue(Utils.ALLOW_INVALID_EDGES, value);
+        Eagle.setSettingValue(Utils.ALLOW_COMPONENT_EDITING, value);
+        Eagle.setSettingValue(Utils.ALLOW_PALETTE_EDITING, value);
+        Eagle.setSettingValue(Utils.ALLOW_READONLY_PALETTE_EDITING, value);
+        Eagle.setSettingValue(Utils.ALLOW_EDGE_EDITING, value);
+    }
+
     getName = () : string => {
         return this.name;
     }
@@ -56,7 +71,7 @@ export class Setting {
     }
 
     getDisplay = (eagle: Eagle) : boolean => {
-        return this.display(eagle);
+        return this.displayFunc(eagle);
     }
 
     // TODO: do we need this?
@@ -85,6 +100,8 @@ export class Setting {
 
         // update the value
         this.value(!this.value());
+
+        this.toggleFunc(this.value());
     }
 
     copy = () : void => {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -64,6 +64,7 @@ export class Utils {
     static readonly ALLOW_COMPONENT_EDITING : string = "AllowComponentEditing";
     static readonly ALLOW_READONLY_PALETTE_EDITING : string = "AllowReadonlyPaletteEditing";
     static readonly ALLOW_EDGE_EDITING : string = "AllowEdgeEditing";
+    static readonly SHOW_DALIUGE_RUNTIME_PARAMETERS : string = "ShowDaliugeRuntimeParameters";
 
     static readonly ALLOW_PALETTE_EDITING : string = "AllowPaletteEditing";
     static readonly DISPLAY_NODE_KEYS : string = "DisplayNodeKeys"

--- a/src/bindingHandlers/graphRenderer.ts
+++ b/src/bindingHandlers/graphRenderer.ts
@@ -892,11 +892,8 @@ function render(graph: LogicalGraph, elementId : string, eagle : Eagle){
                                     // check if link is valid
                                     const linkValid : Eagle.LinkValid = Edge.isValid(graph, sourceNodeKey, sourcePortId, destinationNodeKey, destinationPortId, false, true, true);
 
-                                    // check if we should allow invalid edges
-                                    const allowInvalidEdges : boolean = Eagle.findSettingValue(Utils.ALLOW_INVALID_EDGES);
-
                                     // abort if edge is invalid
-                                    if (allowInvalidEdges || linkValid === Eagle.LinkValid.Valid || linkValid === Eagle.LinkValid.Warning){
+                                    if (Eagle.allowInvalidEdges() || linkValid === Eagle.LinkValid.Valid || linkValid === Eagle.LinkValid.Warning){
                                         if (linkValid === Eagle.LinkValid.Warning){
                                             addEdge(sourceNodeKey, sourcePortId, destinationNodeKey, destinationPortId, srcPort.getName(), sourceDataType, true, false);
                                         } else {

--- a/templates/base.html
+++ b/templates/base.html
@@ -121,17 +121,17 @@
                                         <h5>Selection Summary</h5>
                                     </div>
                                     <div class="col-4 text-right headerBtns">
-                                        <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
+                                        <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Eagle.allowPaletteEditing() -->
                                         <button type="button" id="duplicateSelectedNodes" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false, eagleTooltip: 'Duplicate Selection ' + Utils.getKeyboardShortcutTextByKey('duplicate_selection', true)" data-bs-placement="left">
                                             <i  class="material-icons md-24">content_copy</i>
                                         </button>
                                         <!-- /ko -->
-                                        <!-- ko if: allowPaletteEditing() -->
+                                        <!-- ko if: Eagle.allowPaletteEditing() -->
                                         <button type="button" id="addSelectedNodesToPalette" class="btn btn-secondary btn-sm" data-bind="click: addSelectedNodesToPalette, clickBubble: false, eagleTooltip: 'Add Selected Node To Palette'" data-bs-placement="left">
                                             <i  class="material-icons md-24">library_add</i>
                                         </button>
                                         <!-- /ko -->
-                                        <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
+                                        <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Eagle.allowPaletteEditing() -->
                                         <button type="button" id="deleteSelectedNodes" class="btn btn-secondary btn-sm" data-bind="click: function(){deleteSelection(false);}, clickBubble: false, eagleTooltip: 'Delete Selected Node ' + Utils.getKeyboardShortcutTextByKey('delete_selection', true)" data-bs-placement="left">
                                             <i class="material-icons md-24">delete</i>
                                         </button>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -577,7 +577,7 @@
                         </thead>
                             <tbody data-bind="foreach: $root.currentParamsArray()">
                             <!-- ko if: $data.fitsTableSearchQuery() -->
-                                <!-- ko if: !$data.isDaliugeField() || $root.showDaliugeRuntimeParameters() -->
+                                <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
                                 <tr>
                                     <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'text' }"><input class="tableParameter" type="string" data-bind="value: text, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
                                     <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'name' }"><input class="tableParameter" type="string" data-bind="value: name, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -579,7 +579,7 @@
                         </thead>
                             <tbody data-bind="foreach: $root.currentParamsArray()">
                             <!-- ko if: $data.fitsTableSearchQuery() -->
-                                <!-- ko if: !$data.isExpertModeField() || $root.expertModeEnabled() -->
+                                <!-- ko if: !$data.isDaliugeField() || $root.showDaliugeRuntimeParameters() -->
                                 <tr>
                                     <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'text' }"><input class="tableParameter" type="string" data-bind="value: text, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.text, 'text', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
                                     <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'name' }"><input class="tableParameter" type="string" data-bind="value: name, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.name, 'name', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -294,58 +294,56 @@
             </div>
             <div class="modal-body">
                 <div id="settingsModalHeader">
-                    <!-- ko foreach: Object.keys(Eagle.settings) -->
-                        <button class="settingsModalButton" data-bind="attr:{id: $root.getSettingCategoryId($data)}, text: $data, click: $root.toggleSettingsTab($root.getSettingCategoryId($data), 'settingsCategory'+$index()+'Content')"></button>
+                    <!-- ko foreach: Eagle.settings -->
+                        <button class="settingsModalButton" data-bind="attr:{id: $data.getHtmlId()}, text: $data.name, click: $root.toggleSettingsTab($data.getHtmlId(), 'settingsCategory'+$index()+'Content'), visible: $data.isVisible($root)"></button>
                     <!-- /ko -->
                 </div>
                 <form>
-                    <!-- ko foreach: Object.keys(Eagle.settings) -->
-                        <div class="settingsModalCategoryWrapper" data-bind="attr:{id:'settingsCategory'+$index()+'Content'}">
+                    <!-- ko foreach: Eagle.settings -->
+                        <div class="settingsModalCategoryWrapper" data-bind="attr:{id:'settingsCategory'+$index()+'Content'}, visible: $data.isVisible($root)">
                             <div class="row">
-                                <!-- ko foreach: Eagle.settings[$data] -->
-                                    <!-- ko if: $data.getDisplay($root) -->
-                                        <!-- ko if: $data.getType() === 0 -->
-                                            <div class="input-group mb-1">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
-                                                </div>
-                                                <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                <!-- ko foreach: $data.settings -->
+                                    <!-- ko if: $data.getType() === 0 -->
+                                        <div class="input-group mb-1">
+                                            <div class="input-group-prepend">
+                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
                                             </div>
-                                        <!-- /ko -->
-                                        <!-- ko if: $data.getType() === 1 -->
-                                            <div class="input-group mb-1">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
-                                                </div>
-                                                <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                            <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                        </div>
+                                    <!-- /ko -->
+                                    <!-- ko if: $data.getType() === 1 -->
+                                        <div class="input-group mb-1">
+                                            <div class="input-group-prepend">
+                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
                                             </div>
-                                        <!-- /ko -->
-                                        <!-- ko if: $data.getType() === 2 -->
-                                            <div class="settingSm col-6">
-                                                <div class="input-group mb-1 checkSettingLabel">
-                                                    <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
-                                                    <div class="input-group-append">
-                                                        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.toggle, attr:{id:'setting'+$data.getKey()+'Button'}">
-                                                            <i class="material-icons md-18" data-bind="visible: $data.value">radio_button_checked</i>
-                                                            <i class="material-icons md-18" data-bind="hidden: $data.value">radio_button_unchecked</i>
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        <!-- /ko -->
-                                        <!-- ko if: $data.getType() === 3 -->
-                                            <div class="input-group mb-1">
-                                                <div class="input-group-prepend">
-                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip:$data.getDescription()" data-bs-placement="left"></span>
-                                                </div>
-                                                <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                            <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                        </div>
+                                    <!-- /ko -->
+                                    <!-- ko if: $data.getType() === 2 -->
+                                        <div class="settingSm col-6">
+                                            <div class="input-group mb-1 checkSettingLabel">
+                                                <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
                                                 <div class="input-group-append">
-                                                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.copy, attr:{id:'setting'+$data.getKey()+'Copy'}">
-                                                        <i class="material-icons md-18">content_copy</i>
+                                                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.toggle, attr:{id:'setting'+$data.getKey()+'Button'}">
+                                                        <i class="material-icons md-18" data-bind="visible: $data.value">radio_button_checked</i>
+                                                        <i class="material-icons md-18" data-bind="hidden: $data.value">radio_button_unchecked</i>
                                                     </button>
                                                 </div>
                                             </div>
-                                        <!-- /ko -->
+                                        </div>
+                                    <!-- /ko -->
+                                    <!-- ko if: $data.getType() === 3 -->
+                                        <div class="input-group mb-1">
+                                            <div class="input-group-prepend">
+                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip:$data.getDescription()" data-bs-placement="left"></span>
+                                            </div>
+                                            <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
+                                            <div class="input-group-append">
+                                                <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.copy, attr:{id:'setting'+$data.getKey()+'Copy'}">
+                                                    <i class="material-icons md-18">content_copy</i>
+                                                </button>
+                                            </div>
+                                        </div>
                                     <!-- /ko -->
                                 <!-- /ko -->
                             </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -303,47 +303,49 @@
                         <div class="settingsModalCategoryWrapper" data-bind="attr:{id:'settingsCategory'+$index()+'Content'}">
                             <div class="row">
                                 <!-- ko foreach: Eagle.settings[$data] -->
-                                    <!-- ko if: $data.getType() === 0 -->
-                                        <div class="input-group mb-1">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
+                                    <!-- ko if: $data.getDisplay($root) -->
+                                        <!-- ko if: $data.getType() === 0 -->
+                                            <div class="input-group mb-1">
+                                                <div class="input-group-prepend">
+                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
+                                                </div>
+                                                <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                             </div>
-                                            <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
-                                        </div>
-                                    <!-- /ko -->
-                                    <!-- ko if: $data.getType() === 1 -->
-                                        <div class="input-group mb-1">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
+                                        <!-- /ko -->
+                                        <!-- ko if: $data.getType() === 1 -->
+                                            <div class="input-group mb-1">
+                                                <div class="input-group-prepend">
+                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip: $data.getDescription()" data-bs-placement="left"></span>
+                                                </div>
+                                                <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                             </div>
-                                            <input type="text" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
-                                        </div>
-                                    <!-- /ko -->
-                                    <!-- ko if: $data.getType() === 2 -->
-                                        <div class="settingSm col-6">
-                                            <div class="input-group mb-1 checkSettingLabel">
-                                                <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
+                                        <!-- /ko -->
+                                        <!-- ko if: $data.getType() === 2 -->
+                                            <div class="settingSm col-6">
+                                                <div class="input-group mb-1 checkSettingLabel">
+                                                    <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
+                                                    <div class="input-group-append">
+                                                        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.toggle, attr:{id:'setting'+$data.getKey()+'Button'}">
+                                                            <i class="material-icons md-18" data-bind="visible: $data.value">radio_button_checked</i>
+                                                            <i class="material-icons md-18" data-bind="hidden: $data.value">radio_button_unchecked</i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        <!-- /ko -->
+                                        <!-- ko if: $data.getType() === 3 -->
+                                            <div class="input-group mb-1">
+                                                <div class="input-group-prepend">
+                                                    <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip:$data.getDescription()" data-bs-placement="left"></span>
+                                                </div>
+                                                <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
                                                 <div class="input-group-append">
-                                                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.toggle, attr:{id:'setting'+$data.getKey()+'Button'}">
-                                                        <i class="material-icons md-18" data-bind="visible: $data.value">radio_button_checked</i>
-                                                        <i class="material-icons md-18" data-bind="hidden: $data.value">radio_button_unchecked</i>
+                                                    <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.copy, attr:{id:'setting'+$data.getKey()+'Copy'}">
+                                                        <i class="material-icons md-18">content_copy</i>
                                                     </button>
                                                 </div>
                                             </div>
-                                        </div>
-                                    <!-- /ko -->
-                                    <!-- ko if: $data.getType() === 3 -->
-                                        <div class="input-group mb-1">
-                                            <div class="input-group-prepend">
-                                                <span class="input-group-text" data-bind="attr:{id:'setting'+$data.getKey()}, text:$data.getName(), eagleTooltip:$data.getDescription()" data-bs-placement="left"></span>
-                                            </div>
-                                            <input type="password" autocomplete="off" class="form-control" placeholder="" data-bind="value: $data.value, attr:{id:'setting'+$data.getKey()+'Value'}">
-                                            <div class="input-group-append">
-                                                <button class="btn btn-secondary btn-sm" type="button" data-bind="click: $data.copy, attr:{id:'setting'+$data.getKey()+'Copy'}">
-                                                    <i class="material-icons md-18">content_copy</i>
-                                                </button>
-                                            </div>
-                                        </div>
+                                        <!-- /ko -->
                                     <!-- /ko -->
                                 <!-- /ko -->
                             </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -37,7 +37,7 @@
                 <button id="zoomOut" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: zoomOut, eagleTooltip: 'Zoom Out ' + Utils.getKeyboardShortcutTextByKey('zoom_out', true)" data-intro="Zoom out from the graph within the graph rendering area.">
                     <i class="material-icons md-18">zoom_out</i>
                 </button>
-                <!-- ko if: allowPaletteEditing() -->
+                <!-- ko if: Eagle.allowPaletteEditing() -->
                 <button id="addGraphNodesToPalette" class="btn btn-outline-secondary navbar-btn" type="button" data-bs-placement="bottom" data-bind="click: addGraphNodesToPalette, eagleTooltip: 'Add Graph Nodes to Palette ' + Utils.getKeyboardShortcutTextByKey('add_graph_nodes_to_palette', true)" data-intro="Add all nodes in the current graph to the a new or existing palette.">
                     <i class="material-icons md-18">palette</i>
                 </button>
@@ -117,7 +117,7 @@
                     Palette
                 </a>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownPalette">
-                <!-- ko if: allowPaletteEditing() -->
+                <!-- ko if: Eagle.allowPaletteEditing() -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
                             <a class="dropdown-item" id="createNewPalette" href="#" data-bind="click: newPalette">Create New Palette
@@ -144,7 +144,7 @@
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" id="saveToPalette" href="#" data-bind="click: addGraphNodesToPalette">Save Node To Palette</a>
                 <!-- /ko -->
-                <!-- ko if: !allowPaletteEditing() -->
+                <!-- ko if: !Eagle.allowPaletteEditing() -->
                     <a class="dropdown-item" id="loadPalette" href="#" data-bind="click: getPaletteFileToLoad">Load Local Palette
                         <span data-bind="text: Utils.getKeyboardShortcutTextByKey('open_palette_from_local_disk', true)"></span>
                     </a>

--- a/templates/node_inspector.html
+++ b/templates/node_inspector.html
@@ -42,17 +42,17 @@
                     <!-- /ko -->
                 </div>
                 <div class="col-6 text-right">
-                    <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
+                    <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Eagle.allowPaletteEditing() -->
                     <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: duplicateSelection, clickBubble: false, eagleTooltip: 'Duplicate Selection ' + Utils.getKeyboardShortcutTextByKey('duplicate_selection', true)" data-bs-placement="left">
                         <i  class="material-icons md-20">content_copy</i>
                     </button>
                     <!-- /ko -->
-                    <!-- ko if: allowPaletteEditing() -->
+                    <!-- ko if: Eagle.allowPaletteEditing() -->
                     <button type="button" id="addSelectedNodeToPalette" class="btn btn-secondary btn-sm" data-bind="click: addSelectedNodesToPalette, clickBubble: false, eagleTooltip: 'Add Selected Node To Palette'" data-bs-placement="left">
                         <i  class="material-icons md-20">library_add</i>
                     </button>
                     <!-- /ko -->
-                    <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || allowPaletteEditing() -->
+                    <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Eagle.allowPaletteEditing() -->
                     <button type="button" id="deleteSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: function(){deleteSelection(false);}, clickBubble: false, eagleTooltip: 'Delete Selected Node ' + Utils.getKeyboardShortcutTextByKey('delete_selection', true)" data-bs-placement="left">
                         <i class="material-icons md-20">delete</i>
                     </button>

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -18,7 +18,7 @@
             </div>
             <!-- ko foreach: selectedNode().getFields() -->
                 <!-- ko if: $data.fitsComponentSearchQuery() -->
-                    <!-- ko if: !$data.isDaliugeField() || $root.showDaliugeRuntimeParameters() -->
+                    <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
                         <field params="data: $data, ro: $parent.selectedNode().getFieldReadonly($index()), fieldType: Eagle.FieldType.Field"></field>
                     <!-- /ko -->
                 <!-- /ko -->

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -18,7 +18,7 @@
             </div>
             <!-- ko foreach: selectedNode().getFields() -->
                 <!-- ko if: $data.fitsComponentSearchQuery() -->
-                    <!-- ko if: !$data.isExpertModeField() || $root.expertModeEnabled() -->
+                    <!-- ko if: !$data.isDaliugeField() || $root.showDaliugeRuntimeParameters() -->
                         <field params="data: $data, ro: $parent.selectedNode().getFieldReadonly($index()), fieldType: Eagle.FieldType.Field"></field>
                     <!-- /ko -->
                 <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -8,7 +8,7 @@
                 more_vert
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="paletteWindowdropdown">
-            <!-- ko if: allowPaletteEditing() -->
+            <!-- ko if: Eagle.allowPaletteEditing() -->
                 <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                     <div class="dropDropDown">
                         <a class="dropdown-item" id="createNewPalette" href="#" data-bind="click: newPalette">Create New Palette
@@ -45,7 +45,7 @@
                     <!-- ko if: $data.fileInfo().repositoryService !== Eagle.RepositoryService.Unknown -->
                     <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}, clickBubble: false" data-html="true"><span>Reload Palette</span></a>
                     <!-- /ko -->
-                    <!-- ko if: $root.allowPaletteEditing() -->
+                    <!-- ko if: Eagle.allowPaletteEditing() -->
                         <a href="#" data-bind="click: $root.savePaletteToDisk" data-html="true"><span>Save Locally</span></a>
                         <a href="#" data-bind="click: $root.savePaletteToGit" data-html="true"><span>Save To Git</span></a>
                     <!-- /ko -->

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -20,9 +20,6 @@ test('Edit node parameter', async t =>{
         // open settings modal
         .click('#settings')
 
-        // switch to advanced editing tab in settings
-        .click('#settingCategoryAdvancedEditing')
-
         // enable 'expert mode'
         .click('#settingEnableExpertModeButton')
 

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -26,12 +26,6 @@ test('Edit node parameter', async t =>{
         // enable 'expert mode'
         .click('#settingEnableExpertModeButton')
 
-        // allow some time for the extra settings to appear
-        .wait(1000)
-
-        // enable 'allow palette editing'
-        .click('#settingAllowPaletteEditingButton')
-
         // close settings modal
         .click('#settingsModalAffirmativeButton')
 

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -23,14 +23,14 @@ test('Edit node parameter', async t =>{
         // switch to advanced editing tab in settings
         .click('#settingCategoryAdvancedEditing')
 
-        // enable 'allow palette editing'
+        // enable 'expert mode'
         .click('#settingEnableExpertModeButton')
+
+        // allow some time for the extra settings to appear
+        .wait(1000)
 
         // enable 'allow palette editing'
         .click('#settingAllowPaletteEditingButton')
-
-        // enable 'expert mode'
-        .click('#settingEnableExpertModeButton')
 
         // close settings modal
         .click('#settingsModalAffirmativeButton')

--- a/tests/edit-node-parameter.js
+++ b/tests/edit-node-parameter.js
@@ -24,6 +24,9 @@ test('Edit node parameter', async t =>{
         .click('#settingCategoryAdvancedEditing')
 
         // enable 'allow palette editing'
+        .click('#settingEnableExpertModeButton')
+
+        // enable 'allow palette editing'
         .click('#settingAllowPaletteEditingButton')
 
         // enable 'expert mode'


### PR DESCRIPTION
Added two new attributes to the Settings class (displayFunc and toggleFunc).

- displayFunc is a function that is run to determine whether the setting should appear in the list of settings.
- toggleFunc is a function that is run whenever the setting is changed by the user.

This allows us to hide several "advanced editing" and "workaround" settings, until "expert mode" is enabled.

Then, when expert mode is enabled, we run a toggleFunc which enabled ALL the "advanced editing" settings automatically.

Also, I added one new setting ("Show DALiuGE runtime parameters") that hides/shows the list of component parameters common to DALiuGE. Previously, this behaviour was controlled by the "expert mode" setting, but now it has its own.

All "expert mode" does is hide/show all the "advanced editing" settings, enabling them all by default when it is enabled, and disabling them all when it is disabled.