### PR TITLE
Eagle 808

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2468,23 +2468,6 @@ export class Eagle {
         }
     }
 
-    // TODO: remove if possible
-    getCurrentParamReadonly = (index: number) : boolean => {
-        if(Eagle.selectedLocation() === Eagle.FileType.Palette){
-            if(Eagle.allowPaletteEditing()){
-                return false;
-            }else{
-                return this.selectedNode().getFields()[index].isReadonly();
-            }
-        }else{
-            if(Eagle.allowComponentEditing()){
-                return false;
-            }else{
-                return this.selectedNode().getFields()[index].isReadonly();
-            }
-        }
-    }
-
     toggleSettingsTab = (btn:any, target:any) :void => {
         //deselect and deactivate current tab content and buttons
         $(".settingsModalButton").removeClass("settingCategoryBtnActive");
@@ -2518,34 +2501,6 @@ export class Eagle {
         }
 
         return null;
-    }
-
-    // TODO: maybe move to Field.ts
-    // TODO: add comments
-    // TODO: a "get" function probably should not alter state
-    // TODO: we need the logic for the boolean case, but otherwise, can remove?
-    getFieldType = (type:string, id:string, value:string) : string => {
-        const typePrefix = Utils.dataTypePrefix(type);
-
-        if (typePrefix === Eagle.DataType_Float || typePrefix === Eagle.DataType_Integer){
-            return "number"
-        }else if(type === Eagle.DataType_Boolean){
-            $("#"+id).addClass("form-check-input")
-            if (Utils.asBool(value)){
-                $("#"+id).addClass("inputChecked")
-                $("#"+id).html("Checked")
-            }else {
-                $("#"+id).removeClass("inputChecked")
-                $("#"+id).html("Check")
-            }
-            return "checkbox"
-        }else if(type === Eagle.DataType_Select){
-            return "select";
-        }else if(type === Eagle.DataType_Password){
-            return "password";
-        }else{
-            return "text"
-        }
     }
 
     static resetParamsTableSelection = ():void => {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2468,6 +2468,7 @@ export class Eagle {
         }
     }
 
