### PR TITLE
Eagle 723

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4524,9 +4524,14 @@ export class Eagle {
         let eligibleComponents : Node[];
 
         if (this.selectedNode().isData()){
-            eligibleComponents = Utils.getDataComponentsWithInputsAndOutputs(this.palettes(), this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Data, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+        } else if (this.selectedNode().isApplication()){
+            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Application, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+        } else if (this.selectedNode().isGroup()){
+            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Group, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         } else {
-            // TODO
+            console.warn("Not sure which other nodes are suitable for change, show user all");
+            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Unknown, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         }
 
         const eligibleComponentNames: string[] = [];
@@ -4861,6 +4866,14 @@ export namespace Eagle
         UnknownApplication = "UnknownApplication", // when we know the component is an application, but know wlmost nothing else about it
 
         Component = "Component" // legacy only
+    }
+
+    // TODO: add to CategoryData somehow? use in Node.isData() etc?
+    export enum CategoryType {
+        Data = "Data",
+        Application = "Application",
+        Group = "Group",
+        Unknown = "Unknown"
     }
 
     export enum Direction {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4534,6 +4534,15 @@ export class Eagle {
             eligibleCategories = Utils.getCategoriesWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Unknown, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         }
 
+        // set selectedIndex to the index of the current category within the eligibleCategories list
+        for (let i = 0 ; i < eligibleCategories.length ; i++){
+            if (eligibleCategories[i] === this.selectedNode().getCategory()){
+                selectedIndex = i;
+                break;
+            }
+        }
+
+        // launch modal
         Utils.requestUserChoice("Edit Node Category", "NOTE: changing a node's category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category", eligibleCategories, selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
             if (!completed){
                 return;

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4518,32 +4518,35 @@ export class Eagle {
     }
 
     editNodeCategory = (eagle: Eagle) : void => {
-        // create array of all categories
-        let categories: Eagle.Category[] = [];
         let selectedIndex = 0;
         let i = 0;
 
-        for (const category of Object.values(Eagle.Category)){
-            categories.push(category);
-            if (category === this.selectedNode().getCategory()){
-                selectedIndex = i;
-            }
-            i++;
+        let eligibleComponents : Node[];
+
+        if (this.selectedNode().isData()){
+            eligibleComponents = Utils.getDataComponentsWithInputsAndOutputs(this.palettes(), this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+        } else {
+            // TODO
         }
 
-        Utils.requestUserChoice("Edit Node Category", "NOTE: changing a node's category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category", categories, selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
+        const eligibleComponentNames: string[] = [];
+        for (const component of eligibleComponents){
+            eligibleComponentNames.push(component.getName());
+        }
+
+        Utils.requestUserChoice("Edit Node Category", "NOTE: changing a node's category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category", eligibleComponentNames, selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
             if (!completed){
                 return;
             }
 
             // change the category of the node
-            this.selectedNode().setCategory(categories[userChoiceIndex]);
+            this.selectedNode().setCategory(eligibleComponents[userChoiceIndex].getCategory());
 
             // once the category is changed, some things about the node may no longer be valid
             // for example, the node may contain ports, but no ports are allowed
 
             // get category data
-            const categoryData = Eagle.getCategoryData(categories[userChoiceIndex]);
+            const categoryData = Eagle.getCategoryData(eligibleComponents[userChoiceIndex].getCategory());
 
             // delete parameters, if necessary
             if (this.selectedNode().getComponentParameters().length > 0 && !categoryData.canHaveComponentParameters){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4521,37 +4521,32 @@ export class Eagle {
         let selectedIndex = 0;
         let i = 0;
 
-        let eligibleComponents : Node[];
+        let eligibleCategories : Eagle.Category[];
 
         if (this.selectedNode().isData()){
-            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Data, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+            eligibleCategories = Utils.getCategoriesWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Data, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         } else if (this.selectedNode().isApplication()){
-            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Application, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+            eligibleCategories = Utils.getCategoriesWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Application, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         } else if (this.selectedNode().isGroup()){
-            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Group, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+            eligibleCategories = Utils.getCategoriesWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Group, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         } else {
             console.warn("Not sure which other nodes are suitable for change, show user all");
-            eligibleComponents = Utils.getComponentsWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Unknown, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
+            eligibleCategories = Utils.getCategoriesWithInputsAndOutputs(this.palettes(), Eagle.CategoryType.Unknown, this.selectedNode().getInputPorts().length, this.selectedNode().getOutputPorts().length);
         }
 
-        const eligibleComponentNames: string[] = [];
-        for (const component of eligibleComponents){
-            eligibleComponentNames.push(component.getName());
-        }
-
-        Utils.requestUserChoice("Edit Node Category", "NOTE: changing a node's category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category", eligibleComponentNames, selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
+        Utils.requestUserChoice("Edit Node Category", "NOTE: changing a node's category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category", eligibleCategories, selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
             if (!completed){
                 return;
             }
 
             // change the category of the node
-            this.selectedNode().setCategory(eligibleComponents[userChoiceIndex].getCategory());
+            this.selectedNode().setCategory(eligibleCategories[userChoiceIndex]);
 
             // once the category is changed, some things about the node may no longer be valid
             // for example, the node may contain ports, but no ports are allowed
 
             // get category data
-            const categoryData = Eagle.getCategoryData(eligibleComponents[userChoiceIndex].getCategory());
+            const categoryData = Eagle.getCategoryData(eligibleCategories[userChoiceIndex]);
 
             // delete parameters, if necessary
             if (this.selectedNode().getComponentParameters().length > 0 && !categoryData.canHaveComponentParameters){

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -524,6 +524,14 @@ export class Node {
         return Eagle.getCategoryData(this.category()).maxOutputs > 0;
     }
 
+    maxInputs = () : number => {
+        return Eagle.getCategoryData(this.category()).maxInputs;
+    }
+
+    maxOutputs = () : number => {
+        return Eagle.getCategoryData(this.category()).maxOutputs;
+    }
+
     canHaveInputApplication = () : boolean => {
         return Eagle.getCategoryData(this.category()).canHaveInputApplication;
     }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1009,6 +1009,14 @@ export class Node {
         }
     }
 
+    removeAllOutputPorts = () : void => {
+        for (let i = this.fields().length - 1 ; i >= 0 ; i--){
+            if (this.fields()[i].getFieldType() === Eagle.FieldType.OutputPort){
+                this.fields.splice(i, 1);
+            }
+        }
+    }
+
     clone = () : Node => {
         const result : Node = new Node(this.key(), this.name(), this.description(), this.category());
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1186,6 +1186,47 @@ export class Utils {
         return result;
     }
 
+    static getCategoriesWithInputsAndOutputs(palettes: Palette[], categoryType: Eagle.CategoryType, numRequiredInputs: number, numRequiredOutputs: number) : Eagle.Category[] {
+        console.log("getDataComponentsWithInputsAndOutputs");
+
+        const result: Eagle.Category[] = [];
+
+        // loop through all categories
+        for (const category in Eagle.cData){
+            // get category data
+            const categoryData = Eagle.getCategoryData(<Eagle.Category>category);
+
+
+            if (categoryType === Eagle.CategoryType.Data && !categoryData.isData){
+                continue;
+            }
+
+            // skip nodes that are not application components
+            if (categoryType === Eagle.CategoryType.Application && !categoryData.isApplication){
+                continue;
+            }
+
+            // skip nodes that are not group components
+            if (categoryType === Eagle.CategoryType.Group && !categoryData.isGroup){
+                continue;
+            }
+
+            // if input ports required, skip nodes with too few
+            if (numRequiredInputs > categoryData.maxInputs){
+                continue;
+            }
+
+            // if output ports required, skip nodes with too few
+            if (numRequiredOutputs > categoryData.maxOutputs){
+                continue;
+            }
+
+            result.push(<Eagle.Category>category);
+        }
+
+        return result;
+    }
+
     static getDataComponentMemory(palettes: Palette[]) : Node {
         console.log("getDataComponentMemory");
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1114,7 +1114,7 @@ export class Utils {
         return uniquePorts;
     }
 
-    static getDataComponentsWithPortTypeList(palettes: Palette[], portName: string, portType: string, ineligibleCategories: Eagle.Category[]){
+    static getDataComponentsWithPortTypeList(palettes: Palette[], ineligibleCategories: Eagle.Category[]) : Node[] {
         console.log("getDataComponentsWithPortTypeList", ineligibleCategories);
 
         const result: Node[] = [];
@@ -1144,6 +1144,22 @@ export class Utils {
         }
 
         return result;
+    }
+
+    static getDataComponentMemory(palettes: Palette[]) : Node {
+        console.log("getDataComponentMemory");
+
+        // add all data components (except ineligible)
+        for (const palette of palettes){
+            for (const node of palette.getNodes()){
+                // skip nodes that are not data components
+                if (node.getName() === Eagle.Category.Memory){
+                    return node;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static _addPortIfUnique = (ports : Field[], port: Field) : void => {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1146,7 +1146,7 @@ export class Utils {
         return result;
     }
 
-    static getDataComponentsWithInputsAndOutputs(palettes: Palette[], numRequiredInputs: number, numRequiredOutputs: number) : Node[] {
+    static getComponentsWithInputsAndOutputs(palettes: Palette[], categoryType: Eagle.CategoryType, numRequiredInputs: number, numRequiredOutputs: number) : Node[] {
         console.log("getDataComponentsWithInputsAndOutputs");
 
         const result: Node[] = [];
@@ -1155,7 +1155,17 @@ export class Utils {
         for (const palette of palettes){
             for (const node of palette.getNodes()){
                 // skip nodes that are not data components
-                if (!node.isData()){
+                if (categoryType === Eagle.CategoryType.Data && !node.isData()){
+                    continue;
+                }
+
+                // skip nodes that are not application components
+                if (categoryType === Eagle.CategoryType.Application && !node.isApplication()){
+                    continue;
+                }
+
+                // skip nodes that are not group components
+                if (categoryType === Eagle.CategoryType.Group && !node.isGroup()){
                     continue;
                 }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1146,6 +1146,36 @@ export class Utils {
         return result;
     }
 
+    static getDataComponentsWithInputsAndOutputs(palettes: Palette[], numRequiredInputs: number, numRequiredOutputs: number) : Node[] {
+        console.log("getDataComponentsWithInputsAndOutputs");
+
+        const result: Node[] = [];
+
+        // add all data components (except ineligible)
+        for (const palette of palettes){
+            for (const node of palette.getNodes()){
+                // skip nodes that are not data components
+                if (!node.isData()){
+                    continue;
+                }
+
+                // if input ports required, skip nodes with too few
+                if (numRequiredInputs > node.maxInputs()){
+                    continue;
+                }
+
+                // if output ports required, skip nodes with too few
+                if (numRequiredOutputs > node.maxOutputs()){
+                    continue;
+                }
+
+                result.push(node);
+            }
+        }
+
+        return result;
+    }
+
     static getDataComponentMemory(palettes: Palette[]) : Node {
         console.log("getDataComponentMemory");
 


### PR DESCRIPTION
In this change, when the user drags an edge between two application nodes, the intermediate data node is always automatically created as a Memory node. It is then up to the user to click the "edit node category" button and choose a new category, if they want to use something else, like a File or Plasma component.

Previously, users would always be prompted immediately to decide what category of data component was required.

The list of possible categories to which an existing node can be changed, is limited to the same "category type". Applications components can only be changed into other applications, Data components can only be changed into other data components, and Constructs can only be changed into other constructs.