### PR TITLE
Added 'browse dockerhub' button to node inspector, for docker nodes only

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -61,8 +61,8 @@ export namespace Daliuge {
 
         // docker
         IMAGE = "image",
-        TAG = "tag",
-        DIGEST = "digest",
+        TAG = "docker_tag",
+        DIGEST = "docker_digest",
 
         // branch
         YES = "yes",

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3559,7 +3559,7 @@ export class Eagle {
             // build list of image strings
             const images: string[] = [];
             for (const result of data.results){
-                images.push(result.user + "/" + result.name);
+                images.push(result.namespace + "/" + result.name);
             }
 
             // present list of image names to user
@@ -3582,6 +3582,11 @@ export class Eagle {
                     const tags: string[] = [];
                     for (const result of data.results){
                         tags.push(result.name);
+                    }
+
+                    if (tags.length === 0){
+                        Utils.showNotification("EAGLE", "No image tags available for " + imageName + " from Docker Hub", "danger");
+                        return;
                     }
 
                     // present list of tags to user
@@ -3611,6 +3616,8 @@ export class Eagle {
                         if (digestField !== null){
                             digestField.setValue(digest);
                         }
+
+                        Utils.showNotification("EAGLE", "Image, tag and digest set from Docker Hub", "success");
                     });
                 });
             });

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -116,9 +116,9 @@ export class Modals {
             const choice : number = parseInt($('#choiceModalSelect').val().toString(), 10);
 
             //checking if the value of the select element is valid
-            if(!$('#choiceModalSelect').val() || choice > $('#choiceModalSelect').length){
+            if(!$('#choiceModalSelect').val() || choice > $('#choiceModalSelect option').length){
                 $('#choiceModalSelect').val(0)
-                console.warn('Invalid selection value, resetting to 0')
+                console.warn('Invalid selection value (', choice, '), resetting to 0')
             }
 
             // check selected option in select tag

--- a/templates/node_inspector.html
+++ b/templates/node_inspector.html
@@ -170,9 +170,20 @@
 
 
                 <!-- open parameter table  -->
-                <button id='openNodeFieldsTable' class="btn btn-primary btn_wide" data-bind=" click: function(data, event){$root.openParamsTableModal('inspectorTableModal','normal')}, clickBubble: false, eagleTooltip: `Fine tune this node's parameters, arguments and ports ` + Utils.getKeyboardShortcutTextByKey('open_component_parameter_table_modal', true)" data-bs-toggle="tooltip" data-html="true" data-bs-placement="right" data-bs-original-title="Open Component Parameters in Table [T]">
-                    Open Fields Table
-                </button>
+                <div class="input-group mb-1">
+                    <button id='openNodeFieldsTable' class="btn btn-primary btn_wide" data-bind=" click: function(data, event){$root.openParamsTableModal('inspectorTableModal','normal')}, clickBubble: false, eagleTooltip: `Fine tune this node's parameters, arguments and ports ` + Utils.getKeyboardShortcutTextByKey('open_component_parameter_table_modal', true)" data-bs-toggle="tooltip" data-html="true" data-bs-placement="right" data-bs-original-title="Open Component Parameters in Table [T]">
+                        Open Fields Table
+                    </button>
+                </div>
+
+                <!-- open parameter table  -->
+                <!-- ko if: $data.getCategory() === Category.Docker -->
+                <div class="input-group mb-1">
+                    <button id='openDocker' class="btn btn-primary btn_wide" data-bind=" click: $root.fetchDockerHTML, clickBubble: false, eagleTooltip: ` Browse images on dockerhub ` + Utils.getKeyboardShortcutTextByKey('something', true)" data-bs-toggle="tooltip" data-html="true" data-bs-placement="right" data-bs-original-title="]">
+                        Browse DockerHub
+                    </button>
+                </div>
+                <!-- /ko -->
 
             </div>
 


### PR DESCRIPTION
Uses existing button handler code that was previously unused.

Fixed bug where EAGLE thought the names of the tag and digest field in a Docker component were called "tag" and "digest" instead of "docker_tag" and "docker_digest".

Updated query to dockerhub where API had changed slightly ("user" vs. "namespace")

Added new red notification for one error case, where no tags are available for the requested image.
Added new green notification for success.