+    // TODO: remove if possible
     getCurrentParamReadonly = (index: number) : boolean => {
         if(Eagle.selectedLocation() === Eagle.FileType.Palette){
             if(Eagle.allowPaletteEditing()){
@@ -2522,6 +2523,7 @@ export class Eagle {
     // TODO: maybe move to Field.ts
     // TODO: add comments
     // TODO: a "get" function probably should not alter state
+    // TODO: we need the logic for the boolean case, but otherwise, can remove?
     getFieldType = (type:string, id:string, value:string) : string => {
         const typePrefix = Utils.dataTypePrefix(type);
 

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -104,6 +104,23 @@ export class Field {
         this.readonly(readonly);
     }
 
+    // determine if this field is readonly given the current state of eagle
+    isEagleReadonly : ko.PureComputed<boolean> = ko.pureComputed(() => {
+        if(Eagle.selectedLocation() === Eagle.FileType.Palette){
+            if(Eagle.allowPaletteEditing()){
+                return false;
+            }else{
+                return this.isReadonly();
+            }
+        }else{
+            if(Eagle.allowComponentEditing()){
+                return false;
+            }else{
+                return this.isReadonly();
+            }
+        }
+    }, this);
+
     getType = () : string => {
         return this.type();
     }
@@ -111,6 +128,10 @@ export class Field {
     isType = (type: string) => {
         return this.type() === type;
     }
+
+    getTypePrefix : ko.PureComputed<string> = ko.pureComputed(() => {
+        return Utils.dataTypePrefix(this.type());
+    }, this);
 
     valIsTrue = (val:string) : boolean => {
         return Utils.asBool(val);
@@ -246,12 +267,34 @@ export class Field {
         return Config.DALIUGE_PARAMETER_NAMES.indexOf(this.idText()) > -1;
     }, this);
 
-    select = (selection:string, selectionName:string, readOnlyState:boolean, selectionParent:Field, selectionIndex:number, event:any) : void => {
-        Eagle.parameterTableSelectionName(selectionName);
-        Eagle.parameterTableSelectionParent(selectionParent);
-        Eagle.parameterTableSelectionParentIndex(selectionIndex);
-        Eagle.parameterTableSelection(selection);
-        Eagle.parameterTableSelectionReadonly(readOnlyState);
+    // TODO: rename select
+    select2 = (name: string, readOnly: boolean, parent: Field, index: number) : void => {
+        //console.log("select2", parent, parent instanceof Field, typeof parent);
+
+        Eagle.parameterTableSelectionName(name);
+        Eagle.parameterTableSelectionParent(parent);
+        Eagle.parameterTableSelectionParentIndex(index);
+        switch(name){
+            case 'value':
+            Eagle.parameterTableSelection(parent.value());
+            break;
+            case 'defaultValue':
+            Eagle.parameterTableSelection(parent.defaultValue());
+            break;
+            case 'description':
+            Eagle.parameterTableSelection(parent.description());
+            break;
+            case 'displayText':
+            Eagle.parameterTableSelection(parent.displayText());
+            break;
+            case 'idText':
+            Eagle.parameterTableSelection(parent.idText());
+            break;
+            default:
+            console.warn("Field.select(): unknown name:", name);
+            break;
+        }
+        Eagle.parameterTableSelectionReadonly(readOnly);
     }
 
     // used to transform the value attribute of a field into a variable with the correct type

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -126,12 +126,8 @@ export class Field {
     }
 
     isType = (type: string) => {
-        return this.type() === type;
+        return Utils.dataTypePrefix(this.type()) === type;
     }
-
-    getTypePrefix : ko.PureComputed<string> = ko.pureComputed(() => {
-        return Utils.dataTypePrefix(this.type());
-    }, this);
 
     valIsTrue = (val:string) : boolean => {
         return Utils.asBool(val);
@@ -267,10 +263,7 @@ export class Field {
         return Config.DALIUGE_PARAMETER_NAMES.indexOf(this.idText()) > -1;
     }, this);
 
-    // TODO: rename select
-    select2 = (name: string, readOnly: boolean, parent: Field, index: number) : void => {
-        //console.log("select2", parent, parent instanceof Field, typeof parent);
-
+    select = (name: string, readOnly: boolean, parent: Field, index: number) : void => {
         Eagle.parameterTableSelectionName(name);
         Eagle.parameterTableSelectionParent(parent);
         Eagle.parameterTableSelectionParentIndex(index);

--- a/static/components/field.html
+++ b/static/components/field.html
@@ -4,22 +4,26 @@
         <span class="input-group-text" id="group-addon" data-bind="text: $data.displayText, eagleTooltip: $data.getDescriptionText()" data-bs-placement="left"></span>
     </div>
 
-    <!-- ko if: !isType(Eagle.DataType_Boolean) && !isType(Eagle.DataType_Select) -->
-    <input class="form-control" placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()), id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
-    <!-- /ko -->
-
     <!-- ko if: isType(Eagle.DataType_Boolean) -->
     <div class="form-control checkboxParent">
-        <input class="inspectorCheckbox form-check-input btn-check" placeholder="" aria-label="Label" onclick="$(this).val(this.checked ? true : false)" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, checked: valIsTrue($data.value()), valueUpdate: ['afterkeydown', 'input'], disabled: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()), id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();$root.checkGraph();}}, eagleTooltip: getFieldValue()">
-        <label class="btn btn-outline-primary" data-bind="attr:{for: $data.fieldType() + $index()}, html: $data.value() "></label><br>
+        <input class="inspectorCheckbox form-check-input btn-check" type="checkbox" placeholder="" aria-label="Label" onclick="$(this).val(this.checked ? true : false)" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, checked: valIsTrue($data.value()), disabled: isEagleReadonly, attr: {id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();$root.checkGraph();}}, eagleTooltip: getFieldValue()">
+        <label class="btn btn-outline-primary" data-bind="attr:{for: $data.fieldType() + $index()}, html: $data.value()"></label><br>
     </div>
     <!-- /ko -->
 
     <!-- ko if: isType(Eagle.DataType_Select) -->
     <div class="form-control">
-        <select class="form-select" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="disabled: function(){return $root.getCurrentParamReadonly($index(),$data.fieldType())}, attr: {type: $root.getFieldType(getType(), 'nodeInspectorFieldValue' + $index(), $data.value()), id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue(), options: $data.options, value: $data.value">
+        <select class="form-select" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="disabled: isEagleReadonly, attr: {id: 'nodeInspectorFieldValue' + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue(), options: $data.options, value: $data.value">
         </select>
     </div>
+    <!-- /ko -->
+
+    <!-- ko if: isType(Eagle.DataType_Integer) || isType(Eagle.DataType_Float) -->
+    <input class="form-control" type="number" placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: isEagleReadonly, attr: {id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
+    <!-- /ko -->
+
+    <!-- ko if: !isType(Eagle.DataType_Boolean) && !isType(Eagle.DataType_Select) && !isType(Eagle.DataType_Integer) && !isType(Eagle.DataType_Float)-->
+    <input class="form-control" type="text" placeholder="" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="value: $data.value, valueUpdate: ['afterkeydown', 'input'], readonly: isEagleReadonly, attr: {id: $data.fieldType() + $index()}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, eagleTooltip: getFieldValue()">
     <!-- /ko -->
 
     <!-- ko ifnot: $root.selectedNode().isLocked() -->

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -629,20 +629,47 @@
                         </tr>
                         </thead>
                             <tbody data-bind="foreach: $root.selectedNode().getFields()">
-                            <!-- ko if: $data.fitsTableSearchQuery() -->
-                                <!-- ko if: !$data.isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
+                            <!-- ko if: fitsTableSearchQuery() -->
+                                <!-- ko if: !isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
                                 <tr>
-                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'displayText' }"><input class="tableParameter" type="string" data-bind="value: displayText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.displayText(), 'displayText', $root.selectedNode().isLocked(), $data, $index(), event)}, event:{keyup: function(event, data){select($data.displayText(), 'displayText', $root.selectedNode().isLocked(), $data, $index(), event)}}"></td>
-                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'idText' }"><input class="tableParameter" type="string" data-bind="value: idText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.idText(), 'idText', $root.selectedNode().isLocked(), $data, $index(), event)}, event:{keyup: function(event, data){select($data.idText(), 'idText', $root.selectedNode().isLocked(), $data, $index(), event)}}"></td>
+                                    <!-- DISPLAY TEXT -->
+                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'displayText' }"><input class="tableParameter" type="string" data-bind="value: displayText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('displayText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('displayText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
 
-                                    <!-- value fields -->
-                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'password' -->
-                                        <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), readonly: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.value(), 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}, click: function(event, data){select($data.value(), 'value', $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), $data, $index(),event)}}"></td>
-                                    <!-- /ko -->
-                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'checkbox' -->
-                                    <td><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+                                    <!-- ID TEXT -->
+                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'idText' }"><input class="tableParameter" type="string" data-bind="value: idText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('idText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('idText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
+
+                                    <!-- VALUE -->
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Integer || getTypePrefix() === Eagle.DataType_Float -->
+                                        <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() !== null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
+                                            <input class="tableParameter" type="number" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                        </td>
                                     <!-- /ko -->
 
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Password -->
+                                        <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
+                                            <input class="tableParameter" type="password" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Boolean -->
+                                        <td>
+                                            <input class="tableParameter" type="checkbox" data-bind="checked: valIsTrue(value()), disabled: isEagleReadonly, value: value, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Select -->
+                                        <td>
+                                            <input class="tableParameter" type="text" data-bind="disabled: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() !== Eagle.DataType_Integer && getTypePrefix() !== Eagle.DataType_Float && getTypePrefix() !== Eagle.DataType_Password && getTypePrefix() !== Eagle.DataType_Boolean && getTypePrefix() !== Eagle.DataType_Select -->
+                                        <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
+                                            <input class="tableParameter" type="text" data-bind="readonly: isEagleReadonly(), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- READ ONLY -->
                                     <!-- ko ifnot: $root.selectedNode().isLocked() -->
                                         <td><input class="tableParameter" data-bind="checked: readonly, disabled: $root.selectedNode().isLocked(), event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr: {type: 'checkbox'}"></td>
                                     <!-- /ko -->
@@ -655,38 +682,69 @@
                                         <!-- /ko -->
                                     <!-- /ko -->
 
-                                    <!-- default value fields -->
-                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'number' || $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'text' || $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'password' -->
-                                        <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }"><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select($data.defaultValue(), 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}, click: function(event, data){select($data.defaultValue(), 'defaultValue', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
-                                    <!-- /ko -->
-                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'checkbox' -->
-                                        <td><input class="tableParameter" onclick="$(this).val(this.checked ? true : false)" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                    <!-- /ko -->
-
-                                    <!-- selection input -->
-                                    <!-- ko if: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value()) === 'select' -->
-                                        <td><input class="tableParameter" data-bind="checked: valIsTrue($data.value()), disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.value())},  event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
-                                        <td><input class="tableParameter" data-bind="checked: valIsTrue($data.defaultValue()), disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $root.getFieldType(getType(), $data.fieldType() + $index(), $data.defaultValue())}, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+                                    <!-- DEFAULT VALUE -->
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Integer || getTypePrefix() === Eagle.DataType_Float -->
+                                        <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
+                                            <input class="tableParameter" type="number" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                        </td>
                                     <!-- /ko -->
 
