### PR TITLE
Removed autoload of 'Graph Components' palette at startup. These are …

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -23,9 +23,6 @@
 */
 
 export class Config {
-    // File name of the palette template.
-    static readonly templatePaletteFileName : string = "template.palette";
-
     // Dimensions.
     static readonly paletteNodeHeight : number = 22;
     static readonly paletteNodeWidth : number = 130;

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,7 +109,6 @@ $(function(){
     if (Setting.findValue(Utils.OPEN_DEFAULT_PALETTE)){
         eagle.loadPalettes([
             {name:"Builtin Components", filename:Config.DALIUGE_PALETTE_URL, readonly:true},
-            {name:"Graph Components", filename:window.location.origin + "/static/" + Config.templatePaletteFileName, readonly:true},
             {name:Palette.DYNAMIC_PALETTE_NAME, filename:Config.DALIUGE_TEMPLATE_URL, readonly:true}
         ], (palettes: Palette[]):void => {
             for (const palette of palettes){


### PR DESCRIPTION
…built into the 'template' palette now.