### PR TITLE
Eagle 775

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2453,18 +2453,17 @@ export class Eagle {
     }
 
     getCurrentParamReadonly = (index: number) : boolean => {
-
         if(Eagle.selectedLocation() === Eagle.FileType.Palette){
             if(Eagle.allowPaletteEditing()){
                 return false;
             }else{
-                return this.selectedNode().getFieldReadonly(index);
+                return this.selectedNode().getFields()[index].isReadonly();
             }
         }else{
             if(Eagle.allowComponentEditing()){
                 return false;
             }else{
-                return this.selectedNode().getFieldReadonly(index);
+                return this.selectedNode().getFields()[index].isReadonly();
             }
         }
     }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2548,22 +2548,6 @@ export class Eagle {
         return options
     }
 
-    fillFieldTypeCell = (fieldType:Eagle.FieldType):string => {
-        var options:string = "";
-
-        const allowedTypes = [Eagle.FieldType.ApplicationArgument, Eagle.FieldType.InputPort, Eagle.FieldType.OutputPort];
-
-        for (let dataType of allowedTypes){
-            var selected=""
-            if(fieldType === dataType){
-                selected = "selected=true"
-            }
-            options = options + "<option value="+dataType+"  "+selected+">"+dataType+"</option>";
-        }
-
-        return options
-    }
-
     static findSettingValue = (key : string) : any => {
         const setting = Eagle.findSetting(key);
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1191,7 +1191,16 @@ export class Eagle {
     }
 
     displayLogicalGraphAsJson = () : void => {
-        const jsonString: string = JSON.stringify(LogicalGraph.toOJSJson(this.logicalGraph(), false));
+        const cloneLG: LogicalGraph = this.logicalGraph().clone();
+
+        // zero-out some info that isn't useful for comparison
+        cloneLG.fileInfo().sha = "";
+        cloneLG.fileInfo().gitUrl = "";
+        cloneLG.fileInfo().lastModifiedName = "";
+        cloneLG.fileInfo().lastModifiedEmail = "";
+        cloneLG.fileInfo().lastModifiedDatetime = 0;
+
+        const jsonString: string = JSON.stringify(LogicalGraph.toOJSJson(cloneLG, false), null, 4);
 
         Utils.requestUserText("Export Graph to JSON", "", jsonString, (completed: boolean, userText: string): void => {});
     }
@@ -4024,7 +4033,7 @@ export class Eagle {
             $("#customParameterOptionsWrapper").hide();
 
             // create a field variable to serve as temporary field when "editing" the information. If the add field modal is completed the actual field component parameter is created.
-            const field: Field = new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Integer, false, [], false);
+            const field: Field = new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Integer, false, [], false, Eagle.FieldType.ComponentParameter);
 
             Utils.requestUserEditField(this, Eagle.ModalType.Add, fieldType, field, allFieldNames, (completed : boolean, newField: Field) => {
                 // abort if the user aborted
@@ -4385,6 +4394,10 @@ export class Eagle {
         Utils.showNotification("Graph URL", "Copied to clipboard", "success");
     }
 
+    copyInputTextModalInput = (): void => {
+        navigator.clipboard.writeText($('#inputTextModalInput').val().toString());
+    }
+
     checkGraph = (): void => {
         const checkResult = Utils.checkGraph(this.logicalGraph());
 
@@ -4468,13 +4481,11 @@ export class Eagle {
             let newOutputPort = newNode.findPortByIdText(destPort.getIdText(), false, false);
 
             if (!newInputPort){
-                newInputPort = new Field(Utils.uuidv4(), srcPort.getDisplayText(), srcPort.getIdText(), "", "", "", false, srcPort.getType(), false, [], false);
-                newInputPort.setFieldType(Eagle.FieldType.InputPort);
+                newInputPort = new Field(Utils.uuidv4(), srcPort.getDisplayText(), srcPort.getIdText(), "", "", "", false, srcPort.getType(), false, [], false, Eagle.FieldType.InputPort);
                 newNode.addField(newInputPort);
             }
             if (!newOutputPort){
-                newOutputPort = new Field(Utils.uuidv4(), destPort.getDisplayText(), destPort.getIdText(), "", "", "", false, destPort.getType(), false, [], false);
-                newOutputPort.setFieldType(Eagle.FieldType.OutputPort);
+                newOutputPort = new Field(Utils.uuidv4(), destPort.getDisplayText(), destPort.getIdText(), "", "", "", false, destPort.getType(), false, [], false, Eagle.FieldType.OutputPort);
                 newNode.addField(newOutputPort);
             }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -66,7 +66,6 @@ export class Eagle {
     selectedObjects : ko.ObservableArray<Node|Edge>;
     static selectedLocation : ko.Observable<Eagle.FileType>;
 
-    static parameterTableType : ko.Observable<Eagle.FieldType>;
     static parameterTableSelectionParent : ko.Observable<Field>; // row in the parameter table that is currently selected
     static parameterTableSelectionParentIndex : ko.Observable<number> // id of the selected field
     static parameterTableSelection : ko.Observable<string>; // cell in the parameter table that is currently selected
@@ -217,8 +216,7 @@ export class Eagle {
         Eagle.shortcuts.push(new KeyboardShortcut("open_help", "Open help", ["h"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.onlineDocs();}));
         Eagle.shortcuts.push(new KeyboardShortcut("open_keyboard_shortcut_modal", "Open Keyboard Shortcut Modal", ["k"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.openShortcuts();}));
         Eagle.shortcuts.push(new KeyboardShortcut("close_keyboard_shortcut_modal", "Close Keyboard Shortcut Modal", ["k"], "keyup", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Disabled, KeyboardShortcut.true, (eagle): void => {eagle.openShortcuts();}));
-        Eagle.shortcuts.push(new KeyboardShortcut("open_component_parameter_table_modal", "Open Component Parameter Table Modal", ["t"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.openParamsTableModal(Eagle.FieldType.ComponentParameter);}));
-        Eagle.shortcuts.push(new KeyboardShortcut("open_application_argument_table_modal", "Open Application Argument Table Modal", ["t"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.openParamsTableModal(Eagle.FieldType.ApplicationArgument);}));
+        Eagle.shortcuts.push(new KeyboardShortcut("open_component_parameter_table_modal", "Open Component Parameter Table Modal", ["t"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.openParamsTableModal();}));
         Eagle.shortcuts.push(new KeyboardShortcut("undo", "Undo", ["z"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.undo().prevSnapshot(eagle)}));
         Eagle.shortcuts.push(new KeyboardShortcut("redo", "Redo", ["z"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.undo().nextSnapshot(eagle)}));
         Eagle.shortcuts.push(new KeyboardShortcut("check_graph", "Check Graph", ["!"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.graphNotEmpty, (eagle): void => {eagle.showGraphErrors();}));
@@ -233,7 +231,6 @@ export class Eagle {
         this.globalOffsetY = 0;
         this.globalScale = 1.0;
 
-        Eagle.parameterTableType = ko.observable(Eagle.FieldType.Unknown);
         Eagle.parameterTableSelectionParent = ko.observable(null);
         Eagle.parameterTableSelectionParentIndex = ko.observable(-1);
         Eagle.parameterTableSelection = ko.observable(null);
@@ -2447,78 +2444,27 @@ export class Eagle {
         Utils.showSettingsModal();
     }
 
-    openParamsTableModal = (tableType:Eagle.FieldType) : void => {
-        Eagle.parameterTableType(tableType)
+    openParamsTableModal = () : void => {
         if (!this.selectedNode()){
             Utils.showNotification("Error", "No Node Is Selected", "warning");
         }else{
-            if (tableType === Eagle.FieldType.ComponentParameter){
-                if (!this.selectedNode().canHaveComponentParameters()){
-                    Utils.showNotification("Error", "This node cannot have component parameters", "warning");
-                    return
-                }
-            }else{
-                if (!this.selectedNode().canHaveApplicationArguments()){
-                    Utils.showNotification("Error", "This node cannot have application arguments", "warning");
-                    return
-                }
-            }
             Utils.showOpenParamsTableModal();
         }
     }
 
-    getParamsTableModalTitleText = () : string => {
-        if (Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-            return "Component Parameter Table"
-        }else{
-            return "Application Argument Table"
-        }
-    }
-
-    getParamsTableModalButtonText = () : string => {
-        if (Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-            return "Add Parameter"
-        }else{
-            return "Add Argument"
-        }
-    }
-
-    currentParamsArray : ko.PureComputed<Field[]> = ko.pureComputed(() => {
-        if (this.selectedNode() === null){
-            return [];
-        }
-
-        if (Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-            return this.selectedNode().getFields()
-        }else{
-            return this.selectedNode().getApplicationArgs()
-        }
-    })
-
-    getCurrentParamReadonly = (index: number, type:Eagle.FieldType) : boolean => {
-        if (type === Eagle.FieldType.Unknown){
-            type = Eagle.parameterTableType()
-        }
+    getCurrentParamReadonly = (index: number) : boolean => {
 
         if(Eagle.selectedLocation() === Eagle.FileType.Palette){
             if(Eagle.allowPaletteEditing()){
-                    return false;
+                return false;
             }else{
-                if (type === Eagle.FieldType.ComponentParameter){
-                    return this.selectedNode().getFieldReadonly(index);
-                }else{
-                    return this.selectedNode().getApplicationParamReadonly(index);
-                }
+                return this.selectedNode().getFieldReadonly(index);
             }
         }else{
             if(Eagle.allowComponentEditing()){
-                return false
+                return false;
             }else{
-                if (type === Eagle.FieldType.ComponentParameter){
-                    return this.selectedNode().getFieldReadonly(index);
-                }else{
-                    return this.selectedNode().getApplicationParamReadonly(index);
-                }
+                return this.selectedNode().getFieldReadonly(index);
             }
         }
     }
@@ -3354,42 +3300,29 @@ export class Eagle {
     addEmptyTableRow = () : void => {
         var fieldIndex:number
 
-            if(Eagle.parameterTableSelectionParentIndex() != -1){
-                // A cell in the table is selected well insert new row instead of adding at the end
-                    fieldIndex = Eagle.parameterTableSelectionParentIndex()+1
-                    if(Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-                        //component table
-                        this.selectedNode().addEmptyField(fieldIndex)
-                    }else{
-                        //argument table
-                        this.selectedNode().addEmptyArg(fieldIndex)
-                    }
-                }else{
-                //no cell selected, add new row at the end
-                    if(Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-                        //component table
-                        this.selectedNode().addEmptyField(-1)
-                    }else{
-                        //argument table
-                        this.selectedNode().addEmptyArg(-1)
-                    }
-                    //getting the length of the array to use as an index to select the last row in the table
-                    fieldIndex = this.currentParamsArray().length-1
-                }
+        if(Eagle.parameterTableSelectionParentIndex() != -1){
+            // A cell in the table is selected well insert new row instead of adding at the end
+            fieldIndex = Eagle.parameterTableSelectionParentIndex()+1
+            this.selectedNode().addEmptyField(fieldIndex)
+        }else{
+            this.selectedNode().addEmptyField(-1)
 
-                //a timeout was necessary to wait for the element to be added before counting how many there are
-                setTimeout(function() {
-                    //handling selecting and highlighting the newly created row
-                    let clickTarget = $("#paramsTableWrapper tbody").children()[fieldIndex].firstElementChild.firstElementChild as HTMLElement
+            //getting the length of the array to use as an index to select the last row in the table
+            fieldIndex = this.selectedNode().getFields().length-1;
+        }
 
-                    clickTarget.click() //simply clicking the element is best as it also lets knockout handle all of the selection and obsrevable update processes
+        //a timeout was necessary to wait for the element to be added before counting how many there are
+        setTimeout(function() {
+            //handling selecting and highlighting the newly created row
+            let clickTarget = $("#paramsTableWrapper tbody").children()[fieldIndex].firstElementChild.firstElementChild as HTMLElement
 
-                    //scroll to new row
-                    $("#parameterTableModal .modal-content").animate({
-                        scrollTop: (fieldIndex*30)
-                      }, 1000);
-                }, 100);
+            clickTarget.click() //simply clicking the element is best as it also lets knockout handle all of the selection and obsrevable update processes
 
+            //scroll to new row
+            $("#parameterTableModal .modal-content").animate({
+                scrollTop: (fieldIndex*30)
+            }, 1000);
+        }, 100);
     }
 
     nodeInspectorDropdownClick = (val:number, num:number, divID:string) : void => {
@@ -3539,13 +3472,13 @@ export class Eagle {
         });
     }
 
-    removeParamFromNodeByIndex = (node: Node, fieldType: Eagle.FieldType, index: number) : void => {
+    removeParamFromNodeByIndex = (node: Node, index: number) : void => {
         if (node === null){
             console.warn("Could not remove param from null node");
             return;
         }
 
-        node.removeParamByIndex(fieldType, index);
+        node.removeFieldByIndex(index);
 
         this.checkGraph();
         this.undo().pushSnapshot(this, "Remove param from node");
@@ -4122,20 +4055,13 @@ export class Eagle {
                 if (choice === choices.length){
                     newField.setFieldType(fieldType);
 
-                   //create field from user input in modal
-                   if (fieldType === Eagle.FieldType.ComponentParameter){
-                       node.addField(newField);
-                   } else {
-                       node.addApplicationArg(newField);
-                   }
+                    //create field from user input in modal
+                    node.addField(newField);
+
                 } else {
-                   const clone : Field = allFields[choice].clone();
-                   clone.setFieldType(fieldType);
-                   if (fieldType === Eagle.FieldType.ComponentParameter){
-                       node.addField(clone);
-                   } else {
-                       node.addApplicationArg(clone);
-                   }
+                    const clone : Field = allFields[choice].clone();
+                    clone.setFieldType(fieldType);
+                    node.addField(clone);
                 }
 
                 this.checkGraph();
@@ -4149,11 +4075,11 @@ export class Eagle {
             switch (fieldType){
             case Eagle.FieldType.ComponentParameter:
                 $("#editFieldModalTitle").html("Edit Component Parameter");
-                field = this.selectedNode().getFields()[fieldIndex];
+                field = this.selectedNode().getComponentParameters()[fieldIndex];
                 break;
             case Eagle.FieldType.ApplicationArgument:
                 $("#editFieldModalTitle").html("Edit Application Argument");
-                field = this.selectedNode().getApplicationArgs()[fieldIndex];
+                field = this.selectedNode().getApplicationArguments()[fieldIndex];
                 break;
             case Eagle.FieldType.InputPort:
                 $("#editFieldModalTitle").html("Edit Input Port");
@@ -4201,36 +4127,23 @@ export class Eagle {
     duplicateParameter = (index:number) :void => {
         var fieldIndex:number //variable holds the index of which row to highlight after creation
         if(Eagle.parameterTableSelectionParentIndex() != -1){
-        //if a cell in the table is selected in this case the new node will be placed below the currently selected node
+            //if a cell in the table is selected in this case the new node will be placed below the currently selected node
             fieldIndex = Eagle.parameterTableSelectionParentIndex()+1
-            if (Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-            //for component parameter tables
-                this.selectedNode().addFieldAtPosition(this.selectedNode().getFields()[index].clone(),fieldIndex)
-            }else{
-            //for application parameter tables
-                this.selectedNode().addApplicationArgAtPosition(this.selectedNode().getApplicationArgs()[index].clone(),fieldIndex)
-            }
+            this.selectedNode().addFieldAtPosition(this.selectedNode().getFields()[index].clone(),fieldIndex)
         }else{
-        //if no call in the table is selected, in this case the new node is appended
-            if (Eagle.parameterTableType() === Eagle.FieldType.ComponentParameter){
-            //for component parameter tables
-                this.selectedNode().addField(this.selectedNode().getFields()[index].clone())
-            }else{
-            //for application parameter tables
-                this.selectedNode().addApplicationArg(this.selectedNode().getApplicationArgs()[index].clone())
-            }
+            //if no call in the table is selected, in this case the new node is appended
+            this.selectedNode().addField(this.selectedNode().getFields()[index].clone())
             fieldIndex = this.selectedNode().getFields().length -1
         }
 
         setTimeout(function() {
             //handling selecting and highlighting the newly created node
-        let clickTarget = $("#paramsTableWrapper tbody").children()[fieldIndex].firstElementChild.firstElementChild as HTMLElement
-        clickTarget.click() //simply clicking the element is best as it also lets knockout handle all of the selection and obsrevable update process
-        $("#parameterTableModal .modal-content").animate({
-            scrollTop: (fieldIndex*30)
-          }, 1000);
+            let clickTarget = $("#paramsTableWrapper tbody").children()[fieldIndex].firstElementChild.firstElementChild as HTMLElement
+            clickTarget.click() //simply clicking the element is best as it also lets knockout handle all of the selection and obsrevable update process
+            $("#parameterTableModal .modal-content").animate({
+                scrollTop: (fieldIndex*30)
+            }, 1000);
         }, 100);
-
     }
 
     explorePalettesClickHelper = (data: PaletteInfo, event:any): void => {
@@ -4567,12 +4480,12 @@ export class Eagle {
             if (!newInputPort){
                 newInputPort = new Field(Utils.uuidv4(), srcPort.getDisplayText(), srcPort.getIdText(), "", "", "", false, srcPort.getType(), false, [], false);
                 newInputPort.setFieldType(Eagle.FieldType.InputPort);
-                newNode.addApplicationArg(newInputPort);
+                newNode.addField(newInputPort);
             }
             if (!newOutputPort){
                 newOutputPort = new Field(Utils.uuidv4(), destPort.getDisplayText(), destPort.getIdText(), "", "", "", false, destPort.getType(), false, [], false);
                 newOutputPort.setFieldType(Eagle.FieldType.OutputPort);
-                newNode.addApplicationArg(newOutputPort);
+                newNode.addField(newOutputPort);
             }
 
             // set the parent of the new node
@@ -4630,13 +4543,13 @@ export class Eagle {
             const categoryData = Eagle.getCategoryData(categories[userChoiceIndex]);
 
             // delete parameters, if necessary
-            if (this.selectedNode().getFields().length > 0 && !categoryData.canHaveComponentParameters){
-                this.selectedNode().removeAllFields();
+            if (this.selectedNode().getComponentParameters().length > 0 && !categoryData.canHaveComponentParameters){
+                this.selectedNode().removeAllComponentParameters();
             }
 
             // delete application args, if necessary
-            if (this.selectedNode().getApplicationArgs().length > 0 && !categoryData.canHaveApplicationArguments){
-                this.selectedNode().removeAllApplicationArgs();
+            if (this.selectedNode().getApplicationArguments().length > 0 && !categoryData.canHaveApplicationArguments){
+                this.selectedNode().removeAllApplicationArguments();
             }
 
             // delete extra input ports
@@ -4702,7 +4615,7 @@ export class Eagle {
                 newNode.setName(node.getName());
 
                 // Remove the redundant input port
-                newNode.removeApplicationArgByIndex(0);
+                newNode.removeAllInputPorts();
 
                 // flag that the logical graph has been modified
                 this.logicalGraph().fileInfo().modified = true;

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -22,7 +22,7 @@ export class Field {
     private isEvent : ko.Observable<boolean>;
     private nodeKey : ko.Observable<number>;
 
-    constructor(id: string, displayText: string, idText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: Eagle.DataType, precious: boolean, options: string[], positional: boolean){
+    constructor(id: string, displayText: string, idText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: Eagle.DataType, precious: boolean, options: string[], positional: boolean, fieldType: Eagle.FieldType){
         this.displayText = ko.observable(displayText);
         this.idText = ko.observable(idText);
         this.value = ko.observable(value);
@@ -35,7 +35,7 @@ export class Field {
         this.positional = ko.observable(positional);
 
         this.id = ko.observable(id);
-        this.fieldType = ko.observable(Eagle.FieldType.ComponentParameter);
+        this.fieldType = ko.observable(fieldType);
         this.isEvent = ko.observable(false);
         this.nodeKey = ko.observable(0);
     }
@@ -174,7 +174,7 @@ export class Field {
     }
 
     clone = () : Field => {
-        const f = new Field(this.id(), this.displayText(), this.idText(), this.value(), this.defaultValue(), this.description(), this.readonly(), this.type(), this.precious(), this.options(), this.positional());
+        const f = new Field(this.id(), this.displayText(), this.idText(), this.value(), this.defaultValue(), this.description(), this.readonly(), this.type(), this.precious(), this.options(), this.positional(), this.fieldType());
         f.setIsEvent(this.isEvent());
         f.setFieldType(this.fieldType());
         return f;
@@ -307,6 +307,7 @@ export class Field {
         let precious: boolean = false;
         let options: string[] = [];
         let positional: boolean = false;
+        let fieldType: Eagle.FieldType = Eagle.FieldType.Unknown;
 
         if (typeof data.id !== 'undefined')
             id = data.id;
@@ -322,8 +323,8 @@ export class Field {
             type = data.type;
         if (typeof data.value !== 'undefined' && data.value !== null)
             value = data.value.toString();
-        if (typeof data.default !== 'undefined' && data.default !== null)
-            defaultValue = data.default.toString();
+        if (typeof data.defaultValue !== 'undefined' && data.defaultValue !== null)
+            defaultValue = data.defaultValue.toString();
         if (typeof data.precious !== 'undefined')
             precious = data.precious;
         if (typeof data.options !== 'undefined')
@@ -331,7 +332,7 @@ export class Field {
         if (typeof data.positional !== 'undefined')
             positional = data.positional;
 
-        return new Field(id, text, name, value, defaultValue, description, readonly, type, precious, options, positional);
+        return new Field(id, text, name, value, defaultValue, description, readonly, type, precious, options, positional, fieldType);
     }
 
     public static sortFunc = (a: Field, b: Field) : number => {
@@ -381,7 +382,7 @@ export class Field {
             text = data.IdText;
         }
 
-        const f = new Field(data.Id, text, data.IdText, "", "", description, false, type, false, [], false);
+        const f = new Field(data.Id, text, data.IdText, "", "", description, false, type, false, [], false, Eagle.FieldType.Unknown);
         f.setIsEvent(event);
         return f;
     }

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -314,16 +314,15 @@ export class Modals {
 
             switch(realType){
                 case Eagle.DataType.Boolean:
-                    newField = new Field(id, displayText, idText, valueCheckbox.toString(), defaultValueCheckbox.toString(), description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueCheckbox.toString(), defaultValueCheckbox.toString(), description, readonly, realType, precious, options, positional, realFieldType);
                     break;
                 case Eagle.DataType.Select:
-                    newField = new Field(id, displayText, idText, valueSelect, defaultValueSelect, description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueSelect, defaultValueSelect, description, readonly, realType, precious, options, positional, realFieldType);
                     break;
                 default:
-                    newField = new Field(id, displayText, idText, valueText, defaultValueText, description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueText, defaultValueText, description, readonly, realType, precious, options, positional, realFieldType);
                     break;
             }
-            newField.setFieldType(realFieldType);
 
             callback(true, newField);
         });

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -950,7 +950,7 @@ export class Node {
 
     setGroupStart = (value: boolean) => {
         if (!this.hasFieldWithIdText("group_start")){
-            this.addField(new Field(Utils.uuidv4(), "Group Start", "group_start", value.toString(), "false", "Is this node the start of a group?", false, Eagle.DataType.Boolean, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "Group Start", "group_start", value.toString(), "false", "Is this node the start of a group?", false, Eagle.DataType.Boolean, false, [], false, Eagle.FieldType.ComponentParameter));
         } else {
             this.getFieldByIdText("group_start").setValue(value.toString());
         }
@@ -958,7 +958,7 @@ export class Node {
 
     setGroupEnd = (value: boolean) => {
         if (!this.hasFieldWithIdText("group_end")){
-            this.addField(new Field(Utils.uuidv4(), "Group End", "group_end", value.toString(), "false", "Is this node the end of a group?", false, Eagle.DataType.Boolean, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "Group End", "group_end", value.toString(), "false", "Is this node the end of a group?", false, Eagle.DataType.Boolean, false, [], false, Eagle.FieldType.ComponentParameter));
         } else {
             this.getFieldByIdText("group_end").setValue(value.toString());
         }
@@ -1176,14 +1176,14 @@ export class Node {
 
         // if no fields exist, create at least one, to store the custom data
         if (this.fields().length === 0){
-            this.addField(new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Unknown, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Unknown, false, [], false, Eagle.FieldType.ComponentParameter));
         }
 
         this.fields()[0].setValue(e.value);
     }
 
     addEmptyField = (index:number) :void => {
-        var newField = new Field(Utils.uuidv4(), "New Parameter", "", "", "", "", false, Eagle.DataType.String, false, [], false)
+        var newField = new Field(Utils.uuidv4(), "New Parameter", "", "", "", "", false, Eagle.DataType.String, false, [], false, Eagle.FieldType.ComponentParameter)
         if(index === -1){
             this.addField(newField);
         }else{
@@ -1485,7 +1485,7 @@ export class Node {
         if (typeof nodeData.fields !== 'undefined'){
             for (const fieldData of nodeData.fields){
                 const field = Field.fromOJSJson(fieldData);
-                //field.setFieldType(Eagle.FieldType.ComponentParameter);
+                field.setFieldType(Eagle.FieldType.ComponentParameter);
 
                 // we should support comment and description nodes, these need to use one component parameter, even though they don't officially support them
                 const isCommentOrDescriptionContentField : boolean = (category === Eagle.Category.Description || category === Eagle.Category.Comment) && field.getIdText() === "";
@@ -1504,7 +1504,7 @@ export class Node {
         if (typeof nodeData.applicationArgs !== 'undefined'){
             for (const paramData of nodeData.applicationArgs){
                 const field = Field.fromOJSJson(paramData);
-                //field.setFieldType(Eagle.FieldType.ApplicationArgument);
+                field.setFieldType(Eagle.FieldType.ApplicationArgument);
 
                 // check
                 if (!node.canHaveFieldType(field.getFieldType())){
@@ -1725,7 +1725,17 @@ export class Node {
         // add fields
         result.fields = [];
         for (const field of node.fields()){
-            result.fields.push(Field.toOJSJson(field));
+            if (field.getFieldType() === Eagle.FieldType.ComponentParameter){
+                result.fields.push(Field.toOJSJson(field));
+            }
+        }
+
+        // add applicationArgs
+        result.applicationArgs = [];
+        for (const field of node.fields()){
+            if (field.getFieldType() === Eagle.FieldType.ApplicationArgument){
+                result.applicationArgs.push(Field.toOJSJson(field));
+            }
         }
 
         // add fields from inputApplication
@@ -1841,7 +1851,17 @@ export class Node {
         // add fields
         result.fields = [];
         for (const field of node.fields()){
-            result.fields.push(Field.toOJSJson(field));
+            if (field.getFieldType() === Eagle.FieldType.ComponentParameter){
+                result.fields.push(Field.toOJSJson(field));
+            }
+        }
+
+        // add applicationArgs
+        result.applicationArgs = [];
+        for (const field of node.fields()){
+            if (field.getFieldType() === Eagle.FieldType.ApplicationArgument){
+                result.applicationArgs.push(Field.toOJSJson(field));
+            }
         }
 
         // add fields from inputApplication

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -467,29 +467,6 @@ export class Node {
         return !allowParam;
     }
 
-    getFieldReadonly = (index: number) : boolean => {
-        console.assert(index < this.fields().length);
-
-        const field: Field = this.fields()[index];
-
-        // modify using settings and node readonly
-
-        //looking at the readonly state of the component parameters and the allow read only parameter editing setting
-        return (field.isReadonly());
-    }
-
-    getComponentParameterReadonly = (index: number) : boolean => {
-        console.assert(index < this.getComponentParameters().length);
-
-        return this.getComponentParameters()[index].isReadonly();
-    }
-
-    getApplicationArgumentReadonly = (index: number) : boolean => {
-        console.assert(index < this.getApplicationArguments().length);
-
-        return this.getApplicationArguments()[index].isReadonly();
-    }
-
     getCategory = () : Eagle.Category => {
         return this.category();
     }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -478,6 +478,12 @@ export class Node {
         return (field.isReadonly());
     }
 
+    getComponentParameterReadonly = (index: number) : boolean => {
+        console.assert(index < this.getComponentParameters().length);
+
+        return this.getComponentParameters()[index].isReadonly();
+    }
+
     getApplicationArgumentReadonly = (index: number) : boolean => {
         console.assert(index < this.getApplicationArguments().length);
 
@@ -1218,6 +1224,35 @@ export class Node {
 
     setExpanded = (value : boolean) : void => {
         this.expanded(value);
+    }
+
+    fillFieldTypeCell = (fieldType: Eagle.FieldType):string => {
+        var options:string = "";
+
+        const allowedTypes: Eagle.FieldType[] = [];
+
+        if (this.canHaveComponentParameters()){
+            allowedTypes.push(Eagle.FieldType.ComponentParameter);
+        }
+        if (this.canHaveApplicationArguments()){
+            allowedTypes.push(Eagle.FieldType.ApplicationArgument);
+        }
+        if (this.canHaveInputs()){
+            allowedTypes.push(Eagle.FieldType.InputPort);
+        }
+        if (this.canHaveOutputs()){
+            allowedTypes.push(Eagle.FieldType.OutputPort);
+        }
+
+        for (let dataType of allowedTypes){
+            var selected=""
+            if(fieldType === dataType){
+                selected = "selected=true"
+            }
+            options = options + "<option value="+dataType+"  "+selected+">"+dataType+"</option>";
+        }
+
+        return options
     }
 
     static canHaveInputApp = (node : Node) : boolean => {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1183,7 +1183,7 @@ export class Utils {
 
         // build a list from all nodes, add fields into the list
         for (const node of diagram.getNodes()) {
-            for (const param of node.getApplicationArgs()) {
+            for (const param of node.getApplicationArguments()) {
                 Utils._addFieldIfUnique(uniqueapplicationArgs, param.clone());
             }
         }
@@ -1424,43 +1424,13 @@ export class Utils {
             }
         }
 
-        // check that all application params have default values
-        for (const node of graph.getNodes()){
-            for (const field of node.getApplicationArgs()){
-                if (field.getDefaultValue() === "" && field.getType() !== Eagle.DataType.String){
-                    warnings.push("Node " + node.getKey() + " (" + node.getName() + ") has an application parameter (" + field.getIdText() + ") whose default value is not specified");
-                }
-            }
-        }
-
         // check that fields and application parameters don't share the same name
         // NOTE: this code checks many pairs of fields twice
         for (const node of graph.getNodes()){
-            for (const field of node.getFields()){
-                for (const appArg of node.getApplicationArgs()){
-                    if (field.getIdText() == appArg.getIdText()){
-                        warnings.push("Node " + node.getKey() + " (" + node.getName() + ") has a component parameter (" + field.getIdText() + ") that shares the same name as an application argument.");
-                    }
-                }
-            }
-            for (const appArg of node.getApplicationArgs()){
-                for (const field of node.getFields()){
-                    if (appArg.getIdText() === field.getIdText()){
-                        warnings.push("Node " + node.getKey() + " (" + node.getName() + ") has an application argument (" + appArg.getIdText() + ") that shares the same name as a component parameter.");
-                    }
-                }
-            }
-
-            for (const appArg0 of node.getApplicationArgs()){
-                for (const appArg1 of node.getApplicationArgs()){
-                    if (appArg0.getId() === appArg1.getId()){
-                        continue;
-                    }
-
-                    // check for two application arguments with the same idText, not allowed unless
-                    // - one is a input and one is an output
-                    if (appArg0.getIdText() === appArg1.getIdText() && (appArg0.getFieldType() === appArg1.getFieldType() || appArg0.getFieldType() === Eagle.FieldType.ApplicationArgument || appArg1.getFieldType() === Eagle.FieldType.ApplicationArgument)){
-                        errors.push("Node " + node.getKey() + " (" + node.getName() + ") has multiple application arguments with the same idText (" + appArg0.getIdText() + ").");
+            for (const field0 of node.getFields()){
+                for (const field1 of node.getFields()){
+                    if (field0.getId() !== field1.getId() && field0.getIdText() === field1.getIdText() && field0.getFieldType() === field1.getFieldType()){
+                        warnings.push("Node " + node.getKey() + " (" + node.getName() + ") has multiple attributes with the same id text (" + field0.getIdText() + ").");
                     }
                 }
             }
@@ -1514,18 +1484,6 @@ export class Utils {
             if (node.getCategory() === Eagle.Category.Service && node.hasInputApplication() && node.getInputApplication().getOutputPorts().length > 0){
                 errors.push("Node " + node.getKey() + " (" + node.getName() + ") is a Service node, but has an input application with at least one output.");
             }
-
-            // check that for Data nodes, all ports match
-            if (node.isData()){
-                for (const appArg0 of node.getApplicationArgs()){
-                    for (const appArg1 of node.getApplicationArgs()){
-                        if (!Utils.portsMatch(appArg0, appArg1)){
-                            errors.push("Node " + node.getKey() + " (" + node.getName() + ") is a Data node, but contains ports that do not match. Data nodes do not transform data, so input and output ports should match. Port " + appArg0.getDisplayText() + " (" + appArg0.getType() + ") does not match " + appArg1.getDisplayText() + " (" + appArg1.getType() + ").");
-                        }
-                    }
-                }
-            }
-
         }
 
         // check all edges are valid

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -672,7 +672,7 @@
                                         </select>
                                     </td>
                                     <td>
-                                        <select data-bind="html: $root.fillFieldTypeCell($data.fieldType()), value: fieldType, disabled: $root.selectedNode().isLocked()">
+                                        <select data-bind="html: $root.selectedNode().fillFieldTypeCell($data.fieldType()), value: fieldType, disabled: $root.selectedNode().isLocked()">
                                             <!-- options are added dynamically -->
                                         </select>
                                     </td>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -584,7 +584,7 @@
                 <!-- ko if: selectedNode() != null -->
 
             <div class="modal-header" data-bind="click: function(){Eagle.resetParamsTableSelection()}">
-                <h5 class="modal-title" id="parameterTableModalTitle" data-bind="html: $root.getParamsTableModalTitleText()">Component Parameters</h5>
+                <h5 class="modal-title" id="parameterTableModalTitle">Attributes</h5>
                 <!-- ko if: selectedNode().isLocked() -->
                     <button type="button" class="btn btn-secondary btn-sm" data-bind="click: function() { }, clickBubble: false, eagleTooltip: getReadOnlyText">
                         <i class="material-icons md-20">lock</i>
@@ -618,15 +618,13 @@
                             <th id="parameter_table_default_value">Default Value</th>
                             <th id="parameter_table_description">Description</th>
                             <th id="parameter_table_type">Type</th>
-                             <!-- ko if: Eagle.parameterTableType() === Eagle.FieldType.ApplicationArgument -->
-                             <th id="parameter_table_isPort">Use As</th>
-                             <!-- /ko -->
+                            <th id="parameter_table_isPort">Use As</th>
                             <th id="parameter_table_precious" data-bind="eagleTooltip:'Argument never suppressed'" data-bs-placement="top">Precious</th>
                             <th id="parameter_table_positional" data-bind="eagleTooltip:'If checked only the value of this argument will be put on the command line'" data-bs-placement="top">Positional</th>
                             <th id="parameter_table_actions">Actions</th>
                         </tr>
                         </thead>
-                            <tbody data-bind="foreach: $root.currentParamsArray()">
+                            <tbody data-bind="foreach: $root.selectedNode().getFields()">
                             <!-- ko if: $data.fitsTableSearchQuery() -->
                                 <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
                                 <tr>
@@ -673,13 +671,11 @@
                                         <!-- options are added dynamically -->
                                         </select>
                                     </td>
-                                    <!-- ko if: Eagle.parameterTableType() === Eagle.FieldType.ApplicationArgument -->
                                     <td>
                                         <select data-bind="html: $root.fillFieldTypeCell($data.fieldType()), value: fieldType, disabled: $root.selectedNode().isLocked()">
                                             <!-- options are added dynamically -->
                                         </select>
                                     </td>
-                                    <!-- /ko -->
                                     <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: precious, valueUpdate: ['afterkeydown', 'input'], event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
                                     <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: positional, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
                                     <td>
@@ -694,7 +690,7 @@
                     </table>
             </div>
             <div class="modal-footer"  data-bind="click: Eagle.resetParamsTableSelection">
-                <button type="button" class="btn btn-primary" id="parameterTableModalAddParameterButton" data-bind="click: $root.addEmptyTableRow, clickBubble:false, disabled: $root.selectedNode().isLocked(),html: $root.getParamsTableModalButtonText()" ><span id="parameterTableModalAddParameter">Add Parameter</span></button>
+                <button type="button" class="btn btn-primary" id="parameterTableModalAddParameterButton" data-bind="click: $root.addEmptyTableRow, clickBubble:false, disabled: $root.selectedNode().isLocked()" ><span id="parameterTableModalAddParameter">Add Parameter</span></button>
                 <button type="button" class="btn btn-primary" id="parameterTableModalAffirmativeButton" data-bs-dismiss="modal" data-bind="clickBubble:false"><span id="parameterTableModalAffirmativeAnswer">Close</span></button>
             </div>
             <!-- /ko -->

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -105,6 +105,9 @@
                             <div class="input-group mb-3">
                                 <textarea class="form-control" id="inputTextModalInput" rows="10"></textarea>
                             </div>
+                            <button id="copyInputTextModalInput" class="btn btn-secondary" type="button" data-bs-placement="bottom" data-bind="click: copyInputTextModalInput, eagleTooltip: 'Copy Text'">
+                                <i class="material-icons md-18">content_copy</i>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/templates/node_inspector_application_parameters.html
+++ b/templates/node_inspector_application_parameters.html
@@ -4,9 +4,6 @@
         <i class="material-icons">settings_applications</i>
         <span class="nodeInspectorSubsectionTitle" data-bind="eagleTooltip:'Parameters which are passed on to the payload application of this component at runtime.'">Application Arguments</span>
     </h5>
-    <button class="btn btn-secondary btn-sm openParamsTableBtn" data-bind=" click: function(data, event){openParamsTableModal(Eagle.FieldType.ApplicationArgument)}, clickBubble: false, eagleTooltip: 'Open Application Arguments in Table ' + Utils.getKeyboardShortcutTextByKey('open_application_argument_table_modal', true)">
-        <i class="material-icons md-18">table_chart</i>
-    </button>
     <div class="collapse nodeInspectorCollapseAll" id="nodeCategoryCollapse11">
         <div class="card-body" >
             <div class="searchBarContainer">
@@ -16,11 +13,9 @@
                 </a>
                 <input class="componentSearchBar" type="text" placeholder="Search" data-bind="valueUpdate: ['afterkeydown', 'input'], value:Eagle.applicationArgsSearchString, event:{keyup: function(data,event){$root.setSearchBarClearBtnState(data,event)}} "></input>
             </div>
-            <!-- ko foreach: selectedNode().getApplicationArgs() -->
-                <!-- ko if: $data.getFieldType() === Eagle.FieldType.ApplicationArgument -->
+            <!-- ko foreach: selectedNode().getApplicationArguments() -->
                 <!-- ko if: $data.fitsApplicationSearchQuery() -->
-                    <field params="data: $data, ro: $parent.selectedNode().getApplicationParamReadonly($index())"></field>
-                <!-- /ko -->
+                    <field params="data: $data, ro: $parent.selectedNode().getApplicationArgumentReadonly($index())"></field>
                 <!-- /ko -->
             <!-- /ko -->
 

--- a/templates/node_inspector_application_parameters.html
+++ b/templates/node_inspector_application_parameters.html
@@ -15,7 +15,7 @@
             </div>
             <!-- ko foreach: selectedNode().getApplicationArguments() -->
                 <!-- ko if: $data.fitsApplicationSearchQuery() -->
-                    <field params="data: $data, ro: $parent.selectedNode().getApplicationArgumentReadonly($index())"></field>
+                    <field params="data: $data, ro: $data.isReadonly()"></field>
                 <!-- /ko -->
             <!-- /ko -->
 

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -4,7 +4,7 @@
         <i class="material-icons">archive</i>
         <span class="nodeInspectorSubsectionTitle" data-bind="eagleTooltip:'Wrapper parameters describing this component for the DALiuGE system.'">Component Parameters</span>
     </h5>
-    <button class="btn btn-secondary btn-sm openParamsTableBtn" data-bind=" click: function(data, event){openParamsTableModal(Eagle.FieldType.ComponentParameter)}, clickBubble: false, eagleTooltip: 'Open Component Parameters in Table ' + Utils.getKeyboardShortcutTextByKey('open_component_parameter_table_modal', true)">
+    <button class="btn btn-secondary btn-sm openParamsTableBtn" data-bind=" click: function(data, event){openParamsTableModal()}, clickBubble: false, eagleTooltip: 'Open Component Parameters in Table ' + Utils.getKeyboardShortcutTextByKey('open_component_parameter_table_modal', true)">
         <i class="material-icons md-18">table_chart</i>
     </button>
     <div class="collapse nodeInspectorCollapseAll" id="nodeCategoryCollapse9">

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -19,7 +19,7 @@
             <!-- ko foreach: selectedNode().getComponentParameters() -->
                 <!-- ko if: $data.fitsComponentSearchQuery() -->
                     <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
-                        <field params="data: $data, ro: $parent.selectedNode().getComponentParameterReadonly($index())"></field>
+                        <field params="data: $data, ro: $data.isReadonly()"></field>
                     <!-- /ko -->
                 <!-- /ko -->
             <!-- /ko -->

--- a/templates/node_inspector_parameters.html
+++ b/templates/node_inspector_parameters.html
@@ -16,10 +16,10 @@
                 </a>
                 <input class="componentSearchBar" type="text" placeholder="Search" data-bind="valueUpdate: ['afterkeydown', 'input'], value:Eagle.componentParamsSearchString, event:{keyup: function(data,event){$root.setSearchBarClearBtnState(data,event)}}"></input>
             </div>
-            <!-- ko foreach: selectedNode().getFields() -->
+            <!-- ko foreach: selectedNode().getComponentParameters() -->
                 <!-- ko if: $data.fitsComponentSearchQuery() -->
                     <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
-                        <field params="data: $data, ro: $parent.selectedNode().getFieldReadonly($index())"></field>
+                        <field params="data: $data, ro: $parent.selectedNode().getComponentParameterReadonly($index())"></field>
                     <!-- /ko -->
                 <!-- /ko -->
             <!-- /ko -->


### PR DESCRIPTION
This work was motivated by a problem with EAGLE that occurred when a user wanted to add a port to a data component. Since data components are not allowed to be given "application arguments", then there was no way to promote one of those into a port.

Instead, we decided that users would add a component parameter, as was already allowed, but they we'd modify EAGLE to allow those component parameters to be promoted to ports.

This also meant that we needed the parameters table to show everything (component parameters/application arguments/input ports/output ports) even when launched from the button on the header of the component parameters section.

So this removed the need for two different "modes" of the parameter table. So I've removed the button from the "application arguments" section, since sometimes that is invisible. And the single button displays the table in a single mode, where everything is shown.

Internally, all four things (component parameters/application arguments/input ports/output ports) are now stored in a single array Node.fields. But input and output is the same as before, the JSON has 4 different arrays.

This change touched a lot of areas, so please take a look at the behaviour of the parameter table, and at promoting fields into ports and back again.