-                                    <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'description' }"><input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select($data.description(), 'description', $root.selectedNode().isLocked(), $data, $index(),event)}, event:{keyup: function(event, data){select($data.description(), 'description', $root.selectedNode().isLocked(), $data, $index(),event)}}"></td>
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Password -->
+                                        <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
+                                            <input class="tableParameter" type="password" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Boolean -->
+                                        <td>
+                                            <input class="tableParameter" type="checkbox" data-bind="checked: valIsTrue(defaultValue()), disabled: $root.selectedNode().isLocked(), value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Select -->
+                                        <td>
+                                            <input class="tableParameter" type="text" data-bind="disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
+                                        </td>
+                                    <!-- /ko -->
+
+                                    <!-- ko if: getTypePrefix() !== Eagle.DataType_Integer && getTypePrefix() !== Eagle.DataType_Float && getTypePrefix() !== Eagle.DataType_Password && getTypePrefix() !== Eagle.DataType_Boolean && getTypePrefix() !== Eagle.DataType_Select -->
+                                        <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
+                                            <input class="tableParameter" type="text" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                        </td>
+                                    <!-- /ko -->
+
+
+                                    <!-- DESCRIPTION -->
+                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'description' }">
+                                        <input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('description', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('description', $root.selectedNode().isLocked(), $root.selectedNode().isLocked(), $data, $index())}}">
+                                    </td>
+
+                                    <!-- TYPE -->
                                     <td>
