### PR TITLE
When creating a new node as a result of an edge drop, make sure that …

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3250,16 +3250,20 @@ export class Eagle {
             if (!RightClick.edgeDropSrcIsInput){
                 this.addEdge(realSourceNode, realSourcePort, realDestNode, realDestPort, false, false,null);
 
-                // name new node according to source port
+                // if the new node is a Data node, name the new node according to source port
                 const newName = realSourcePort.getDisplayText();
-                node.setName(newName);
+                if (node.isData()){
+                    node.setName(newName);
+                }
                 realDestPort.setDisplayText(newName);
             } else {
                 this.addEdge(realDestNode, realDestPort, realSourceNode, realSourcePort, false, false, null);
 
-                // name new node according to destination port
+                // if the new node is a Data node, name the new node according to destination port
                 const newName = realDestPort.getDisplayText();
-                node.setName(newName);
+                if (node.isData()){
+                    node.setName(newName);
+                }
                 realSourcePort.setDisplayText(newName);
             }
         });

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1549,6 +1549,7 @@ export class GraphRenderer {
         GraphRenderer.mousePosY(GraphRenderer.SCREEN_TO_GRAPH_POSITION_Y(null));
     }
 
+    // TODO: can we use the Daliuge.FieldUsage type here for the 'usage' parameter?
     static portDragStart(port:Field, usage:string) : void {
         const eagle = Eagle.getInstance();
 


### PR DESCRIPTION
…only data components are re-named by apps. Apps should not be re-named by data nodes.