### PR TITLE
Added check of hasSelection to tableInspectorUpdateSelection

### DIFF
--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -37,6 +37,11 @@ export class ParameterTable {
     }
 
     tableInspectorUpdateSelection = (value:string) : void => {
+        // abort update if nothing is selected
+        if (!ParameterTable.hasSelection()){
+            return;
+        }
+
         const selected = ParameterTable.selectionName()
         const selectedForm = ParameterTable.selectionParent()
         if(selected === 'displayText'){


### PR DESCRIPTION
I found the reason for the last selected cell in the Parameter Table being deleted when we unselect and reselect a node.

The function ParameterTable.tableInspectorUpdateSelection was being called. I'm not sure why it was being called, it seems like it should only be called on "keyup" events within the #tableInspectorValue element, but it also gets called when a node is selected.

The value passed to tableInspectorUpdateSelection was an empty string.

So, I've done a sort of minimal fix where the function will be aborted if the hasSelection() check fails.