-                                        <select data-bind="html: $root.fillParametersTable($data.type()), value: type, disabled: $root.selectedNode().isLocked()">
+                                        <select data-bind="html: $root.fillParametersTable(type()), value: type, disabled: $root.selectedNode().isLocked()">
                                         <!-- options are added dynamically -->
                                         </select>
                                     </td>
+
+                                    <!-- USES AS -->
                                     <td>
-                                        <select data-bind="html: $root.selectedNode().fillFieldTypeCell($data.fieldType()), value: fieldType, disabled: $root.selectedNode().isLocked()">
+                                        <select data-bind="html: $root.selectedNode().fillFieldTypeCell(fieldType()), value: fieldType, disabled: $root.selectedNode().isLocked()">
                                             <!-- options are added dynamically -->
                                         </select>
                                     </td>
-                                    <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: precious, valueUpdate: ['afterkeydown', 'input'], event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
-                                    <td><input class="tableParameter" data-bind="disabled: $root.selectedNode().isLocked(), checked: positional, event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr:{ type: 'checkbox'}"></td>
+
+                                    <!-- PRECIOUS -->
+                                    <td><input class="tableParameter" type="checkbox" data-bind="disabled: $root.selectedNode().isLocked(), checked: precious, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+
+                                    <!-- POSITIONAL -->
+                                    <td><input class="tableParameter" type="checkbox" data-bind="disabled: $root.selectedNode().isLocked(), checked: positional, event: {change: function(){$root.selectedObjects.valueHasMutated();}}"></td>
+
+                                    <!-- ACTIONS -->
                                     <td>
