### PR TITLE
Default value of settings were not reset for 'Student' or 'Component' mode

### DIFF
--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -201,12 +201,29 @@ export class Setting {
     }
 
     resetDefault = () : void => {
-        let value = this.graphDefaultValue
-        if(UiModeSystem.getActiveUiMode().getName()==='Minimal'){
-            value = this.minimalDefaultValue
-        }else if(UiModeSystem.getActiveUiMode().getName()==='Expert'){
-            value = this.expertDefaultValue
+        const activeUIModeName: string = UiModeSystem.getActiveUiMode().getName();
+        let value: any = this.graphDefaultValue;
+
+        switch (activeUIModeName){
+            case "Student":
+                value = this.studentDefaultValue;
+                break;
+            case "Minimal":
+                value = this.minimalDefaultValue;
+                break;
+            case "Graph":
+                value = this.graphDefaultValue;
+                break;
+            case "Component":
+                value = this.componentDefaultValue;
+                break;
+            case "Expert":
+                value = this.expertDefaultValue;
+                break;
+            default:
+                console.warn("Unknown active UI mode name:", activeUIModeName, ", using default value for ", this.name, " setting");
         }
+
         this.value(value);
     }
 
@@ -369,7 +386,7 @@ const settings : SettingsGroup[] = [
         "Advanced Editing",
         () => {return true;},
         [
-            new Setting(true,"Allow Invalid edges", Setting.ALLOW_INVALID_EDGES, "Allow the user to create edges even if they would normally be determined invalid.", false, Setting.Type.Boolean, false, false, false, false, true),
+            new Setting(true, "Allow Invalid edges", Setting.ALLOW_INVALID_EDGES, "Allow the user to create edges even if they would normally be determined invalid.", false, Setting.Type.Boolean, false, false, false, false, true),
             new Setting(true, "Allow Component Editing", Setting.ALLOW_COMPONENT_EDITING, "Allow the user to add/remove ports and parameters from components.",false, Setting.Type.Boolean,false, false, false, true,true),
             new Setting(true, "Allow Set Key Parameter", Setting.ALLOW_SET_KEY_PARAMETER, "Allow the user to add/remove key parameter flags from parameters.", false, Setting.Type.Boolean,false, true, true, true,true),
             new Setting(true, "Allow Graph Editing", Setting.ALLOW_GRAPH_EDITING, "Allow the user to edit and create graphs.", false, Setting.Type.Boolean, false, false, true, true, true),

--- a/templates/modals/settings.html
+++ b/templates/modals/settings.html
@@ -101,31 +101,31 @@
 
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
-                                <span class="input-group-text" data-bind=" eagleTooltip: Setting.find(Setting.TRANSLATOR_URL).getDescription()" data-bs-placement="left">Translator url</span>
+                                <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.TRANSLATOR_URL).getDescription()" data-bs-placement="left">Translator url</span>
                             </div>
                             <input type="text" class="form-control" disabled data-bind="value: Setting.findValue(Setting.TRANSLATOR_URL)">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
-                                <span class="input-group-text" data-bind="  eagleTooltip: Setting.find(Setting.GITHUB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitHub Access Token</span>
+                                <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.GITHUB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitHub Access Token</span>
                             </div>
                             <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY)">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
-                                <span class="input-group-text" data-bind="  eagleTooltip: Setting.find(Setting.GITLAB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitLab Access Token</span>
+                                <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.GITLAB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitLab Access Token</span>
                             </div>
                             <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY)">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
-                                <span class="input-group-text" data-bind="  eagleTooltip: Setting.find(Setting.DOCKER_HUB_USERNAME).getDescription()" data-bs-placement="left">Docker Hub Username</span>
+                                <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.DOCKER_HUB_USERNAME).getDescription()" data-bs-placement="left">Docker Hub Username</span>
                             </div>
                             <input type="text" class="form-control" disabled data-bind="value: Setting.findValue(Setting.DOCKER_HUB_USERNAME)">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
-                                <span class="input-group-text" data-bind=" eagleTooltip: Setting.find(Setting.EXPLORE_PALETTES_REPOSITORY).getDescription()" data-bs-placement="left">Explore Palettes Repository</span>
+                                <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.EXPLORE_PALETTES_REPOSITORY).getDescription()" data-bs-placement="left">Explore Palettes Repository</span>
                             </div>
                             <input type="text" class="form-control" disabled data-bind="value: Setting.findValue(Setting.EXPLORE_PALETTES_REPOSITORY)">
                         </div>
@@ -134,7 +134,7 @@
             </div>
             <!-- ko ifnot: Setting.findValue( Setting.STUDENT_SETTINGS_MODE) -->
                 <div class="modal-footer">
-                    <button class="btn btn-danger" id="resetSettingsDefaults" type="button" data-bind="click: Setting.resetDefaults">Reset Defaults</button>
+                    <button class="btn btn-danger" id="resetSettingsDefaults" type="button" data-bind="click: Setting.resetDefaults, eagleTooltip: 'Reset Defaults for this UIMode ONLY, and excluding External Services and Developer settings.'">Reset Defaults</button>
                     <button type="button" class="btn btn-secondary" id="settingsModalNegativeButton" data-bs-dismiss="modal"><span id="settingsModalNegativeAnswer">Cancel</span></button>
                     <button type="button" class="btn btn-primary" id="settingsModalAffirmativeButton" data-bs-dismiss="modal"><span id="settingsModalAffirmativeAnswer">OK</span></button>
                 </div>


### PR DESCRIPTION
Added tooltip to "Reset Defaults" button to make behaviour more obvious. I didn't realise (at first) that it only reset settings for the current UI Mode, and that it skipped the "External Services" and "Developer" settings groups.