### PR TITLE
Eagle 761

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3436,6 +3436,17 @@ export class Eagle {
         }
     }
 
+    editFieldDropdownClick = (newType: string, oldType: string) : void => {
+        console.log("editFieldDropdownClick", newType, oldType);
+
+        // check if the types already match, therefore nothing to do
+        if (Utils.dataTypePrefix(oldType) === newType){
+            return;
+        }
+
+        $('#editFieldModalTypeInput').val(newType);
+    }
+
     changeNodeParent = () : void => {
         // build list of node name + ids (exclude self)
         const selectedNode: Node = this.selectedNode();

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2547,10 +2547,13 @@ export class Eagle {
     // TODO: maybe move to Field.ts
     // TODO: add comments
     // TODO: a "get" function probably should not alter state
-    getFieldType = (type:Eagle.DataType, id:string, value:string) : string => {
-        if (type === Eagle.DataType.Float || type === Eagle.DataType.Integer){
+    getFieldType = (type:string, id:string, value:string) : string => {
+        console.log("getFieldType()", type, id, value);
+        const typePrefix = Utils.dataTypePrefix(type);
+
+        if (typePrefix === Eagle.DataType_Float || typePrefix === Eagle.DataType_Integer){
             return "number"
-        }else if(type === Eagle.DataType.Boolean){
+        }else if(type === Eagle.DataType_Boolean){
             $("#"+id).addClass("form-check-input")
             if (Utils.asBool(value)){
                 $("#"+id).addClass("inputChecked")
@@ -2560,9 +2563,9 @@ export class Eagle {
                 $("#"+id).html("Check")
             }
             return "checkbox"
-        }else if(type === Eagle.DataType.Select){
+        }else if(type === Eagle.DataType_Select){
             return "select";
-        }else if(type === Eagle.DataType.Password){
+        }else if(type === Eagle.DataType_Password){
             return "password";
         }else{
             return "text"
@@ -2574,10 +2577,14 @@ export class Eagle {
         Eagle.parameterTableSelection(null);
     }
 
-    fillParametersTable = (type:Eagle.DataType):string => {
-        var options:string = "";
+    // TODO: fill the datatype select element with all the types known within the current graph and palettes
+    fillParametersTable = (type:string):string => {
+        let options:string = "";
 
-        for (let dataType of Object.values(Eagle.DataType)){
+        // TODO: determine the list of all types in this graph and palettes
+        const allTypes: string[] = [];
+
+        for (let dataType of allTypes){
             var selected=""
             if(type === dataType){
                 selected = "selected=true"
@@ -4074,7 +4081,7 @@ export class Eagle {
             $("#customParameterOptionsWrapper").hide();
 
             // create a field variable to serve as temporary field when "editing" the information. If the add field modal is completed the actual field component parameter is created.
-            const field: Field = new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Integer, false, [], false);
+            const field: Field = new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType_Integer, false, [], false);
 
             Utils.requestUserEditField(this, Eagle.ModalType.Add, fieldType, field, allFieldNames, (completed : boolean, newField: Field) => {
                 // abort if the user aborted
@@ -4837,18 +4844,28 @@ export namespace Eagle
         Valid = "Valid"
     }
 
-    export enum DataType {
-        Unknown = "Unknown",
-        String = "String",
-        Integer = "Integer",
-        Float = "Float",
-        Complex = "Complex",
-        Boolean = "Boolean",
-        Select = "Select",
-        Password = "Password",
-        Json = "Json",
-        Python = "Python",
-    }
+    export const DataType_Unknown = "Unknown";
+    export const DataType_String = "String";
+    export const DataType_Integer = "Integer";
+    export const DataType_Float = "Float";
+    export const DataType_Complex = "Complex";
+    export const DataType_Boolean = "Boolean";
+    export const DataType_Select = "Select";
+    export const DataType_Password = "Password";
+    export const DataType_Json = "Json";
+    export const DataType_Python = "Python";
+    export const DataTypes : string[] = [
+        DataType_Unknown,
+        DataType_String,
+        DataType_Integer,
+        DataType_Float,
+        DataType_Complex,
+        DataType_Boolean,
+        DataType_Select,
+        DataType_Password,
+        DataType_Json,
+        DataType_Python,
+    ];
 
     export enum ModalType {
         Add = "Add",

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2548,7 +2548,6 @@ export class Eagle {
     // TODO: add comments
     // TODO: a "get" function probably should not alter state
     getFieldType = (type:string, id:string, value:string) : string => {
-        console.log("getFieldType()", type, id, value);
         const typePrefix = Utils.dataTypePrefix(type);
 
         if (typePrefix === Eagle.DataType_Float || typePrefix === Eagle.DataType_Integer){
@@ -2582,7 +2581,7 @@ export class Eagle {
         let options:string = "";
 
         // TODO: determine the list of all types in this graph and palettes
-        const allTypes: string[] = [];
+        const allTypes: string[] = Utils.findAllKnownTypes(this.palettes(), this.logicalGraph());
 
         for (let dataType of allTypes){
             var selected=""

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -11,7 +11,7 @@ export class Field {
     private defaultValue : ko.Observable<string>;  // default value
     private description : ko.Observable<string>;
     private readonly : ko.Observable<boolean>;
-    private type : ko.Observable<Eagle.DataType>;
+    private type : ko.Observable<string>;
     private precious : ko.Observable<boolean>; // indicates that the field is somehow important and should always be shown to the user
     private options : ko.ObservableArray<string>;
     private positional : ko.Observable<boolean>;
@@ -22,7 +22,7 @@ export class Field {
     private isEvent : ko.Observable<boolean>;
     private nodeKey : ko.Observable<number>;
 
-    constructor(id: string, displayText: string, idText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: Eagle.DataType, precious: boolean, options: string[], positional: boolean){
+    constructor(id: string, displayText: string, idText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: string, precious: boolean, options: string[], positional: boolean){
         this.displayText = ko.observable(displayText);
         this.idText = ko.observable(idText);
         this.value = ko.observable(value);
@@ -104,15 +104,20 @@ export class Field {
         this.readonly(readonly);
     }
 
-    getType = () : Eagle.DataType => {
+    getType = () : string => {
+        console.log("getType()", this.getId(), this.getDisplayText(), this.type());
         return this.type();
+    }
+
+    isType = (type: string) => {
+        return this.type() === type;
     }
 
     valIsTrue = (val:string) : boolean => {
         return Utils.asBool(val);
     }
 
-    setType = (type: Eagle.DataType) : void => {
+    setType = (type: string) : void => {
         this.type(type);
     }
 
@@ -167,7 +172,7 @@ export class Field {
         this.defaultValue("");
         this.description("");
         this.readonly(false);
-        this.type(Eagle.DataType.Unknown);
+        this.type(Eagle.DataType_Unknown);
         this.precious(false);
         this.options([]);
         this.positional(false);
@@ -252,13 +257,13 @@ export class Field {
 
     // used to transform the value attribute of a field into a variable with the correct type
     // the value attribute is always stored as a string internally
-    static string2Type = (value: string, type: Eagle.DataType) : any => {
+    static stringAsType = (value: string, type: string) : any => {
         switch (type){
-            case Eagle.DataType.Boolean:
+            case Eagle.DataType_Boolean:
                 return Utils.asBool(value);
-            case Eagle.DataType.Float:
+            case Eagle.DataType_Float:
                 return parseFloat(value);
-            case Eagle.DataType.Integer:
+            case Eagle.DataType_Integer:
                 return parseInt(value, 10);
             default:
                 return value;
@@ -269,7 +274,7 @@ export class Field {
         return {
             text:field.displayText(),
             name:field.idText(),
-            value:Field.string2Type(field.value(), field.type()),
+            value:Field.stringAsType(field.value(), field.type()),
             defaultValue:field.defaultValue(),
             description:field.description(),
             readonly:field.readonly(),
@@ -284,7 +289,7 @@ export class Field {
         return {
             text:field.displayText(),
             name:field.idText(),
-            value:Field.string2Type(field.value(), field.type()),
+            value:Field.stringAsType(field.value(), field.type()),
             defaultValue:field.defaultValue(),
             description:field.description(),
             readonly:field.readonly(),
@@ -301,7 +306,7 @@ export class Field {
         let name: string = "";
         let description: string = "";
         let readonly: boolean = false;
-        let type: Eagle.DataType = Eagle.DataType.Unknown;
+        let type: string = Eagle.DataType_Unknown;
         let value: string = "";
         let defaultValue: string = "";
         let precious: boolean = false;
@@ -364,7 +369,7 @@ export class Field {
     static fromOJSJsonPort = (data : any) : Field => {
         let text: string = "";
         let event: boolean = false;
-        let type: Eagle.DataType;
+        let type: string;
         let description: string = "";
 
         if (typeof data.text !== 'undefined')

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -105,7 +105,6 @@ export class Field {
     }
 
     getType = () : string => {
-        console.log("getType()", this.getId(), this.getDisplayText(), this.type());
         return this.type();
     }
 

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -297,7 +297,7 @@ export class Modals {
             const defaultValueSelect : string = <string>$('#editFieldModalDefaultValueInputSelect').val();
 
             const description: string = <string>$('#editFieldModalDescriptionInput').val();
-            const type: string = <string>$('#editFieldModalTypeSelect').val();
+            const type: string = <string>$('#editFieldModalTypeInput').val();
             const fieldType: string = <string>$('#editFieldModalFieldTypeSelect').val();
             const precious: boolean = $('#editFieldModalPreciousInputCheckbox').prop('checked');
 
@@ -308,19 +308,19 @@ export class Modals {
             const positional: boolean = $('#editFieldModalPositionalInputCheckbox').prop('checked');
 
             // translate type
-            const realType: string = Utils.translateStringToDataType(type);
+            const realType: string = Utils.translateStringToDataType(Utils.dataTypePrefix(type));
             const realFieldType: Eagle.FieldType = Utils.translateStringToFieldType(fieldType);
             let newField;
 
             switch(realType){
                 case Eagle.DataType_Boolean:
-                    newField = new Field(id, displayText, idText, valueCheckbox.toString(), defaultValueCheckbox.toString(), description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueCheckbox.toString(), defaultValueCheckbox.toString(), description, readonly, type, precious, options, positional);
                     break;
                 case Eagle.DataType_Select:
-                    newField = new Field(id, displayText, idText, valueSelect, defaultValueSelect, description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueSelect, defaultValueSelect, description, readonly, type, precious, options, positional);
                     break;
                 default:
-                    newField = new Field(id, displayText, idText, valueText, defaultValueText, description, readonly, realType, precious, options, positional);
+                    newField = new Field(id, displayText, idText, valueText, defaultValueText, description, readonly, type, precious, options, positional);
                     break;
             }
             newField.setFieldType(realFieldType);

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -245,9 +245,9 @@ export class Modals {
             const fieldType: string = <string>$('#editFieldModalFieldTypeSelect').val();
 
             // translate type
-            const realType: Eagle.DataType = Utils.translateStringToDataType(type);
+            const realType: string = Utils.translateStringToDataType(type);
 
-            if (realType === Eagle.DataType.Boolean){
+            if (realType === Eagle.DataType_Boolean){
                 $('#editFieldModalValueInputCheckbox').prop('checked', defaultValueCheckbox);
             } else {
                 $('#editFieldModalValueInputText').val(defaultValueText);
@@ -308,15 +308,15 @@ export class Modals {
             const positional: boolean = $('#editFieldModalPositionalInputCheckbox').prop('checked');
 
             // translate type
-            const realType: Eagle.DataType = Utils.translateStringToDataType(type);
+            const realType: string = Utils.translateStringToDataType(type);
             const realFieldType: Eagle.FieldType = Utils.translateStringToFieldType(fieldType);
             let newField;
 
             switch(realType){
-                case Eagle.DataType.Boolean:
+                case Eagle.DataType_Boolean:
                     newField = new Field(id, displayText, idText, valueCheckbox.toString(), defaultValueCheckbox.toString(), description, readonly, realType, precious, options, positional);
                     break;
-                case Eagle.DataType.Select:
+                case Eagle.DataType_Select:
                     newField = new Field(id, displayText, idText, valueSelect, defaultValueSelect, description, readonly, realType, precious, options, positional);
                     break;
                 default:
@@ -331,7 +331,7 @@ export class Modals {
         $('#editFieldModal').on('show.bs.modal', function(){
             const value = $('#editFieldModalTypeSelect').val();
 
-            if(value === Eagle.DataType.Float || value === Eagle.DataType.Integer){
+            if(value === Eagle.DataType_Float || value === Eagle.DataType_Integer){
                 $('#editFieldModalDefaultValueInputText').attr("type", "number")
                 $('#editFieldModalValueInputText').attr("type", "number")
             }else{
@@ -343,21 +343,21 @@ export class Modals {
             // show the correct entry field based on the field type
             const value = $('#editFieldModalTypeSelect').val();
 
-            if(value === Eagle.DataType.Boolean){
+            if(value === Eagle.DataType_Boolean){
                 $("#editFieldModalDefaultValue").hide()
             }else{
                 $("#editFieldModalDefaultValue").show()
             }
 
-            $('#editFieldModalValueInputText').toggle(value !== Eagle.DataType.Boolean && value !== Eagle.DataType.Select);
-            $('#editFieldModalValueInputCheckbox').parent().toggle(value === Eagle.DataType.Boolean);
-            $('#editFieldModalValueInputSelect').toggle(value === Eagle.DataType.Select);
+            $('#editFieldModalValueInputText').toggle(value !== Eagle.DataType_Boolean && value !== Eagle.DataType_Select);
+            $('#editFieldModalValueInputCheckbox').parent().toggle(value === Eagle.DataType_Boolean);
+            $('#editFieldModalValueInputSelect').toggle(value === Eagle.DataType_Select);
 
-            $('#editFieldModalDefaultValueInputText').toggle(value !== Eagle.DataType.Boolean && value !== Eagle.DataType.Select);
-            $('#editFieldModalDefaultValueInputCheckbox').toggle(value === Eagle.DataType.Boolean);
-            $('#editFieldModalDefaultValueInputSelect').toggle(value === Eagle.DataType.Select);
+            $('#editFieldModalDefaultValueInputText').toggle(value !== Eagle.DataType_Boolean && value !== Eagle.DataType_Select);
+            $('#editFieldModalDefaultValueInputCheckbox').toggle(value === Eagle.DataType_Boolean);
+            $('#editFieldModalDefaultValueInputSelect').toggle(value === Eagle.DataType_Select);
 
-            if(value === Eagle.DataType.Float || value === Eagle.DataType.Integer){
+            if(value === Eagle.DataType_Float || value === Eagle.DataType_Integer){
                 $('#editFieldModalDefaultValueInputText').attr("type", "number")
                 $('#editFieldModalValueInputText').attr("type", "number")
             }else{
@@ -479,10 +479,10 @@ export class Modals {
     static _validateFieldModalValueInputText(){
         const type: string = <string>$('#editFieldModalTypeSelect').val();
         const value: string = <string>$('#editFieldModalValueInputText').val();
-        const realType: Eagle.DataType = Utils.translateStringToDataType(type);
+        const realType: string = Utils.translateStringToDataType(type);
 
         // only validate Json fields
-        if (realType !== Eagle.DataType.Json){
+        if (realType !== Eagle.DataType_Json){
             $('#editFieldModalValueInputText').removeClass('is-valid');
             $('#editFieldModalValueInputText').removeClass('is-invalid');
             return;

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -963,7 +963,7 @@ export class Node {
 
     setGroupStart = (value: boolean) => {
         if (!this.hasFieldWithIdText("group_start")){
-            this.addField(new Field(Utils.uuidv4(), "Group Start", "group_start", value.toString(), "false", "Is this node the start of a group?", false, Eagle.DataType.Boolean, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "Group Start", "group_start", value.toString(), "false", "Is this node the start of a group?", false, Eagle.DataType_Boolean, false, [], false));
         } else {
             this.getFieldByIdText("group_start").setValue(value.toString());
         }
@@ -971,7 +971,7 @@ export class Node {
 
     setGroupEnd = (value: boolean) => {
         if (!this.hasFieldWithIdText("group_end")){
-            this.addField(new Field(Utils.uuidv4(), "Group End", "group_end", value.toString(), "false", "Is this node the end of a group?", false, Eagle.DataType.Boolean, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "Group End", "group_end", value.toString(), "false", "Is this node the end of a group?", false, Eagle.DataType_Boolean, false, [], false));
         } else {
             this.getFieldByIdText("group_end").setValue(value.toString());
         }
@@ -1196,14 +1196,14 @@ export class Node {
 
         // if no fields exist, create at least one, to store the custom data
         if (this.fields().length === 0){
-            this.addField(new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType.Unknown, false, [], false));
+            this.addField(new Field(Utils.uuidv4(), "", "", "", "", "", false, Eagle.DataType_Unknown, false, [], false));
         }
 
         this.fields()[0].setValue(e.value);
     }
 
     addEmptyField = (index:number) :void => {
-        var newField = new Field(Utils.uuidv4(), "New Parameter", "", "", "", "", false, Eagle.DataType.String, false, [], false)
+        var newField = new Field(Utils.uuidv4(), "New Parameter", "", "", "", "", false, Eagle.DataType_String, false, [], false)
         if(index === -1){
             this.addField(newField);
         }else{
@@ -1213,9 +1213,9 @@ export class Node {
 
     addEmptyArg = (index:number) :void => {
         if(index === -1){
-            this.addApplicationArg(new Field(Utils.uuidv4(), "New Argument", "", "", "", "", false, Eagle.DataType.String, false, [], false));
+            this.addApplicationArg(new Field(Utils.uuidv4(), "New Argument", "", "", "", "", false, Eagle.DataType_String, false, [], false));
         }else{
-            this.addApplicationArgAtPosition(new Field(Utils.uuidv4(), "New Argument", "", "", "", "", false, Eagle.DataType.String, false, [], false),index);
+            this.addApplicationArgAtPosition(new Field(Utils.uuidv4(), "New Argument", "", "", "", "", false, Eagle.DataType_String, false, [], false),index);
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -754,21 +754,28 @@ export class Utils {
         // delete all options, then iterate through the values in the Eagle.DataType enum, adding each as an option to the select
         $('#editFieldModalTypeSelect').empty();
         for (let dataType of allTypes){
-            $('#editFieldModalTypeSelect').append($('<option>', {
-                value: dataType,
-                text: dataType,
-                selected: field.getType() === dataType
-            }));
+            $('#editFieldModalTypeSelect').append(
+                /*
+                $('<option>', {
+                    value: dataType,
+                    text: dataType,
+                    selected: field.getType() === dataType
+                })
+                */
+                $('<li><a class="dropdown-item" href="#">' + dataType + '</a></li>')
+            );
         }
 
         // delete all options, then iterate through the values in the Eagle.FieldType enum, adding each as an option to the select
         $('#editFieldModalFieldTypeSelect').empty();
         for (let fieldType of [Eagle.FieldType.ComponentParameter, Eagle.FieldType.ApplicationArgument, Eagle.FieldType.InputPort, Eagle.FieldType.OutputPort]){
-            $('#editFieldModalFieldTypeSelect').append($('<option>', {
-                value: fieldType,
-                text: fieldType,
-                selected: field.getFieldType() === fieldType
-            }));
+            $('#editFieldModalFieldTypeSelect').append(
+                $('<option>', {
+                    value: fieldType,
+                    text: fieldType,
+                    selected: field.getFieldType() === fieldType
+                })
+            );
         }
         // hide the fieldType select if the fieldType is ComponentParameter, since that can't be changed
         if (field.getFieldType() === Eagle.FieldType.ComponentParameter){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1044,7 +1044,33 @@ export class Utils {
 
     // TODO: incomplete!
     static findAllKnownTypes = (palettes : Palette[], graph: LogicalGraph): string[] => {
-        return [];
+        const uniqueTypes : string[] = [];
+
+        // build a list from all palettes
+        for (const palette of palettes){
+            for (const node of palette.getNodes()){
+                for (const field of node.getFields()) {
+                    Utils._addTypeIfUnique(uniqueTypes, field.getType());
+                }
+
+                for (const arg of node.getApplicationArgs()) {
+                    Utils._addTypeIfUnique(uniqueTypes, arg.getType());
+                }
+            }
+        }
+
+        // add all types in LG nodes
+        for (const node of graph.getNodes()){
+            for (const field of node.getFields()) {
+                Utils._addTypeIfUnique(uniqueTypes, field.getType());
+            }
+
+            for (const arg of node.getApplicationArgs()) {
+                Utils._addTypeIfUnique(uniqueTypes, arg.getType());
+            }
+        }
+
+        return uniqueTypes;
     }
 
     /**
@@ -1169,6 +1195,15 @@ export class Utils {
 
         // otherwise add the port
         ports.push(port);
+    }
+
+    private static _addTypeIfUnique = (types: string[], newType: string) : void => {
+        for (const t of types){
+            if (t === newType){
+                return;
+            }
+        }
+        types.push(newType);
     }
 
     /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1042,7 +1042,6 @@ export class Utils {
         $('#editEdgeModalDataTypeInput').val(edge.getDataType());
     }
 
-    // TODO: incomplete!
     static findAllKnownTypes = (palettes : Palette[], graph: LogicalGraph): string[] => {
         const uniqueTypes : string[] = [];
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -298,7 +298,6 @@ export class Utils {
     }
 
     static translateStringToDataType(dataType: string): string {
-
         for (let dt of Eagle.DataTypes){
             if (dt.toLowerCase() === dataType.toLowerCase()){
                 return dt;
@@ -748,22 +747,26 @@ export class Utils {
         $('#editFieldModalDefaultValueInputCheckbox').toggle(field.isType(Eagle.DataType_Boolean));
         $('#editFieldModalDefaultValueInputSelect').toggle(field.isType(Eagle.DataType_Select));
 
+        $('#editFieldModalTypeInput').val(field.getType());
+
         // TODO: this looks like Eagle.ts::fillParametersTable(), can we make them common
         const allTypes = Utils.findAllKnownTypes(eagle.palettes(), eagle.logicalGraph());
 
         // delete all options, then iterate through the values in the Eagle.DataType enum, adding each as an option to the select
         $('#editFieldModalTypeSelect').empty();
         for (let dataType of allTypes){
-            $('#editFieldModalTypeSelect').append(
-                /*
-                $('<option>', {
-                    value: dataType,
-                    text: dataType,
-                    selected: field.getType() === dataType
-                })
-                */
-                $('<li><a class="dropdown-item" href="#">' + dataType + '</a></li>')
-            );
+            const li = $('<li></li>');
+            const a = $('<a class="dropdown-item" href="#">' + dataType + '</a>');
+
+            a.attr("href", "javascript:eagle.editFieldDropdownClick('" + dataType + "','" + field.getType() + "');");
+
+            if (Utils.dataTypePrefix(field.getType()) === dataType){
+                a.addClass("active");
+            }
+
+            // add to the html
+            li.append(a);
+            $('#editFieldModalTypeSelect').append(li);
         }
 
         // delete all options, then iterate through the values in the Eagle.FieldType enum, adding each as an option to the select

--- a/static/base.css
+++ b/static/base.css
@@ -81,6 +81,22 @@
     background-color: #b6c3cf;
 }
 
+#editFieldModalTypeSelect{
+    position: absolute;
+    background: white;
+    padding: 0px;
+    height: 130px;
+    overflow-y: scroll;
+    margin: 0px;
+    transform: none !important;
+    inset: 40px 0px auto auto !important;
+}
+
+#editFieldModalTypeSelect .dropdown-item:hover{
+    background: #002e5f;
+    color: white;
+}
+
 #explorePalettesModal li.list-group-item span{
     pointer-events: none;
 }

--- a/static/base.css
+++ b/static/base.css
@@ -1337,12 +1337,12 @@ div.rightWindow h5.card-header {
     top: 2px;
 }
 
-.btn-outline-secondary {
+ul.nav.navbar-nav .btn-outline-secondary {
     border-color: #dadada;
     color:white;
 }
 
-.btn-outline-secondary:hover{
+ul.nav.navbat-nav .btn-outline-secondary:hover{
     background-color: white;
     color: #002349;
 }
@@ -1388,7 +1388,7 @@ div.rightWindow h5.card-header {
      margin-left:4px;
  }
 
-.dropdown-menu{
+ul.nav.navbar-nav .dropdown-menu{
     border:solid 1px #000c1a;
     border-radius: 6px;
      position: absolute;
@@ -1396,16 +1396,16 @@ div.rightWindow h5.card-header {
      background-color: #0059a5;
 }
 
-.dropdown-menu-right{
+ul.nav.navbar-nav .dropdown-menu-right{
     right: 0;
     left: auto !important;
 }
 
-.dropdown-item{
+ul.nav.navbar-nav .dropdown-item{
     color: white;
 }
 
-.dropdown-item:hover{
+ul.nav.navbar-nav .dropdown-item:hover{
     background-color: #001d3b;
     color: white;
 }

--- a/static/components/field.html
+++ b/static/components/field.html
@@ -4,18 +4,18 @@
         <span class="input-group-text" id="group-addon" data-bind="text: $data.displayText, eagleTooltip: $data.getDescriptionText()" data-bs-placement="left"></span>
     </div>
 
-    <!-- ko if: getType() !== Eagle.DataType.Boolean && getType() !== Eagle.DataType.Select -->
+    <!-- ko if: !isType(Eagle.DataType_Boolean) && !isType(Eagle.DataType_Select) -->
     <input class="form-control" placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()), id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
     <!-- /ko -->
 
-    <!-- ko if: getType() === Eagle.DataType.Boolean -->
+    <!-- ko if: isType(Eagle.DataType_Boolean) -->
     <div class="form-control checkboxParent">
         <input class="inspectorCheckbox form-check-input btn-check" placeholder="" aria-label="Label" onclick="$(this).val(this.checked ? true : false)" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, checked: valIsTrue($data.value()), valueUpdate: ['afterkeydown', 'input'], disabled: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()), id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();$root.checkGraph();}}, eagleTooltip: getFieldValue()">
         <label class="btn btn-outline-primary" data-bind="attr:{for: $data.fieldType() + $index()}, html: $data.value() "></label><br>
     </div>
     <!-- /ko -->
 
-    <!-- ko if: getType() === Eagle.DataType.Select -->
+    <!-- ko if: isType(Eagle.DataType_Select) -->
     <div class="form-control">
         <select class="form-select" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="disabled: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue(), options: $data.options, value: $data.value">
         </select>
@@ -23,7 +23,7 @@
     <!-- /ko -->
 
     <!-- ko ifnot: $root.selectedNode().isLocked() -->
-        <!-- ko if: getType() === Eagle.DataType.String -->
+        <!-- ko if: isType(Eagle.DataType_String) -->
         <div class="input-group-append">
             <button class="btn btn-secondary btn-sm" type="button" data-bind="click: function(){$root.showFieldValuePicker($index(), $data.input);}, attr: {id: 'nodeInspectorEditField' + $index()}, eagleTooltip: 'Open Field Value Wizard'" data-bs-placement="left">
                 <i class="material-icons md-18">link</i>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -521,11 +521,29 @@
                             <p>Type:</p>
                         </div>
                         <div class="col">
+
+                            <!--
                             <div class="form-group">
                                 <select class="form-control" id="editFieldModalTypeSelect">
-                                    <!-- options are added dynamically -->
+
                                 </select>
                             </div>
+                            -->
+
+                            <div class="input-group mb-3">
+                                <input type="text" class="form-control" aria-label="Text input with dropdown button">
+                                <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
+                                <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end">
+                                    <!--
+                                    <li><a class="dropdown-item" href="#">Action</a></li>
+                                    <li><a class="dropdown-item" href="#">Another action</a></li>
+                                    <li><a class="dropdown-item" href="#">Something else here</a></li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li><a class="dropdown-item" href="#">Separated link</a></li>
+                                    -->
+                                </ul>
+                            </div>
+
                         </div>
                     </div>
                     <div class="row">

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -521,29 +521,12 @@
                             <p>Type:</p>
                         </div>
                         <div class="col">
-
-                            <!--
-                            <div class="form-group">
-                                <select class="form-control" id="editFieldModalTypeSelect">
-
-                                </select>
-                            </div>
-                            -->
-
                             <div class="input-group mb-3">
-                                <input type="text" class="form-control" aria-label="Text input with dropdown button">
+                                <input id="editFieldModalTypeInput" type="text" class="form-control" aria-label="Text input with dropdown button">
                                 <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
                                 <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end">
-                                    <!--
-                                    <li><a class="dropdown-item" href="#">Action</a></li>
-                                    <li><a class="dropdown-item" href="#">Another action</a></li>
-                                    <li><a class="dropdown-item" href="#">Something else here</a></li>
-                                    <li><hr class="dropdown-divider"></li>
-                                    <li><a class="dropdown-item" href="#">Separated link</a></li>
-                                    -->
                                 </ul>
                             </div>
-
                         </div>
                     </div>
                     <div class="row">

--- a/tools/testNode.ts
+++ b/tools/testNode.ts
@@ -1,6 +1,7 @@
 import {Eagle} from '../src/Eagle';
 import {Node} from '../src/Node';
 import {Field} from '../src/Field';
+import {Utils} from '../src/Utils';
 
 const KEY : number = -9;
 const NAME : string = "Test Node";
@@ -38,9 +39,9 @@ const OUTPUT_PORT_NAME : string = "Output Port";
 const OUTPUT_PORT_TYPE : string = "Boolean";
 const OUTPUT_PORT_DESCRIPTION : string = "Out Description";
 
-const FIELD : Field = new Field("Field Display Text", "Field Id Text", "Field Value", "Field Default Value", "Field Desc", true, Eagle.DataType.String, false, [], false);
-const INPUT_APP_FIELD : Field = new Field("Input App Field Display Text", "Input App Field Id Text", "Input App Field Value", "Input App Field Default Value", "Input App Field Desc", false, Eagle.DataType.Integer, false, [], false);
-const OUTPUT_APP_FIELD : Field = new Field("Output App Field Display Text", "Output App Field Id Text", "Output App Field Value", "Output App Field Default Value", "Output App Field Desc", false, Eagle.DataType.Boolean, false, [], false);
+const FIELD : Field = new Field(Utils.uuidv4(), "Field Display Text", "Field Id Text", "Field Value", "Field Default Value", "Field Desc", true, Eagle.DataType_String, false, [], false);
+const INPUT_APP_FIELD : Field = new Field(Utils.uuidv4(), "Input App Field Display Text", "Input App Field Id Text", "Input App Field Value", "Input App Field Default Value", "Input App Field Desc", false, Eagle.DataType_Integer, false, [], false);
+const OUTPUT_APP_FIELD : Field = new Field(Utils.uuidv4(), "Output App Field Display Text", "Output App Field Id Text", "Output App Field Value", "Output App Field Default Value", "Output App Field Desc", false, Eagle.DataType_Boolean, false, [], false);
 
 // create table to contain results
 var table : any[] = [];

--- a/tools/updateGraph.ts
+++ b/tools/updateGraph.ts
@@ -232,28 +232,28 @@ function readNode(nodeData : any, index : number) : Node {
     // add input ports
     if (typeof nodeData.inputPorts !== 'undefined'){
         for (const portData of nodeData.inputPorts){
-            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType.Unknown), true);
+            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType_Unknown), true);
         }
     }
 
     // add output ports
     if (typeof nodeData.outputPorts !== 'undefined'){
         for (const portData of nodeData.outputPorts){
-            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType.Unknown), false);
+            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType_Unknown), false);
         }
     }
 
     // add input local ports
     if (typeof nodeData.inputLocalPorts !== 'undefined'){
         for (const portData of nodeData.inputLocalPorts){
-            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType.Unknown), true);
+            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType_Unknown), true);
         }
     }
 
     // add output local ports
     if (typeof nodeData.outputLocalPorts !== 'undefined'){
         for (const portData of nodeData.outputLocalPorts){
-            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType.Unknown), false);
+            node.addPort(new Port(portData.Id, portData.IdText, false, Eagle.DataType_Unknown), false);
         }
     }
 
@@ -299,11 +299,11 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure scatter nodes have a 'num_of_copies' field
     if (node.getCategory() === Eagle.Category.Scatter){
         if (node.getFieldByName('num_of_copies') === null){
-            node.addField(new Field("Number of copies", "num_of_copies", "1", "", false, Eagle.DataType.Integer));
+            node.addField(new Field("Number of copies", "num_of_copies", "1", "", false, Eagle.DataType_Integer));
             logMessage("Added missing 'num_of_copies' field to Scatter node " + index);
         }
         if (node.getFieldByName('scatter_axis') === null){
-            node.addField(new Field("Scatter Axis", "scatter_axis", "", "", false, Eagle.DataType.String));
+            node.addField(new Field("Scatter Axis", "scatter_axis", "", "", false, Eagle.DataType_String));
             logMessage("Added missing 'scatter_axis' field to Scatter node " + index);
         }
     }
@@ -311,11 +311,11 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure gather nodes have a 'num_of_inputs' field
     if (node.getCategory() === Eagle.Category.Gather){
         if (node.getFieldByName('num_of_inputs') === null){
-            node.addField(new Field("Number of inputs", "num_of_inputs", "1", "", false, Eagle.DataType.Integer));
+            node.addField(new Field("Number of inputs", "num_of_inputs", "1", "", false, Eagle.DataType_Integer));
             logMessage("Added missing 'num_of_inputs' field to Gather node " + index);
         }
         if (node.getFieldByName('gather_axis') === null){
-            node.addField(new Field("Gather Axis", "gather_axis", "", "", false, Eagle.DataType.String));
+            node.addField(new Field("Gather Axis", "gather_axis", "", "", false, Eagle.DataType_String));
             logMessage("Added missing 'gather_axis' field to Gather node " + index);
         }
     }
@@ -323,15 +323,15 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure MKN nodes have 'm', 'k', and 'n' fields
     if (node.getCategory() === Eagle.Category.MKN){
         if (node.getFieldByName('m') === null){
-            node.addField(new Field("M", "m", "1", "1", "", false, Eagle.DataType.Integer, false));
+            node.addField(new Field("M", "m", "1", "1", "", false, Eagle.DataType_Integer, false));
             logMessage("Added missing 'm' field to MKN node " + index);
         }
         if (node.getFieldByName('k') === null){
-            node.addField(new Field("K", "k", "1", "1", "", false, Eagle.DataType.Integer, false));
+            node.addField(new Field("K", "k", "1", "1", "", false, Eagle.DataType_Integer, false));
             logMessage("Added missing 'k' field to MKN node " + index);
         }
         if (node.getFieldByName('n') === null){
-            node.addField(new Field("N", "n", "1", "1", "", false, Eagle.DataType.Integer, false));
+            node.addField(new Field("N", "n", "1", "1", "", false, Eagle.DataType_Integer, false));
             logMessage("Added missing 'n' field to MKN node " + index);
         }
     }
@@ -339,7 +339,7 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure comment nodes have appropriate fields
     if (node.getCategory() === Eagle.Category.Comment){
         if (node.getFieldByName('comment') === null){
-            node.addField(new Field("Comment", "comment", node.getName(), node.getName(), "The text value of the comment", false, Eagle.DataType.String, false));
+            node.addField(new Field("Comment", "comment", node.getName(), node.getName(), "The text value of the comment", false, Eagle.DataType_String, false));
             node.setName("");
             logMessage("Added missing 'comment' field to Comment node " + index);
         }
@@ -348,7 +348,7 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure description nodes have appropriate fields
     if (node.getCategory() === Eagle.Category.Description){
         if (node.getFieldByName('description') === null){
-            node.addField(new Field("Description", "description", "", "", "The text value of the description", false, Eagle.DataType.String, false));
+            node.addField(new Field("Description", "description", "", "", "The text value of the description", false, Eagle.DataType_String, false));
             logMessage("Added missing 'description' field to Description node " + index);
         }
     }
@@ -356,7 +356,7 @@ function readNode(nodeData : any, index : number) : Node {
     // make sure "file" nodes that were created from old "Data" nodes have appropriate fields
     if (node.getCategory() === Eagle.Category.File && nodeData.category === "Data"){
         if (node.getFieldByName('filepath') === null){
-            node.addField(new Field("File path", "file_path", nodeData.text, nodeData.text, "", false, Eagle.DataType.String, false));
+            node.addField(new Field("File path", "file_path", nodeData.text, nodeData.text, "", false, Eagle.DataType_String, false));
             logMessage("Copied old 'text' value (" + nodeData.text + ") as filepath field for old Data node translated to File node " + index);
         }
     }


### PR DESCRIPTION
This switches to using a string for the "type" of each field (component parameter/application argument/input port/output port) instead of an enumerated type.

We need a much richer type system in order to describe all the various output types from components.

There are still several "known" types (Integer, Float, Boolean, String etc). But the user can specify any string.

Perhaps check the functionality surrounding creating new fields, changing types, both in the edit field modal, and in the parameters table.