-                                        <button class="edit" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.editField(null, 'Field', Eagle.FieldType.Unknown, $index());}, disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), eagleTooltip:'Edit'"><i class="material-icons">edit</i></button>
-                                        <button class="resetDefaults" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$data.resetToDefault();$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown), eagleTooltip:'Reset To Default'"><i class="material-icons">upload_file</i></button>
-                                        <button class="duplicate" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.duplicateParameter($index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Duplicate'"><i class="material-icons">content_copy</i></button>
-                                        <button class="delete" onclick="$(this).val(this.checked ? true : false)" data-bind="click: function(){$root.removeParamFromNodeByIndex($root.selectedNode(), $index());}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
+                                        <button class="edit" data-bind="click: function(){$root.editField(null, 'Field', Eagle.FieldType.Unknown, $index());}, disabled: isEagleReadonly, eagleTooltip:'Edit'"><i class="material-icons">edit</i></button>
+                                        <button class="resetDefaults" data-bind="click: function(){resetToDefault();$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: isEagleReadonly, eagleTooltip:'Reset To Default'"><i class="material-icons">upload_file</i></button>
+                                        <button class="duplicate" data-bind="click: function(){$root.duplicateParameter($index());$root.selectedObjects.valueHasMutated();$root.flagActiveFileModified();}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Duplicate'"><i class="material-icons">content_copy</i></button>
+                                        <button class="delete" data-bind="click: function(){$root.removeParamFromNodeByIndex($root.selectedNode(), $index());}, disabled: $root.selectedNode().isLocked(), eagleTooltip:'Remove parameter'"><i class="material-icons md-24">delete</i></button>
                                     </td>
                                 </tr>
                                 <!-- /ko -->

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -633,39 +633,39 @@
                                 <!-- ko if: !isDaliugeField() || Eagle.showDaliugeRuntimeParameters() -->
                                 <tr>
                                     <!-- DISPLAY TEXT -->
-                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'displayText' }"><input class="tableParameter" type="string" data-bind="value: displayText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('displayText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('displayText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
+                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'displayText' }"><input class="tableParameter" type="string" data-bind="value: displayText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select('displayText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select('displayText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
 
                                     <!-- ID TEXT -->
-                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'idText' }"><input class="tableParameter" type="string" data-bind="value: idText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('idText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('idText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
+                                    <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'idText' }"><input class="tableParameter" type="string" data-bind="value: idText, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select('idText', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select('idText', $root.selectedNode().isLocked(), $data, $index())}}"></td>
 
                                     <!-- VALUE -->
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Integer || getTypePrefix() === Eagle.DataType_Float -->
+                                    <!-- ko if: isType(Eagle.DataType_Integer) || isType(Eagle.DataType_Float) -->
                                         <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() !== null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
