### PR TITLE
Eagle 745 - Generalise the checkGraph modal for use during file loading

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -777,23 +777,15 @@ export class Eagle {
     }
 
     private _handleLoadingErrors = (errorsWarnings: Eagle.ErrorsWarnings, fileName: string, service: Eagle.RepositoryService) : void => {
-        // TODO: determine showErrors from settings
         const showErrors: boolean = Eagle.findSetting(Utils.SHOW_FILE_LOADING_ERRORS).value();
-        const showWarnings = true;
 
         // show errors (if found)
         if (errorsWarnings.errors.length > 0 || errorsWarnings.warnings.length > 0){
-            if (showErrors || showWarnings){
-                // TODO: better modal here, use the check graph modal if possible
-                Utils.showUserMessage("Loading", errorsWarnings.warnings.join('<br/>') + '<br/>' + errorsWarnings.errors.join('<br/>'));
+            if (showErrors){
+                Utils.showErrorsModal("Loading File", errorsWarnings.errors, errorsWarnings.warnings);
             }
         } else {
             Utils.showNotification("Success", fileName + " has been loaded from " + service + ".", "success");
-        }
-
-        // print warnings in console
-        for (const warning of errorsWarnings.warnings){
-            console.warn(warning);
         }
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4407,45 +4407,12 @@ export class Eagle {
     // TODO: maybe try to move some of this html out to a template
     showGraphErrors = (): void => {
         if (this.graphWarnings().length > 0 || this.graphErrors().length > 0){
-            let message = "";
 
-            //start of modal content
-            message += "<div class='accordion' id='checkGraphAccordion'>"
+            // show graph modal
+            Utils.showErrorsModal("Check Graph", this.graphErrors(), this.graphWarnings());
 
-                //graph errors
-                if (this.graphErrors().length > 0){
-                    message += '<div class="accordion-item">'
-                        message += '<h2 class="accordion-header" id="checkGraphAccordionHeadingOne">'
-                            message += '<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors  <span id="graphErrorRed">[' + this.graphErrors().length + ']</span></button>'
-                        message += "</h2>"
-                        message += '<div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">'
-                            message += '<div class="accordion-body">'
-                                message += this.graphErrors().join('<br/>')
-                            message += '</div>'
-                        message += '</div>'
-                    message += "</div>"
-                }
-
-                //graph warnings
-                if (this.graphWarnings().length > 0){
-                    message += '<div class="accordion-item">'
-                        message += '<h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">'
-                            message += '<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings  <span id="graphErrorYellow">[' + this.graphWarnings().length + ']</span></button>'
-                        message += "</h2>"
-                        message += '<div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">'
-                            message += '<div class="accordion-body">'
-                                message += this.graphWarnings().join('<br/>')
-                            message += '</div>'
-                        message += '</div>'
-                    message += "</div>"
-                }
-
-            //end of modal content
-            message += "</div>"
-
-            Utils.showUserMessage("Check Graph", message);
             //set fixed height for this use of the shared modal to prevent it collapsing when collapsing a section within
-            $("#checkGraphAccordion").parent().parent().css("height","70vh")
+            $("#errorsModalAccordion").parent().parent().css("height","70vh")
         } else {
             Utils.showNotification("Check Graph", "Graph OK", "success");
         }
@@ -4937,7 +4904,7 @@ $( document ).ready(function() {
     $('.modal').on('hidden.bs.modal', function () {
         $('.modal-dialog').css({"left":"0px", "top":"0px"})
         $("#editFieldModal textarea").attr('style','')
-        $("#checkGraphAccordion").parent().parent().attr('style','')
+        $("#errorsModalAccordion").parent().parent().attr('style','')
 
         //reset parameter table selecction
         Eagle.resetParamsTableSelection()

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4389,7 +4389,6 @@ export class Eagle {
     }
 
     checkGraph = (): void => {
-        console.log("checkGraph()");
         const checkResult = Utils.checkGraph(this.logicalGraph());
 
         this.graphWarnings(checkResult.warnings);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4401,9 +4401,6 @@ export class Eagle {
 
             // show graph modal
             Utils.showErrorsModal("Check Graph", this.graphErrors(), this.graphWarnings());
-
-            //set fixed height for this use of the shared modal to prevent it collapsing when collapsing a section within
-            $("#errorsModalAccordion").parent().parent().css("height","70vh")
         } else {
             Utils.showNotification("Check Graph", "Graph OK", "success");
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1485,6 +1485,16 @@ export class Node {
             for (const fieldData of nodeData.fields){
                 const field = Field.fromOJSJson(fieldData);
                 field.setFieldType(Eagle.FieldType.ComponentParameter);
+
+                // we should support comment and description nodes, these need to use one component parameter, even though they don't officially support them
+                const isCommentOrDescriptionContentField : boolean = (category === Eagle.Category.Description || category === Eagle.Category.Comment) && field.getIdText() === "";
+
+                // check
+                if (!node.canHaveComponentParameters() && !isCommentOrDescriptionContentField){
+                    errorsWarnings.warnings.push("Node '" + node.getName() + "' (category: " + category + ") should not have any component parameters. Removed " + field.getDisplayText());
+                    continue;
+                }
+
                 node.addField(field);
             }
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1494,6 +1494,13 @@ export class Node {
             for (const paramData of nodeData.applicationArgs){
                 const field = Field.fromOJSJson(paramData);
                 field.setFieldType(Eagle.FieldType.ApplicationArgument);
+
+                // check
+                if (!node.canHaveApplicationArguments()){
+                    errorsWarnings.warnings.push("Node '" + node.getName() + "' (category: " + category + ") should not have any application arguments. Removed " + field.getDisplayText());
+                    continue;
+                }
+
                 node.addApplicationArg(field);
             }
         }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1425,6 +1425,20 @@ export class Utils {
                     }
                 }
             }
+
+            for (const appArg0 of node.getApplicationArgs()){
+                for (const appArg1 of node.getApplicationArgs()){
+                    if (appArg0.getId() === appArg1.getId()){
+                        continue;
+                    }
+
+                    // check for two application arguments with the same idText, not allowed unless
+                    // - one is a input and one is an output
+                    if (appArg0.getIdText() === appArg1.getIdText() && (appArg0.getFieldType() === appArg1.getFieldType() || appArg0.getFieldType() === Eagle.FieldType.ApplicationArgument || appArg1.getFieldType() === Eagle.FieldType.ApplicationArgument)){
+                        errors.push("Node " + node.getKey() + " (" + node.getName() + ") has multiple application arguments with the same idText (" + appArg0.getIdText() + ").");
+                    }
+                }
+            }
         }
 
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -443,6 +443,26 @@ export class Utils {
         }
     }
 
+    static showErrorsModal(title: string, errors: string[], warnings: string[]){
+        console.log("showErrorsModal() errors:", errors.length, "warnings:", warnings.length);
+
+        $('#errorsModalTitle').text(title);
+
+        // hide whole errors or warnings sections if none are found
+        $('#errorsModalErrorsAccordionItem').toggle(errors.length > 0);
+        $('#errorsModalWarningsAccordionItem').toggle(warnings.length > 0);
+
+        // set count of errors and warnings
+        $('#errorsModalErrorCount').html('[' + errors.length.toString() + ']');
+        $('#errorsModalWarningCount').html('[' + warnings.length.toString() + ']');
+
+        // add error and warning text to those sections
+        $('#errorsModalErrorsAccordionBody').html(errors.join('<br/>'));
+        $('#errorsModalWarningsAccordionBody').html(warnings.join('<br/>'));
+
+        $('#errorsModal').modal("toggle");
+    }
+
     static showNotification(title : string, message : string, type : "success" | "info" | "warning" | "danger") : void {
         $.notify({
             title:title + ":",

--- a/static/base.css
+++ b/static/base.css
@@ -776,29 +776,29 @@ select.form-control{
     border: 1px solid #c2c8dc;
 }
 
-#checkGraphAccordion .accordion-button{
+#errorsModalAccordion .accordion-button{
     color: white;
     background-color: #4a6b8f;
 }
 
-#checkGraphAccordion .accordion-button::after{
+#errorsModalAccordion .accordion-button::after{
     background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>") !important;
 }
 
-#checkGraphAccordion .accordion-button:focus{
+#errorsModalAccordion .accordion-button:focus{
     border-color: transparent;
     box-shadow: none !important;
 }
 
-#checkGraphAccordion .accordion-item{
+#errorsModalAccordion .accordion-item{
     margin-bottom: 10px;
 }
 
-#graphErrorRed{
+#errorsModalErrorCount{
     color: #dc3545;
 }
 
-#graphErrorYellow{
+#errorsModalWarningCount{
     color: #ffc107;
 }
 

--- a/static/base.css
+++ b/static/base.css
@@ -802,6 +802,10 @@ select.form-control{
     color: #ffc107;
 }
 
+#errorsModal .modal-content{
+    height: 70vh;
+}
+
 #resetSettingsDefaults{
     left: 10px;
     position: absolute;

--- a/static/components/field.html
+++ b/static/components/field.html
@@ -42,7 +42,7 @@
 
     <!-- ko ifnot: $root.selectedNode().isLocked() -->
     <div class="input-group-append">
-        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.selectedNode().removeParamByIndex($data.fieldType(), $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, attr: {id: 'nodeInspectorRemoveField' + $index()}, eagleTooltip:'Remove parameter'" data-bs-placement="left">
+        <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.removeParamFromNodeByIndex($root.selectedNode(), $data.fieldType(), $index());}, attr: {id: 'nodeInspectorRemoveField' + $index()}, eagleTooltip:'Remove parameter'" data-bs-placement="left">
             <i class="material-icons md-18">delete</i>
         </button>
     </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -643,7 +643,7 @@
                                     <td>
                                         <button class="resetDefaults" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$data.resetToDefault();$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), eagleTooltip:'Reset To Default'"><i class="material-icons">upload_file</i></button>
                                         <button class="duplicate" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.duplicateParameter($index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Duplicate'"><i class="material-icons">content_copy</i></button>
-                                        <button class="delete" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.selectedNode().removeParamByIndex($data.fieldType(), $index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
+                                        <button class="delete" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.removeParamFromNodeByIndex($root.selectedNode(), $data.fieldType(), $index());}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
                                     </td>
                                 </tr>
                                 <!-- /ko -->

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -16,6 +16,48 @@
     </div>
 </div>
 
+<!-- Errors Modal -->
+<div class="modal fade" id="errorsModal" tabindex="-1" role="dialog" aria-labelledby="errorsModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="errorsModalTitle">Title</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class='accordion' id='errorsModalAccordion'>
+
+                    <div class="accordion-item" id="errorsModalErrorsAccordionItem">
+                        <h2 class="accordion-header" id="checkGraphAccordionHeadingOne">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors&nbsp;<span id="errorsModalErrorCount"></span></button>
+                        </h2>
+                        <div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">
+                            <div class="accordion-body" id="errorsModalErrorsAccordionBody">
+                                message += this.graphErrors().join('<br/>')
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="accordion-item" id="errorsModalWarningsAccordionItem">
+                        <h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings&nbsp;<span id="errorsModalWarningCount"></span></button>
+                        </h2>
+                        <div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">
+                            <div class="accordion-body" id="errorsModalWarningsAccordionBody">
+                                message += this.graphWarnings().join('<br/>')
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Request User Input Modal -->
 <div class="modal fade" id="inputModal" tabindex="-1" role="dialog" aria-labelledby="inputModalTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">


### PR DESCRIPTION
A few different issues in one PR.

- I wanted to re-use the checkGraph modal for use during file loading, to display errors and warnings. The existing checkGraph modal actually re-used the "messageModal", so I split it out into it's own modal, the "errorsModal". And added a function Utils.showErrorsModal(), that can be used to launch it.
- All the different ways of loading graphs and palettes, from file, from JSON, from git, all used similar 5-10 lines of code to show the errors during loading. So I combined that into one function _handleLoadingErrors(), and re-use it everywhere. The value of the "show errors during loading" setting can be looked-up in one place, instead of lots of different places and passed down through many function calls
- I made deleting params from nodes use a function on Eagle, instead of on the Node, so that we can undo, and we can flag the graph as modified, and we can trigger checkGraph to re-run.
- I also added a bit to the Node loading code, so check for component parameters or application arguments being added to nodes that shouldn't have them. If one is found, a warning is generated during loading.

I mostly wanted you to check that I had moved the accordion html over to the new modal correctly, and that the CSS was all still applied. The modal does seem to collapse when both the errors and warnings are collapsed.