### PR TITLE
Eagle 1050 - Open/close builtin palettes when the OPEN_DEFAULT_PALETTE setting is toggled.

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2231,7 +2231,19 @@ export class Eagle {
     // if currently shown, just remove them from the palettes list
     // if currently not shown, fetch them from the remove source and add to palettes list
     toggleDefaultPalettes = () : void => {
+        const allowGraphEditing: boolean = Setting.find(Setting.ALLOW_GRAPH_EDITING).value() as boolean;
+        const allowPaletteEditing: boolean = Setting.find(Setting.ALLOW_PALETTE_EDITING).value() as boolean;
         const openDefaultPalette: boolean = Setting.find(Setting.OPEN_DEFAULT_PALETTE).value() as boolean;
+
+        // if:
+        // - user is loading palettes
+        // - allow palette editing is off
+        // - allow graph editing is off
+        // then the palettes tab is invisible anyway, and the user will not see the palettes loaded, so notify them of this corner case
+        if (openDefaultPalette && !allowGraphEditing && !allowPaletteEditing){
+            Utils.showNotification("Palettes Disabled", "Palettes are not visible in the current UI mode", "warning");
+        }
+
         const eagle: Eagle = Eagle.getInstance();
 
         const builtinPalette: Palette = this.findPalette(Palette.BUILTIN_PALETTE_NAME, false);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2189,6 +2189,14 @@ export class Eagle {
         Utils.showNotification("Success", "Confirmation message pop ups re-enabled", "success");
     }
 
+    // toggles the default palettes on or off
+    // if currently shown, just remove them from the palettes list
+    // if currently not shown, fetch them from the remove source and add to palettes list
+    toggleDefaultPalettes = () : void => {
+        const openDefaultPalette: boolean = Setting.find(Setting.OPEN_DEFAULT_PALETTE).value() as boolean;
+        console.log("toggleDefaultPalette", openDefaultPalette);
+    }
+
     // TODO: shares some code with saveFileToLocal(), we should try to factor out the common stuff at some stage
     savePaletteToDisk = (palette : Palette) : void => {
         console.log("savePaletteToDisk()", palette.fileInfo().name, palette.fileInfo().type);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1940,7 +1940,7 @@ export class Eagle {
 
                     // warn user if file newer than EAGLE
                     if (Utils.newerEagleVersion(eagleVersion, (<any>window).version)){
-                        Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", "", (confirmed : boolean) : void => {
+                        Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", null, (confirmed : boolean) : void => {
                             if (confirmed){
                                 this._loadGraph(dataObject, file);
                             }
@@ -2080,7 +2080,7 @@ export class Eagle {
 
         // if dictated by settings, reload the palette immediately
         if (alreadyLoadedPalette !== null && Setting.findValue(Setting.CONFIRM_RELOAD_PALETTES)){
-            Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No",Setting.CONFIRM_RELOAD_PALETTES, (confirmed : boolean) : void => {
+            Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No", Setting.find(Setting.CONFIRM_RELOAD_PALETTES), (confirmed : boolean) : void => {
                 if (confirmed){
                     this._reloadPalette(file, data, alreadyLoadedPalette);
                 }
@@ -2148,7 +2148,7 @@ export class Eagle {
 
                 // check if the palette is modified, and if so, ask the user to confirm they wish to close
                 if (p.fileInfo().modified && Setting.findValue(Setting.CONFIRM_DISCARD_CHANGES)){
-                    Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel",'', (confirmed : boolean) : void => {
+                    Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel", null, (confirmed : boolean) : void => {
                         if (confirmed){
                             this.palettes.splice(i, 1);
                         }
@@ -3177,7 +3177,7 @@ export class Eagle {
         }
 
         // request confirmation from user
-        Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No",Setting.CONFIRM_DELETE_OBJECTS, (confirmed : boolean) : void => {
+        Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_OBJECTS), (confirmed : boolean) : void => {
             if (!confirmed){
                 console.log("User aborted deleteSelection()");
                 return;
@@ -4640,7 +4640,7 @@ export class Eagle {
         if (Setting.findValue(Setting.CONFIRM_NODE_CATEGORY_CHANGES)){
 
             // request confirmation from user
-            Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No",Setting.CONFIRM_NODE_CATEGORY_CHANGES, (confirmed : boolean) : void => {
+            Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES), (confirmed : boolean) : void => {
                 if (!confirmed){
                     //we need to reset the input select to the previous value
                     $(event.target).val(this.selectedNode().getCategory())

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -53,8 +53,9 @@ export class Repositories {
         }
 
         // if the file is modified, get the user to confirm they want to overwrite changes
-        if (isModified && Setting.findValue(Setting.CONFIRM_DISCARD_CHANGES)){
-            Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel",Setting.CONFIRM_DISCARD_CHANGES, (confirmed : boolean) : void => {
+        const confirmDiscardChanges: Setting = Setting.find(Setting.CONFIRM_DISCARD_CHANGES);
+        if (isModified && confirmDiscardChanges.value()){
+            Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges, (confirmed : boolean) : void => {
                 if (!confirmed){
                     console.log("selectFile() cancelled");
                     return;
@@ -106,14 +107,16 @@ export class Repositories {
     };
 
     removeCustomRepository = (repository : Repository) : void => {
+        const confirmRemoveRepositories: Setting = Setting.find(Setting.CONFIRM_REMOVE_REPOSITORIES);
+
         // if settings dictates that we don't confirm with user, remove immediately
-        if (!Setting.findValue(Setting.CONFIRM_REMOVE_REPOSITORIES)){
+        if (!confirmRemoveRepositories.value()){
             this._removeCustomRepository(repository);
             return;
         }
 
         // otherwise, check with user
-        Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel",Setting.CONFIRM_REMOVE_REPOSITORIES, (confirmed : boolean) =>{
+        Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel", confirmRemoveRepositories, (confirmed : boolean) =>{
             if (!confirmed){
                 console.log("User aborted removeCustomRepository()");
                 return;

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -354,14 +354,14 @@ const settings : SettingsGroup[] = [
         "User Options",
         () => {return true;},
         [
-            new Setting(true, "Reset Action Confirmations", Setting.ACTION_CONFIRMATIONS, "Enable all action confirmation prompts",false, Setting.Type.Button, '', '','','','',[], function(){console.log("test rac");console.trace();Eagle.getInstance().resetActionConfirmations()}),
+            new Setting(true, "Reset Action Confirmations", Setting.ACTION_CONFIRMATIONS, "Enable all action confirmation prompts",false, Setting.Type.Button, '', '', '', '', '', [], function(){Eagle.getInstance().resetActionConfirmations();}),
             new Setting(false, "Confirm Discard Changes", Setting.CONFIRM_DISCARD_CHANGES, "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.",false, Setting.Type.Boolean, true, true,true,true,true),
             new Setting(false, "Confirm Node Category Changes", Setting.CONFIRM_NODE_CATEGORY_CHANGES, "Prompt user to confirm that changing the node category may break the node.",false, Setting.Type.Boolean, true, true,true,true,true),
             new Setting(false, "Confirm Remove Repositories", Setting.CONFIRM_REMOVE_REPOSITORIES, "Prompt user to confirm removing a repository from the list of known repositories.",false , Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Confirm Reload Palettes", Setting.CONFIRM_RELOAD_PALETTES, "Prompt user to confirm when loading a palette that is already loaded.",false , Setting.Type.Boolean,true,true,true,true,true),
             new Setting(false, "Confirm Delete", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Confirm Delete", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
-            new Setting(true, "Open Default Palette on Startup", Setting.OPEN_DEFAULT_PALETTE, "Open a default palette on startup. The palette contains an example of all known node categories", false, Setting.Type.Boolean, false,false,true,true,true),
+            new Setting(true, "Open Default Palette on Startup", Setting.OPEN_DEFAULT_PALETTE, "Open a default palette on startup. The palette contains an example of all known node categories", false, Setting.Type.Boolean, false,false,true,true,true, [], function(){Eagle.getInstance().toggleDefaultPalettes();}),
             new Setting(true, "Disable JSON Validation", Setting.DISABLE_JSON_VALIDATION, "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", false, Setting.Type.Boolean, false,false,false,false,false),
             new Setting(true, "Overwrite Existing Translator Tab", Setting.OVERWRITE_TRANSLATION_TAB, "When translating a graph, overwrite an existing translator tab", false, Setting.Type.Boolean, true,true,true,true,true),
         ]

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -47,10 +47,10 @@ export class Setting {
     private componentDefaultValue : any;
     private expertDefaultValue : any;
     private oldValue : any;
-    private options : string[];
-    private buttonFunc : () => void;
+    private options : string[]; // an optional list of possible values for this setting
+    private eventFunc : () => void; // optional function to be called when a settings button is clicked, or checkbox is toggled, or a input is changed
 
-    constructor(display: boolean, name : string, key:string, description : string,perpetual:boolean, type : Setting.Type, studentDefaultValue : any, minimalDefaultValue : any,graphDefaultValue : any,componentDefaultValue : any,expertDefaultValue : any, options?: string[], buttonFunc?: () => void){
+    constructor(display: boolean, name : string, key:string, description : string,perpetual:boolean, type : Setting.Type, studentDefaultValue : any, minimalDefaultValue : any,graphDefaultValue : any,componentDefaultValue : any,expertDefaultValue : any, options?: string[], eventFunc?: () => void){
         this.display = display;
         this.name = name;
         this.key = key;
@@ -63,7 +63,7 @@ export class Setting {
         this.componentDefaultValue = componentDefaultValue;
         this.expertDefaultValue = expertDefaultValue;
         this.options = options;
-        this.buttonFunc = buttonFunc;
+        this.eventFunc = eventFunc;
 
         this.oldValue = "";
         this.value = ko.observable(graphDefaultValue);
@@ -140,6 +140,8 @@ export class Setting {
 
         // update the value
         this.value(!this.value());
+
+        this.callEventFunc();
     }
 
     copy = () : void => {
@@ -158,12 +160,8 @@ export class Setting {
         this.oldValue = this.value()
     }
 
-    run = () : void => {
-        this.buttonFunc();
-    }
-
-    static toggleByName(settingName:string) : void {
-        Setting.find(settingName).toggle()
+    callEventFunc = () : void => {
+        this.eventFunc?.();
     }
 
     static find(key : string) : Setting {
@@ -356,7 +354,7 @@ const settings : SettingsGroup[] = [
         "User Options",
         () => {return true;},
         [
-            new Setting(true, "Reset Action Confirmations", Setting.ACTION_CONFIRMATIONS, "Enable all action confirmation prompts",false, Setting.Type.Button, '', '','','','',[], function(){console.log("test rac");Eagle.getInstance().resetActionConfirmations()}),
+            new Setting(true, "Reset Action Confirmations", Setting.ACTION_CONFIRMATIONS, "Enable all action confirmation prompts",false, Setting.Type.Button, '', '','','','',[], function(){console.log("test rac");console.trace();Eagle.getInstance().resetActionConfirmations()}),
             new Setting(false, "Confirm Discard Changes", Setting.CONFIRM_DISCARD_CHANGES, "Prompt user to confirm that unsaved changes to the current file should be discarded when opening a new file, or when navigating away from EAGLE.",false, Setting.Type.Boolean, true, true,true,true,true),
             new Setting(false, "Confirm Node Category Changes", Setting.CONFIRM_NODE_CATEGORY_CHANGES, "Prompt user to confirm that changing the node category may break the node.",false, Setting.Type.Boolean, true, true,true,true,true),
             new Setting(false, "Confirm Remove Repositories", Setting.CONFIRM_REMOVE_REPOSITORIES, "Prompt user to confirm removing a repository from the list of known repositories.",false , Setting.Type.Boolean, true,true,true,true,true),

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -578,20 +578,20 @@ export class Utils {
         $('#choiceModal').modal("toggle");
     }
 
-    static requestUserConfirm(title : string, message : string, affirmativeAnswer : string, negativeAnswer : string,confirmSetting:string, callback : (confirmed : boolean) => void ) : void {
+    static requestUserConfirm(title : string, message : string, affirmativeAnswer : string, negativeAnswer : string, confirmSetting: Setting, callback : (confirmed : boolean) => void ) : void {
         $('#confirmModalTitle').text(title);
         $('#confirmModalMessage').html(message);
         $('#confirmModalAffirmativeAnswer').text(affirmativeAnswer);
         $('#confirmModalNegativeAnswer').text(negativeAnswer);
         
         $('#confirmModalDontShowAgain button').off()
-        if(confirmSetting === ''){
+        if(confirmSetting === null){
             $('#confirmModalDontShowAgain').hide()
         }else{
             $('#confirmModalDontShowAgain').show()
             $('#confirmModalDontShowAgain button').text('check_box_outline_blank')
-            $('#confirmModalDontShowAgain button').on('click',function(){
-                Setting.toggleByName(confirmSetting)
+            $('#confirmModalDontShowAgain button').on('click', function(){
+                confirmSetting.toggle();
                 if($('#confirmModalDontShowAgain button').text() === 'check_box_outline_blank'){
                     $('#confirmModalDontShowAgain button').text('check_box')
                 }else{

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,29 +130,7 @@ $(function(){
 
     // load the default palette
     if (Setting.findValue(Setting.OPEN_DEFAULT_PALETTE)){
-        eagle.loadPalettes([
-            {name:Palette.BUILTIN_PALETTE_NAME, filename:Daliuge.PALETTE_URL, readonly:true},
-            {name:Palette.DYNAMIC_PALETTE_NAME, filename:Daliuge.TEMPLATE_URL, readonly:true}
-        ], (errorsWarnings: Errors.ErrorsWarnings, palettes: Palette[]):void => {
-            const showErrors: boolean = Setting.findValue(Setting.SHOW_FILE_LOADING_ERRORS);
-
-            // display of errors if setting is true
-            if (showErrors && (Errors.hasErrors(errorsWarnings) || Errors.hasWarnings(errorsWarnings))){
-                // add warnings/errors to the arrays
-                eagle.loadingErrors(errorsWarnings.errors);
-                eagle.loadingWarnings(errorsWarnings.warnings);
-
-                eagle.errorsMode(Setting.ErrorsMode.Loading);
-                Utils.showErrorsModal("Loading File");
-            }
-
-            for (const palette of palettes){
-                if (palette !== null){
-                    eagle.palettes.push(palette);
-                }
-            }
-            eagle.leftWindow().shown(true);
-        });
+        eagle.loadDefaultPalettes();
     }
 
     // set other state based on settings values

--- a/templates/modals/settings.html
+++ b/templates/modals/settings.html
@@ -43,7 +43,7 @@
                                             <!-- /ko -->
                                             <!-- ko if: $data.getType() === Setting.Type.Boolean -->
                                                 <div class="settingSm col-6">
-                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: $data.toggle">
+                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: function(){$data.toggle();$data.callEventFunc();}">
                                                         <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
                                                         <div class="input-group-append">
                                                             <button class="btn btn-secondary btn-sm" type="button" data-bind=" attr:{id:'setting'+$data.getKey()+'Button'}">
@@ -56,7 +56,7 @@
                                             <!-- /ko --> 
                                             <!-- ko if: $data.getType() === Setting.Type.Button -->
                                                 <div class="settingSm col-6">
-                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: $data.run">
+                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: $data.callEventFunc">
                                                         <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
                                                         <div class="input-group-append">
                                                             <button class="btn btn-secondary btn-sm" type="button" data-bind="attr:{id:'setting'+$data.getKey()+'Function'}">

--- a/templates/modals/settings.html
+++ b/templates/modals/settings.html
@@ -43,7 +43,7 @@
                                             <!-- /ko -->
                                             <!-- ko if: $data.getType() === Setting.Type.Boolean -->
                                                 <div class="settingSm col-6">
-                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: function(){$data.toggle();$data.callEventFunc();}">
+                                                    <div class="input-group mb-1 checkSettingLabel" data-bind="click: $data.toggle">
                                                         <input type="text" class="form-control" placeholder="" data-bind="attr:{id:'setting'+$data.getKey(),value:$data.getName()}, eagleTooltip:$data.getDescription()" data-bs-placement="left" readonly>
                                                         <div class="input-group-append">
                                                             <button class="btn btn-secondary btn-sm" type="button" data-bind=" attr:{id:'setting'+$data.getKey()+'Button'}">


### PR DESCRIPTION
Loads or removes the two builtin palettes when the user toggles the "Open default palettes on startup" setting in the "User Options" tab.

Previously each Setting object had a "buttonFunc" attribute. This function would be called when the setting button was clicked (if the Setting was a Button type). Non-Button type settings would not use the buttonFunc attribute.

I modified buttonFunc to eventFunc, and called it on Boolean-type settings as well as Button-type settings. So when the checkbox is toggled, the eventFunc is called.

Also split the "loadDefaultPalettes" functionality out of Eagle into its own function, so that it could be called by the eventFunc attached to the OPEN_DEFAULT_PALETTE setting.

If you could test:
- toggling the setting
- starting Eagle with both values
- switching UI modes