-                                            <input class="tableParameter" type="number" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                            <input class="tableParameter" type="number" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select('value', isEagleReadonly(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Password -->
+                                    <!-- ko if: isType(Eagle.DataType_Password) -->
                                         <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
-                                            <input class="tableParameter" type="password" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                            <input class="tableParameter" type="password" data-bind="readonly: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select('value', isEagleReadonly(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Boolean -->
+                                    <!-- ko if: isType(Eagle.DataType_Boolean) -->
                                         <td>
                                             <input class="tableParameter" type="checkbox" data-bind="checked: valIsTrue(value()), disabled: isEagleReadonly, value: value, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Select -->
+                                    <!-- ko if: isType(Eagle.DataType_Select) -->
                                         <td>
                                             <input class="tableParameter" type="text" data-bind="disabled: isEagleReadonly, valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() !== Eagle.DataType_Integer && getTypePrefix() !== Eagle.DataType_Float && getTypePrefix() !== Eagle.DataType_Password && getTypePrefix() !== Eagle.DataType_Boolean && getTypePrefix() !== Eagle.DataType_Select -->
+                                    <!-- ko if: !isType(Eagle.DataType_Integer) && !isType(Eagle.DataType_Float) && !isType(Eagle.DataType_Password) && !isType(Eagle.DataType_Boolean) && !isType(Eagle.DataType_Select) -->
                                         <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'value' }">
-                                            <input class="tableParameter" type="text" data-bind="readonly: isEagleReadonly(), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select2('value', isEagleReadonly(), $data, $index())}}">
+                                            <input class="tableParameter" type="text" data-bind="readonly: isEagleReadonly(), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('value', isEagleReadonly(), $data, $index())}, click: function(event, data){select('value', isEagleReadonly(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
@@ -674,49 +674,49 @@
                                         <td><input class="tableParameter" data-bind="checked: readonly, disabled: $root.selectedNode().isLocked(), event: {change: function(){$root.selectedObjects.valueHasMutated();}}, attr: {type: 'checkbox'}"></td>
                                     <!-- /ko -->
                                     <!-- ko if: $root.selectedNode().isLocked() -->
-                                        <!-- ko if: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
+                                        <!-- ko if: isEagleReadonly -->
                                             <td><i class="material-icons md-20" data-bind="eagleTooltip: $root.getReadOnlyText">lock</i></td>
                                         <!-- /ko -->
-                                        <!-- ko ifnot: $root.getCurrentParamReadonly($index(),Eagle.FieldType.Unknown) -->
+                                        <!-- ko ifnot: isEagleReadonly -->
                                             <td><i class="material-icons md-20" data-bind="eagleTooltip: 'value is readwrite'">lock_open</i></td>
                                         <!-- /ko -->
                                     <!-- /ko -->
 
                                     <!-- DEFAULT VALUE -->
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Integer || getTypePrefix() === Eagle.DataType_Float -->
+                                    <!-- ko if: isType(Eagle.DataType_Integer) || isType(Eagle.DataType_Float) -->
                                         <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
-                                            <input class="tableParameter" type="number" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                            <input class="tableParameter" type="number" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Password -->
+                                    <!-- ko if: isType(Eagle.DataType_Password) -->
                                         <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
-                                            <input class="tableParameter" type="password" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                            <input class="tableParameter" type="password" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Boolean -->
+                                    <!-- ko if: isType(Eagle.DataType_Boolean) -->
                                         <td>
                                             <input class="tableParameter" type="checkbox" data-bind="checked: valIsTrue(defaultValue()), disabled: $root.selectedNode().isLocked(), value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() === Eagle.DataType_Select -->
+                                    <!-- ko if: isType(Eagle.DataType_Select) -->
                                         <td>
                                             <input class="tableParameter" type="text" data-bind="disabled: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated();}}">
                                         </td>
                                     <!-- /ko -->
 
-                                    <!-- ko if: getTypePrefix() !== Eagle.DataType_Integer && getTypePrefix() !== Eagle.DataType_Float && getTypePrefix() !== Eagle.DataType_Password && getTypePrefix() !== Eagle.DataType_Boolean && getTypePrefix() !== Eagle.DataType_Select -->
+                                    <!-- ko if: !isType(Eagle.DataType_Integer) && !isType(Eagle.DataType_Float) && !isType(Eagle.DataType_Password) && !isType(Eagle.DataType_Boolean) && !isType(Eagle.DataType_Select) -->
                                         <td data-bind=" css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'defaultValue' }">
-                                            <input class="tableParameter" type="text" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select2('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
+                                            <input class="tableParameter" type="text" data-bind="readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, event: {change: function(){$root.selectedObjects.valueHasMutated()}, keyup: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}, click: function(event, data){select('defaultValue', $root.selectedNode().isLocked(), $data, $index())}}">
                                         </td>
                                     <!-- /ko -->
 
 
                                     <!-- DESCRIPTION -->
                                     <td data-bind="css: { selectedTableParameter: Eagle.parameterTableSelection() != null && $data == Eagle.parameterTableSelectionParent() && Eagle.parameterTableSelectionName() == 'description' }">
-                                        <input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select2('description', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select2('description', $root.selectedNode().isLocked(), $root.selectedNode().isLocked(), $data, $index())}}">
+                                        <input class="tableParameter" type="string" data-bind="value: description, readonly: $root.selectedNode().isLocked(), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){select('description', $root.selectedNode().isLocked(), $data, $index())}, event:{keyup: function(event, data){select('description', $root.selectedNode().isLocked(), $root.selectedNode().isLocked(), $data, $index())}}">
                                     </td>
 
                                     <!-- TYPE -->


### PR DESCRIPTION
Fixes the issue with the "read-only" and "value" columns appearing in the wrong order in the parameters table.

Also I cleaned up the HTML for the parameters table to remove a few things that weren't used (I hope).

I'm most concerned about removing the getFieldType() function from Eagle.ts. I think we don't need the main result of this function any more, but it also added the "form-check-input" and "inputChecked" classes, as well as setting some html. This seems likely to have broken something that you worked on. Maybe we can talk about it on Thursday.