### PR TITLE
Eagle 814

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -356,7 +356,7 @@ export class Eagle {
         console.log('srcNode', p1x, p1y, 'destNode',p2x, p2y)
         $('#nodeList .col').append('<div class="positionPointer" style="width:5px; height:5px;position:absolute;background-color:red;z-index:1000000;top:'+p1y+'px;left:'+p1x+'px;"></div>')
         $('#nodeList .col').append('<div class="positionPointer" style="width:5px; height:5px;position:absolute;background-color:blue;z-index:1000000;top:'+p2y+'px;left:'+p2x+'px;"></div>')
-        
+
         return
 
         // mid-point of line:
@@ -3330,6 +3330,7 @@ export class Eagle {
     /**
      * Adds an field to the selected node via HTML.
      */
+    // TODO: are these still used?
     addFieldHTML = () : void => {
         const node: Node = this.selectedNode();
 
@@ -3348,6 +3349,7 @@ export class Eagle {
     /**
      * Adds an application param to the selected node via HTML.
      */
+    // TODO: are these still used?
     addApplicationArgHTML = () : void => {
         const node: Node = this.selectedNode();
 
@@ -3410,6 +3412,8 @@ export class Eagle {
         }, 100);
     }
 
+    // TODO: this is a bit difficult to understand, it seems like it is piggy-backing
+    // an old UI that is no longer used, perhaps we should just call Eagle.editField(..., 'Add', ...)
     nodeInspectorDropdownClick = (val:number, num:number, divID:string) : void => {
         let selectSectionID;
         let modalID;
@@ -3429,8 +3433,13 @@ export class Eagle {
             $("#"+divID).hide();
             $("#"+selectSectionID).val(val).trigger('change');
             $("#"+modalID).addClass("nodeSelected");
+
+            // triggers the 'add application argument' modal to show
             $("#"+modalID).removeClass("forceHide");
+
+            // triggers the modal 'lightbox' to show
             $(".modal-backdrop").removeClass("forceHide");
+
         }else{
             $("#"+selectSectionID).val(val).trigger('change');
             $("#"+modalID).addClass("nodeSelected");
@@ -3968,6 +3977,29 @@ export class Eagle {
             for (const node of palette.getNodes()){
                 tableData.push({"palette":palette.fileInfo().name, "name":node.getName(), "key":node.getKey(), "id":node.getId(), "embedKey":node.getEmbedKey(), "category":node.getCategory()});
             }
+        }
+
+        console.table(tableData);
+    }
+
+    printNodeFieldsTable = (nodeIndex: number) : void => {
+        const tableData : any[] = [];
+
+        // check that node at nodeIndex exists
+        if (nodeIndex >= this.logicalGraph().getNumNodes()){
+            console.warn("Unable to print node fields table, node", nodeIndex, "does not exist.");
+            return;
+        }
+
+        // add logical graph nodes to table
+        for (const field of this.logicalGraph().getNodes()[nodeIndex].getFields()){
+            tableData.push({
+                "id":field.getId(),
+                "idText":field.getIdText(),
+                "displayText":field.getDisplayText(),
+                "type":field.getType(),
+                "fieldType":field.getFieldType()
+            });
         }
 
         console.table(tableData);
@@ -4640,7 +4672,7 @@ export class Eagle {
         if (srcNode.getParentKey() === destNode.getKey()){
             newNode.setParentKey(destNode.getKey());
         }
-        
+
          // if dest node is a child of source node, make the new node a child too
         if (destNode.getParentKey() === srcNode.getKey()){
             newNode.setParentKey(srcNode.getKey());
@@ -4649,7 +4681,7 @@ export class Eagle {
         // create TWO edges, one from src to data component, one from data component to dest
         const firstEdge : Edge = new Edge(srcNode.getKey(), srcPort.getId(), newNodeKey, newInputPort.getId(), srcPort.getType(), loopAware, closesLoop, false);
         const secondEdge : Edge = new Edge(newNodeKey, newOutputPort.getId(), destNode.getKey(), destPort.getId(), destPort.getType(), loopAware, closesLoop,false);
-       
+
         this.logicalGraph().addEdgeComplete(firstEdge);
         this.logicalGraph().addEdgeComplete(secondEdge);
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -245,19 +245,23 @@ export class Edge {
         }
 
         if (sourcePortId === ""){
-            return Eagle.LinkValid.Unknown;
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, "source port has no id", "danger", showNotification, showConsole, errors, warnings);
+            return Eagle.LinkValid.Invalid;
         }
 
         if (destinationPortId === ""){
-            return Eagle.LinkValid.Unknown;
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, "destination port has no id", "danger", showNotification, showConsole, errors, warnings);
+            return Eagle.LinkValid.Invalid;
         }
 
         if (sourcePortId === null){
-            return Eagle.LinkValid.Unknown;
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, "source port id is null", "danger", showNotification, showConsole, errors, warnings);
+            return Eagle.LinkValid.Invalid;
         }
 
         if (destinationPortId === null){
-            return Eagle.LinkValid.Unknown;
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, "destination port id is null", "danger", showNotification, showConsole, errors, warnings);
+            return Eagle.LinkValid.Invalid;
         }
 
         // get references to actual source and destination nodes (from the keys)

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -280,8 +280,7 @@ export class Modals {
             }
 
             // extract field data from HTML elements
-            //const id : string = $('#editFieldModalIdInput').val().toString();
-            const id : string = "";
+            const id : string = Utils.uuidv4();
             const idText : string = $('#editFieldModalIdTextInput').val().toString();
             const displayText : string = $('#editFieldModalDisplayTextInput').val().toString();
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1564,6 +1564,15 @@ export class Utils {
             }
         }
 
+        // check that all fields have ids
+        for (const node of graph.getNodes()){
+            for (const field of node.getFields()){
+                if (field.getId() === "" || field.getId() === null){
+                    errors.push("Node " + node.getKey() + " (" + node.getName() + ") has field (" + field.getDisplayText() + ") with no id");
+                }
+            }
+        }
+
         // check that all fields have default values
         for (const node of graph.getNodes()){
             for (const field of node.getFields()){

--- a/src/bindingHandlers/graphRenderer.ts
+++ b/src/bindingHandlers/graphRenderer.ts
@@ -3539,6 +3539,11 @@ function render(graph: LogicalGraph, elementId : string, eagle : Eagle){
                     continue;
                 }
 
+                // if port has no id (broken) then don't consider it as a auto-complete target
+                if (port.getId() === ""){
+                    continue;
+                }
+
                 // get position of port
                 const portX = node.getPosition().x;
                 const portY = node.getPosition().y;


### PR DESCRIPTION
Fixing two bugs:
1. When adding a new application argument, via the '+' button and 'custom' option. The new field would have an id equal to the empty string.
2. An edge could be dragged to a port with an empty id. If multiple ports on the node had empty ids, then the renderer could not determine which was the correct port, and would just choose the first.

The solution to part 1 was to add the id when creating a new application argument. The code here has a bit of technical debt, so I added some TODO comments. Also, I added a Eagle.printNodeFieldsTable() function to easily print the status of all fields on a node.

For part 2, I modified the edge drag auto-complete so that it would not suggest ports with empty ids. Also, modified the Edge.isValid function to judge edges between ports with no ids as invalid. So normal users will not be able to draw them. Expert users (with "Allow invalid edges" setting set to true) will still be able to draw those edges. Finally, I modified Utils.checkGraph() to produce an error if a field has no id

I've checked that this doesn't break:
- adding fields from the parameter table
- editing existing fields from the inspector + modal
- adding component parameters from the inspector

It seems to be OK, but if you could take a look at those things and anything else you can think of, that would be a great help. Thanks.