### PR TITLE
Removed the dataType attribute from Edge

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2629,7 +2629,7 @@ export class Eagle {
         }
 
         // if input edge is null, then we are creating a new edge here, so initialise it with some default values
-        const newEdge = new Edge(this.logicalGraph().getNodes()[0].getKey(), "", this.logicalGraph().getNodes()[0].getKey(), "", "", false, false, false);
+        const newEdge = new Edge(this.logicalGraph().getNodes()[0].getKey(), "", this.logicalGraph().getNodes()[0].getKey(), "", false, false, false);
 
         // display edge editing modal UI
         Utils.requestUserEditEdge(newEdge, this.logicalGraph(), (completed: boolean, edge: Edge) => {
@@ -2639,7 +2639,7 @@ export class Eagle {
             }
 
             // validate edge
-            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.getDataType(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
+            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
             if (isValid === Eagle.LinkValid.Impossible || isValid === Eagle.LinkValid.Invalid || isValid === Eagle.LinkValid.Unknown){
                 Utils.showUserMessage("Error", "Invalid edge");
                 return;
@@ -2684,7 +2684,7 @@ export class Eagle {
             }
 
             // validate edge
-            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.getDataType(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
+            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
             if (isValid === Eagle.LinkValid.Impossible || isValid === Eagle.LinkValid.Invalid || isValid === Eagle.LinkValid.Unknown){
                 Utils.showUserMessage("Error", "Invalid edge");
                 return;
@@ -3897,52 +3897,6 @@ export class Eagle {
         });
     }
 
-    changeEdgeDataType = (edge: Edge) : void => {
-        // get reference to selected Edge
-        const selectedEdge: Edge = this.selectedEdge();
-
-        if (selectedEdge === null){
-            console.error("Attempt to change edge data type when no edge selected");
-            return;
-        }
-
-        // set selectedIndex to the index of the current data type within the allTypes list
-        let selectedIndex = 0;
-        for (let i = 0 ; i < this.types().length ; i++){
-            if (this.types()[i] === selectedEdge.getDataType()){
-                selectedIndex = i;
-                break;
-            }
-        }
-
-        // launch modal
-        Utils.requestUserChoice("Change Edge Data Type", "NOTE: changing a edge's data type will also change the data type of the source and destination ports", this.types(), selectedIndex, false, "", (completed:boolean, userChoiceIndex: number, userCustomString: string) => {
-            if (!completed){
-                return;
-            }
-
-            // get user selection
-            const newType = this.types()[userChoiceIndex];
-
-            // get references to the source and destination ports of this edge
-            const sourceNode = this.logicalGraph().findNodeByKey(edge.getSrcNodeKey());
-            const sourcePort = sourceNode.findFieldById(edge.getSrcPortId());
-            const destinationNode = this.logicalGraph().findNodeByKey(edge.getDestNodeKey());
-            const destinationPort = destinationNode.findFieldById(edge.getDestPortId());
-
-            // update the edge and ports
-            edge.setDataType(newType);
-            sourcePort.setType(newType);
-            destinationPort.setType(newType);
-
-            // flag changes
-            this.checkGraph();
-            this.undo().pushSnapshot(this, "Change Edge Data Type");
-            this.selectedObjects.valueHasMutated();
-            this.logicalGraph.valueHasMutated();
-        });
-    }
-
     removeFieldFromNodeById = (node : Node, id: string) : void => {
         console.log("removeFieldFromNodeById(): node", node.getName(), "id", id);
 
@@ -4479,7 +4433,7 @@ export class Eagle {
 
         // if edge DOES NOT connect two applications, process normally
         if (!edgeConnectsTwoApplications || twoEventPorts){
-            const edge : Edge = new Edge(srcNode.getKey(), srcPort.getId(), destNode.getKey(), destPort.getId(), srcPort.getType(), loopAware, closesLoop, false);
+            const edge : Edge = new Edge(srcNode.getKey(), srcPort.getId(), destNode.getKey(), destPort.getId(), loopAware, closesLoop, false);
             this.logicalGraph().addEdgeComplete(edge);
             setTimeout(() => {
                 this.setSelection(Eagle.RightWindowMode.Hierarchy, edge,Eagle.FileType.Graph)
@@ -4549,8 +4503,8 @@ export class Eagle {
         }
 
         // create TWO edges, one from src to data component, one from data component to dest
-        const firstEdge : Edge = new Edge(srcNode.getKey(), srcPort.getId(), newNodeKey, newInputOutputPort.getId(), srcPort.getType(), loopAware, closesLoop, false);
-        const secondEdge : Edge = new Edge(newNodeKey, newInputOutputPort.getId(), destNode.getKey(), destPort.getId(), srcPort.getType(), loopAware, closesLoop, false);
+        const firstEdge : Edge = new Edge(srcNode.getKey(), srcPort.getId(), newNodeKey, newInputOutputPort.getId(), loopAware, closesLoop, false);
+        const secondEdge : Edge = new Edge(newNodeKey, newInputOutputPort.getId(), destNode.getKey(), destPort.getId(), loopAware, closesLoop, false);
 
         this.logicalGraph().addEdgeComplete(firstEdge);
         this.logicalGraph().addEdgeComplete(secondEdge);

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1304,7 +1304,7 @@ export class GraphRenderer {
                     if (srcHasConnectedInput){
                         // build a new edge
                         const newSrc = GraphRenderer.findInputToDataNode(graph.getEdges(), edge.getSrcNodeKey());
-                        edges.push(new Edge(newSrc.nodeKey, newSrc.portId, edge.getDestNodeKey(), edge.getDestPortId(), edge.getDataType(), edge.isLoopAware(), edge.isClosesLoop(), false));
+                        edges.push(new Edge(newSrc.nodeKey, newSrc.portId, edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false));
                     } else {
                         // draw edge as normal
                         edges.push(edge);
@@ -1665,7 +1665,7 @@ export class GraphRenderer {
         }
 
         // check if link is valid
-        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, null, realSourceNode.getKey(), realSourcePort.getId(), realDestinationNode.getKey(), realDestinationPort.getId(), realSourcePort.getType(), false, false, true, true, {errors:[], warnings:[]});
+        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, null, realSourceNode.getKey(), realSourcePort.getId(), realDestinationNode.getKey(), realDestinationPort.getId(), false, false, true, true, {errors:[], warnings:[]});
 
         // abort if edge is invalid
         if ((Setting.findValue(Setting.ALLOW_INVALID_EDGES) && linkValid === Eagle.LinkValid.Invalid) || linkValid === Eagle.LinkValid.Valid || linkValid === Eagle.LinkValid.Warning){
@@ -2067,7 +2067,7 @@ export class GraphRenderer {
         GraphRenderer.destinationPort = port;
         GraphRenderer.destinationNode = eagle.logicalGraph().findNodeByKey(port.getNodeKey());
 
-        const isValid = Edge.isValid(eagle, null, GraphRenderer.portDragSourceNode().getKey(), GraphRenderer.portDragSourcePort().getId(), GraphRenderer.destinationNode.getKey(), GraphRenderer.destinationPort.getId(), GraphRenderer.portDragSourcePort().getType(), false, false, false, false, {errors:[], warnings:[]});
+        const isValid = Edge.isValid(eagle, null, GraphRenderer.portDragSourceNode().getKey(), GraphRenderer.portDragSourcePort().getId(), GraphRenderer.destinationNode.getKey(), GraphRenderer.destinationPort.getId(), false, false, false, false, {errors:[], warnings:[]});
         GraphRenderer.isDraggingPortValid(isValid);
     }
 
@@ -2193,7 +2193,7 @@ export class GraphRenderer {
         }
 
         // check if link has a warning or is invalid
-        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.getDataType(), edge.isLoopAware(), edge.isClosesLoop(), false, false, {errors:[], warnings:[]});
+        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, false, {errors:[], warnings:[]});
 
         if (linkValid === Eagle.LinkValid.Invalid || linkValid === Eagle.LinkValid.Impossible){
             normalColor = GraphConfig.getColor('edgeInvalid');

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -282,11 +282,10 @@ export class Modals {
             const srcPortId : string = $('#editEdgeModalSrcPortIdSelect').val().toString();
             const destNodeKey : number = parseInt($('#editEdgeModalDestNodeKeySelect').val().toString(), 10);
             const destPortId: string = $('#editEdgeModalDestPortIdSelect').val().toString();
-            const dataType: string = $('#editEdgeModalDataTypeInput').val().toString();
             const loopAware: boolean = $('#editEdgeModalLoopAwareCheckbox').prop('checked');
             const closesLoop: boolean = $('#editEdgeModalClosesLoopCheckbox').prop('checked');
 
-            const newEdge = new Edge(srcNodeKey, srcPortId, destNodeKey, destPortId, dataType, loopAware, closesLoop, false);
+            const newEdge = new Edge(srcNodeKey, srcPortId, destNodeKey, destPortId, loopAware, closesLoop, false);
 
             callback(true, newEdge);
         });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -904,8 +904,6 @@ export class Utils {
                 }));
             }
         }
-
-        $('#editEdgeModalDataTypeInput').val(edge.getDataType());
     }
 
     /**
@@ -1399,7 +1397,7 @@ export class Utils {
 
         // check all edges are valid
         for (const edge of graph.getEdges()){
-            Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.getDataType(), edge.isLoopAware(), edge.isClosesLoop(), false, false, errorsWarnings);
+            Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, false, errorsWarnings);
         }
 
         // check that all node, edge, field ids are unique
@@ -1699,16 +1697,6 @@ export class Utils {
             return false
         }
         return value.toLowerCase() === "true";
-    }
-
-    static fixEdgeType(eagle: Eagle, edgeId: string, newType: string) : void {
-        const edge = eagle.logicalGraph().findEdgeById(edgeId);
-
-        if (edge === null){
-            return;
-        }
-
-        edge.setDataType(newType);
     }
 
     static fixDeleteEdge(eagle: Eagle, edgeId: string): void {
@@ -2033,8 +2021,6 @@ export class Utils {
                 "peek":node.isPeek(),
                 "x":node.getPosition().x,
                 "y":node.getPosition().y,
-                // "realX":node.getRealPosition().x,
-                // "realY":node.getRealPosition().y,
                 "radius":node.getRadius(),
                 "inputAppKey":node.getInputApplication() === null ? null : node.getInputApplication().getKey(),
                 "inputAppCategory":node.getInputApplication() === null ? null : node.getInputApplication().getCategory(),
@@ -2060,7 +2046,6 @@ export class Utils {
                 "sourcePortId":edge.getSrcPortId(),
                 "destNodeKey":edge.getDestNodeKey(),
                 "destPortId":edge.getDestPortId(),
-                "dataType":edge.getDataType(),
                 "loopAware":edge.isLoopAware(),
                 "isSelectionRelative":edge.getSelectionRelative()
             });

--- a/templates/edge_inspector.html
+++ b/templates/edge_inspector.html
@@ -55,19 +55,6 @@
                 </div>
 
                 <div class="input-group mb-1">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text" id="edge-addon5">DataType</span>
-                    </div>
-                    <input type="text" class="form-control" id="edge-data-type" placeholder="" aria-label="DataType" aria-describedby="edge-addon5" readonly data-bind="value: selectedEdge().dataType">
-                    <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
-                        <div class="input-group-append">
-                            <button class="btn btn-secondary btn-sm" id="edgeInspectorChangeDataType" type="button" data-bind="click: function(){$root.changeEdgeDataType(selectedEdge());}">
-                                <i class="material-icons md-18">edit</i>
-                            </button>
-                        </div>
-                    <!-- /ko -->
-                </div>
-                <div class="input-group mb-1">
                     <input type="text" class="form-control edgeInspectorCheckboxLabel" id="nodeLoopAwareValue" data-bind="eagleTooltip: 'Indicates the user is aware that the components at either end of the edge may differ in multiplicity'" placeholder="" aria-label="LoopAware" aria-describedby="node-loop-aware" value="Loop Aware" readonly>
                     <div class="input-group-append">
                         <button class="btn btn-secondary btn-sm" id="edgeInspectorToggleLoopAware" type="button" data-bind="click: function(){selectedEdge().toggleLoopAware();selectedObjects.valueHasMutated();eagle.logicalGraph.valueHasMutated();},disabled:!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)">

--- a/templates/modals/edit_edge.html
+++ b/templates/modals/edit_edge.html
@@ -54,16 +54,6 @@
                     </div>
                     <div class="row">
                         <div class="col-3">
-                            <p>Data Type:</p>
-                        </div>
-                        <div class="col">
-                            <div class="input-group mb-3">
-                                <input type="text" class="form-control" id="editEdgeModalDataTypeInput">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-3">
                             <p>Loop Aware:</p>
                         </div>
                         <div class="col">

--- a/tests/page-model.js
+++ b/tests/page-model.js
@@ -230,8 +230,6 @@ class Page {
       .click(Selector("#editEdgeModalDestPortIdSelect"))
       .click(Selector("#editEdgeModalDestPortIdSelect").find('option').withText(dstPort))
 
-      .typeText(Selector("#editEdgeModalDataTypeInput"), srcPort, { replace: true })
-
       .click(Selector("#editEdgeModalAffirmativeButton"));
   }
 


### PR DESCRIPTION
Removed the 'dataType' attribute from Edges in the graph. Since we already have the type defined in the source and destination port of the edge, storing the type in the edge too is just redundant, and increases the likelihood of mismatches.

There is also a related merge on DALiuGE to handle the changes on that end.