### PR TITLE
Eagle 1139 - Data components generated by dragging from port should get name of port as name

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3191,12 +3191,16 @@ export class Eagle {
                 this.addEdge(realSourceNode, realSourcePort, realDestNode, realDestPort, false, false,null);
 
                 // name new node according to source port
-                node.setName(realSourcePort.getDisplayText());
+                const newName = realSourcePort.getDisplayText();
+                node.setName(newName);
+                realDestPort.setDisplayText(newName);
             } else {
                 this.addEdge(realDestNode, realDestPort, realSourceNode, realSourcePort, false, false, null);
 
                 // name new node according to destination port
-                node.setName(realDestPort.getDisplayText());
+                const newName = realDestPort.getDisplayText();
+                node.setName(newName);
+                realSourcePort.setDisplayText(newName);
             }
         });
     }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3189,8 +3189,14 @@ export class Eagle {
             // create edge (in correct direction)
             if (!RightClick.edgeDropSrcIsInput){
                 this.addEdge(realSourceNode, realSourcePort, realDestNode, realDestPort, false, false,null);
-            } else {    
+
+                // name new node according to source port
+                node.setName(realSourcePort.getDisplayText());
+            } else {
                 this.addEdge(realDestNode, realDestPort, realSourceNode, realSourcePort, false, false, null);
+
+                // name new node according to destination port
+                node.setName(realDestPort.getDisplayText());
             }
         });
     }


### PR DESCRIPTION
Uses the name of the source port as the name for the newly generated Data Component. Also renames the port(s) on the Data Component with the same name.