### PR TITLE
Moved 'change selected node parent' and 'change selected node subject…

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -17,8 +17,8 @@ export class Errors {
 
     static fixAll = () : void => {
         const eagle: Eagle = Eagle.getInstance();
-
-        console.log("fixAll()");
+        const initialNumWarnings = eagle.graphWarnings().length;
+        const initialNumErrors = eagle.graphErrors().length;
         let numErrors   = Infinity;
         let numWarnings = Infinity;
         let numIterations = 0;
@@ -47,6 +47,9 @@ export class Errors {
 
             eagle.checkGraph();
         }
+
+        // show notification
+        Utils.showNotification("Fix All Graph Errors", initialNumErrors + " error(s), " + numErrors + " remain. " + initialNumWarnings + " warning(s), " + numWarnings + " remain.", "info");
 
         Utils.postFixFunc(eagle);
     }

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -1,6 +1,7 @@
 import {Eagle} from './Eagle';
 import {Category} from './Category';
 import {Utils} from './Utils';
+import {Errors} from './Errors';
 
 export class KeyboardShortcut {
     key: string;
@@ -150,8 +151,8 @@ export class KeyboardShortcut {
             new KeyboardShortcut("duplicate_selection", "Duplicate Selection", ["d"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.somethingIsSelected, (eagle): void => {eagle.duplicateSelection('normal');}),
             new KeyboardShortcut("create_subgraph_from_selection", "Create subgraph from selection", ["["], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.somethingIsSelected, (eagle): void => {eagle.createSubgraphFromSelection();}),
             new KeyboardShortcut("create_construct_from_selection", "Create construct from selection", ["]"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.somethingIsSelected, (eagle): void => {eagle.createConstructFromSelection();}),
-            new KeyboardShortcut("change_selected_node_parent", "Change Selected Node Parent", ["f"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.nodeIsSelected, (eagle): void => {eagle.changeNodeParent();}),
-            new KeyboardShortcut("change_selected_node_subject", "Change Selected Node Subject", ["f"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.commentNodeIsSelected, (eagle): void => {eagle.changeNodeSubject();}),
+            new KeyboardShortcut("change_selected_node_parent", "Change Selected Node Parent", ["u"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.nodeIsSelected, (eagle): void => {eagle.changeNodeParent();}),
+            new KeyboardShortcut("change_selected_node_subject", "Change Selected Node Subject", ["u"], "keydown", KeyboardShortcut.Modifier.Shift, KeyboardShortcut.Display.Enabled, KeyboardShortcut.commentNodeIsSelected, (eagle): void => {eagle.changeNodeSubject();}),
             new KeyboardShortcut("add_edge","Add Edge", ["e"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.addEdgeToLogicalGraph();}),
             new KeyboardShortcut("modify_selected_edge","Modify Selected Edge", ["m"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.edgeIsSelected, (eagle): void => {eagle.editSelectedEdge();}),
             new KeyboardShortcut("center_graph", "Center graph", ["c"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => {eagle.centerGraph();}),
@@ -183,6 +184,7 @@ export class KeyboardShortcut {
             new KeyboardShortcut("paste_to_graph", "Paste to graph", ["v"], "keydown", KeyboardShortcut.Modifier.Ctrl, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => { eagle.pasteFromClipboard(); }),
             new KeyboardShortcut("select_all_in_graph", "Select all in graph", ["a"], "keydown", KeyboardShortcut.Modifier.Ctrl, KeyboardShortcut.Display.Enabled, KeyboardShortcut.graphNotEmpty, (eagle): void => { eagle.selectAllInGraph(); }),
             new KeyboardShortcut("select_none_in_graph", "Select none in graph", ["Escape"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.somethingIsSelected, (eagle): void => { eagle.selectNoneInGraph(); }),
+            new KeyboardShortcut("fix_all", "Fix all errors in graph", ["f"], "keydown", KeyboardShortcut.Modifier.None, KeyboardShortcut.Display.Enabled, KeyboardShortcut.true, (eagle): void => { Errors.fixAll(); }),
         ];
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1721,17 +1721,11 @@ export class Utils {
     }
 
     static getShortcutDisplay = () : {description:string, shortcut : string,function:string}[] => {
-        const eagle: Eagle = Eagle.getInstance();
         const displayShorcuts : {description:string, shortcut : string, function : any} []=[];
 
         for (const object of Eagle.shortcuts){
             // skip if shortcut should not be displayed
             if (object.display === KeyboardShortcut.Display.Disabled){
-                continue;
-            }
-
-            // skip if shortcut can not be run in the current state
-            if (!object.canRun(eagle)){
                 continue;
             }
 

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -16,77 +16,6 @@
     </div>
 </div>
 
-<!-- Errors Modal -->
-<div class="modal fade" id="errorsModal" tabindex="-1" role="dialog" aria-labelledby="errorsModalTitle" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="errorsModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class='accordion' id='errorsModalAccordion'>
-
-                    <div class="accordion-item" id="errorsModalErrorsAccordionItem">
-                        <h2 class="accordion-header" id="checkGraphAccordionHeadingOne">
-                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors&nbsp;<span id="errorsModalErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
-                        </h2>
-                        <div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">
-                            <div class="accordion-body" id="errorsModalErrorsAccordionBody">
-                                <ul class="list-group">
-                                <!-- ko foreach: Errors.getErrors -->
-                                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                                        <span data-bind="text: $data.message"></span>
-                                        <div>
-                                        <!-- ko if: $data.show !== null -->
-                                            <button class="btn btn-secondary btn-sm" data-bind="click: $data.show, eagleTooltip: 'Show object to investigate error'">Show</button>
-                                        <!-- /ko -->
-                                        <!-- ko if: $data.fix !== null -->
-                                            <button class="btn btn-primary btn-sm" data-bind="click: function(){Utils.callFixFunc(eagle, $data.fix);}, eagleTooltip: $data.fixDescription">Fix</button>
-                                        <!-- /ko -->
-                                        </div>
-                                    </li>
-                                <!-- /ko -->
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="accordion-item" id="errorsModalWarningsAccordionItem">
-                        <h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">
-                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings&nbsp;<span id="errorsModalWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
-                        </h2>
-                        <div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">
-                            <div class="accordion-body" id="errorsModalWarningsAccordionBody">
-                                <ul class="list-group">
-                                <!-- ko foreach: Errors.getWarnings -->
-                                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                                        <span data-bind="text: $data.message"></span>
-                                        <div>
-                                        <!-- ko if: $data.show !== null -->
-                                            <button class="btn btn-secondary btn-sm" data-bind="click: function($data){$root.checkErrorModalShowError($data)}, eagleTooltip: 'Show object to investigate warning'">Show</button>
-                                        <!-- /ko -->
-                                        <!-- ko if: $data.fix !== null -->
-                                            <button class="btn btn-primary btn-sm" data-bind="click: function(){Utils.callFixFunc(eagle, $data.fix);}, eagleTooltip: $data.fixDescription">Fix</button>
-                                        <!-- /ko -->
-                                        </div>
-                                    </li>
-                                <!-- /ko -->
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-            </div>
-            <div class="modal-footer" style="justify-content: space-between;">
-                <button class="btn btn-primary" data-bind="click: Errors.fixAll, disable: Errors.getNumFixableIssues() === 0, eagleTooltip: Errors.getNumFixableIssues() + ' fix(es) available'">Fix All</button>
-                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <!-- Request User Input Modal -->
 <div class="modal fade" id="inputModal" tabindex="-1" role="dialog" aria-labelledby="inputModalTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
@@ -358,6 +287,7 @@
     </div>
 </div>
 
+{% include 'modals/errors.html' %}
 
 {% include 'modals/settings.html' %}
 {% include 'modals/shortcuts.html' %}

--- a/templates/modals/errors.html
+++ b/templates/modals/errors.html
@@ -1,0 +1,72 @@
+<!-- Errors Modal -->
+<div class="modal fade" id="errorsModal" tabindex="-1" role="dialog" aria-labelledby="errorsModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="errorsModalTitle">Title</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class='accordion' id='errorsModalAccordion'>
+
+                    <div class="accordion-item" id="errorsModalErrorsAccordionItem">
+                        <h2 class="accordion-header" id="checkGraphAccordionHeadingOne">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors&nbsp;<span id="errorsModalErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
+                        </h2>
+                        <div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">
+                            <div class="accordion-body" id="errorsModalErrorsAccordionBody">
+                                <ul class="list-group">
+                                <!-- ko foreach: Errors.getErrors -->
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span data-bind="text: $data.message"></span>
+                                        <div>
+                                        <!-- ko if: $data.show !== null -->
+                                            <button class="btn btn-secondary btn-sm" data-bind="click: $data.show, eagleTooltip: 'Show object to investigate error'">Show</button>
+                                        <!-- /ko -->
+                                        <!-- ko if: $data.fix !== null -->
+                                            <button class="btn btn-primary btn-sm" data-bind="click: function(){Utils.callFixFunc(eagle, $data.fix);}, eagleTooltip: $data.fixDescription">Fix</button>
+                                        <!-- /ko -->
+                                        </div>
+                                    </li>
+                                <!-- /ko -->
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="accordion-item" id="errorsModalWarningsAccordionItem">
+                        <h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings&nbsp;<span id="errorsModalWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
+                        </h2>
+                        <div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">
+                            <div class="accordion-body" id="errorsModalWarningsAccordionBody">
+                                <ul class="list-group">
+                                <!-- ko foreach: Errors.getWarnings -->
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span data-bind="text: $data.message"></span>
+                                        <div>
+                                        <!-- ko if: $data.show !== null -->
+                                            <button class="btn btn-secondary btn-sm" data-bind="click: function($data){$root.checkErrorModalShowError($data)}, eagleTooltip: 'Show object to investigate warning'">Show</button>
+                                        <!-- /ko -->
+                                        <!-- ko if: $data.fix !== null -->
+                                            <button class="btn btn-primary btn-sm" data-bind="click: function(){Utils.callFixFunc(eagle, $data.fix);}, eagleTooltip: $data.fixDescription">Fix</button>
+                                        <!-- /ko -->
+                                        </div>
+                                    </li>
+                                <!-- /ko -->
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+            <div class="modal-footer" style="justify-content: space-between;">
+                <button class="btn btn-primary" data-bind="click: Errors.fixAll, disable: Errors.getNumFixableIssues() === 0, eagleTooltip: Errors.getNumFixableIssues() + ' fix(es) available'">Fix All
+                    <span data-bind="text: Utils.getKeyboardShortcutTextByKey('fix_all', true)"></span>
+                </button>
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
…' shortcuts to 'u'. Used 'f' for 'fix all'. Added user notification during fix all. Moved errors modal to separate file. Display all shortcuts in help, even when canRun condition is not met.