### PR TITLE
eagle-1042 : Allow users to specify the repository service and branch used by "Explore Palettes"

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -435,6 +435,8 @@ def get_explore_palettes():
     content = request.get_json(silent=True)
 
     try:
+        # NOTE: repo_service is not currently used
+        repo_service = content["service"]
         repo_name = content["repository"]
         repo_branch = content["branch"]
         repo_token = content["token"]
@@ -443,6 +445,7 @@ def get_explore_palettes():
         return jsonify({"error":"Repository, Branch or Token not specified in request"})
 
     # Extracting the true repo name and repo folder.
+    # TODO: Only GitHub supported here, add GitLab
     folder_name, repo_name = extract_folder_and_repo_names(repo_name)
     g = github.Github(repo_token)
 
@@ -450,7 +453,7 @@ def get_explore_palettes():
         repo = g.get_repo(repo_name)
     except github.UnknownObjectException as uoe:
         print("UnknownObjectException {1}: {0}".format(str(uoe), repo_name))
-        return jsonify({"error":uoe.message})
+        return jsonify({"error":str(uoe)}), 400
 
     # get results
     d = find_github_palettes(repo, "", repo_branch)

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -856,7 +856,7 @@ export class Eagle {
     
                     // update the activeFileInfo with details of the repository the file was loaded from
                     if (fileFullPath !== ""){
-                        eagle.updateLogicalGraphFileInfo(Eagle.RepositoryService.File, "", "", Utils.getFilePathFromFullPath(fileFullPath), Utils.getFileNameFromFullPath(fileFullPath));
+                        eagle.updateLogicalGraphFileInfo(Repository.Service.File, "", "", Utils.getFilePathFromFullPath(fileFullPath), Utils.getFileNameFromFullPath(fileFullPath));
                     }
     
                     // check graph
@@ -919,7 +919,7 @@ export class Eagle {
         graphFileToInsertInputElement.value = "";
     }
 
-    private _handleLoadingErrors = (errorsWarnings: Errors.ErrorsWarnings, fileName: string, service: Eagle.RepositoryService) : void => {
+    private _handleLoadingErrors = (errorsWarnings: Errors.ErrorsWarnings, fileName: string, service: Repository.Service) : void => {
         const showErrors: boolean = Setting.findValue(Setting.SHOW_FILE_LOADING_ERRORS);
         this.hideEagleIsLoading()
         // show errors (if found)
@@ -972,7 +972,7 @@ export class Eagle {
                 break;
         }
 
-        this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Eagle.RepositoryService.File);
+        this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Repository.Service.File);
     }
 
     createSubgraphFromSelection = () : void => {
@@ -1230,7 +1230,7 @@ export class Eagle {
 
                 eagle._loadPaletteJSON(data, fileFullPath);
 
-                eagle.palettes()[0].fileInfo().repositoryService = Eagle.RepositoryService.File;
+                eagle.palettes()[0].fileInfo().repositoryService = Repository.Service.File;
                 eagle.palettes()[0].fileInfo.valueHasMutated();
             }
             reader.onerror = function (evt) {
@@ -1267,7 +1267,7 @@ export class Eagle {
         const p : Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.DUMMY, "", Utils.getFileNameFromFullPath(fileFullPath)), errorsWarnings);
 
         // show errors (if found)
-        this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Eagle.RepositoryService.File);
+        this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Repository.Service.File);
 
         // sort the palette
         p.sort();
@@ -1436,15 +1436,15 @@ export class Eagle {
          this.closePalette(palette);
 
          switch (fileInfo.repositoryService){
-             case Eagle.RepositoryService.File:
+             case Repository.Service.File:
                 // load palette
                 this.getPaletteFileToLoad();
                 break;
-            case Eagle.RepositoryService.GitLab:
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitLab:
+            case Repository.Service.GitHub:
                 Repositories.selectFile(new RepositoryFile(new Repository(fileInfo.repositoryService, fileInfo.repositoryName, fileInfo.repositoryBranch, false), fileInfo.path, fileInfo.name));
                 break;
-            case Eagle.RepositoryService.Url:
+            case Repository.Service.Url:
                 this.loadPalettes([
                     {name:palette.fileInfo().name, filename:palette.fileInfo().downloadUrl, readonly:palette.fileInfo().readonly}
                 ], (errorsWarnings: Errors.ErrorsWarnings, palettes: Palette[]):void => {
@@ -1488,7 +1488,7 @@ export class Eagle {
     }
 
     saveGraph = () : void => {
-        if (this.logicalGraph().fileInfo().repositoryService === Eagle.RepositoryService.File){
+        if (this.logicalGraph().fileInfo().repositoryService === Repository.Service.File){
             this.saveFileToLocal(Eagle.FileType.Graph);
         } else {
             this.commitToGit(Eagle.FileType.Graph);
@@ -1496,7 +1496,7 @@ export class Eagle {
     }
 
     saveGraphAs = () : void => {
-        const isLocalFile = this.logicalGraph().fileInfo().repositoryService === Eagle.RepositoryService.File;
+        const isLocalFile = this.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
 
         Utils.requestUserChoice("Save Graph As", "Please choose where to save the graph", ["Local File", "Remote Git Repository"], isLocalFile?0:1, false, "", (completed: boolean, userChoiceIndex: number) => {
             if (!completed)
@@ -1553,10 +1553,10 @@ export class Eagle {
         let url : string;
 
         switch (repository.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 url = '/saveFileToRemoteGithub';
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 url = '/saveFileToRemoteGitlab';
                 break;
             default:
@@ -1573,10 +1573,10 @@ export class Eagle {
             }
 
             // Load the file list again.
-            if (repository.service === Eagle.RepositoryService.GitHub){
+            if (repository.service === Repository.Service.GitHub){
                 GitHub.loadRepoContent(repository);
             }
-            if (repository.service === Eagle.RepositoryService.GitLab){
+            if (repository.service === Repository.Service.GitLab){
                 GitLab.loadRepoContent(repository);
             }
 
@@ -1584,10 +1584,10 @@ export class Eagle {
             this.rightWindow().mode(Eagle.RightWindowMode.Repository);
 
             // Show success message
-            if (repository.service === Eagle.RepositoryService.GitHub){
+            if (repository.service === Repository.Service.GitHub){
                 Utils.showNotification("Success", "The file has been saved to GitHub repository.", "success");
             }
-            if (repository.service === Eagle.RepositoryService.GitLab){
+            if (repository.service === Repository.Service.GitLab){
                 Utils.showNotification("Success", "The file has been saved to GitLab repository.", "success");
             }
 
@@ -1654,29 +1654,29 @@ export class Eagle {
         if (this.logicalGraph()){
             // if the repository service is unknown (or file), probably because the graph hasn't been saved before, then
             // just use any existing repo
-            if (fileInfo().repositoryService === Eagle.RepositoryService.Unknown || fileInfo().repositoryService === Eagle.RepositoryService.File){
-                const gitHubRepoList : Repository[] = Repositories.getList(Eagle.RepositoryService.GitHub);
-                const gitLabRepoList : Repository[] = Repositories.getList(Eagle.RepositoryService.GitLab);
+            if (fileInfo().repositoryService === Repository.Service.Unknown || fileInfo().repositoryService === Repository.Service.File){
+                const gitHubRepoList : Repository[] = Repositories.getList(Repository.Service.GitHub);
+                const gitLabRepoList : Repository[] = Repositories.getList(Repository.Service.GitLab);
 
                 // use first gitlab repo as second preference
                 if (gitLabRepoList.length > 0){
-                    defaultRepository = new Repository(Eagle.RepositoryService.GitLab, gitLabRepoList[0].name, gitLabRepoList[0].branch, false);
+                    defaultRepository = new Repository(Repository.Service.GitLab, gitLabRepoList[0].name, gitLabRepoList[0].branch, false);
                 }
 
                 // overwrite with first github repo as first preference
                 if (gitHubRepoList.length > 0){
-                    defaultRepository = new Repository(Eagle.RepositoryService.GitHub, gitHubRepoList[0].name, gitHubRepoList[0].branch, false);
+                    defaultRepository = new Repository(Repository.Service.GitHub, gitHubRepoList[0].name, gitHubRepoList[0].branch, false);
                 }
 
                 if (gitHubRepoList.length === 0 && gitLabRepoList.length === 0){
-                    defaultRepository = new Repository(Eagle.RepositoryService.GitHub, "", "", false);
+                    defaultRepository = new Repository(Repository.Service.GitHub, "", "", false);
                 }
             } else {
                 defaultRepository = new Repository(fileInfo().repositoryService, fileInfo().repositoryName, fileInfo().repositoryBranch, false);
             }
         }
 
-        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(defaultRepository.service), fileInfo().path, fileInfo().name, (completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
+        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(defaultRepository.service), fileInfo().path, fileInfo().name, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
             // check completed boolean
             if (!completed){
                 console.log("Abort commit");
@@ -1726,9 +1726,9 @@ export class Eagle {
 
         // if there is no git repository or filename defined for this file. Please use 'save as' instead!
         if (
-            fileInfo().repositoryService === Eagle.RepositoryService.Unknown ||
-            fileInfo().repositoryService === Eagle.RepositoryService.File ||
-            fileInfo().repositoryService === Eagle.RepositoryService.Url ||
+            fileInfo().repositoryService === Repository.Service.Unknown ||
+            fileInfo().repositoryService === Repository.Service.File ||
+            fileInfo().repositoryService === Repository.Service.Url ||
             fileInfo().repositoryName === null
         ) {
             this.commitToGitAs(fileType);
@@ -1801,10 +1801,10 @@ export class Eagle {
         let token : string;
 
         switch (repository.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 token = Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY);
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 token = Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY);
                 break;
             default:
@@ -1899,13 +1899,13 @@ export class Eagle {
         // check the service required to fetch the file
         let openRemoteFileFunc;
         switch (file.repository.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 openRemoteFileFunc = GitHub.openRemoteFile;
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 openRemoteFileFunc = GitLab.openRemoteFile;
                 break;
-            case Eagle.RepositoryService.Url:
+            case Repository.Service.Url:
                 openRemoteFileFunc = Utils.openRemoteFileFromUrl;
                 break;
             default:
@@ -2012,10 +2012,10 @@ export class Eagle {
         // check the service required to fetch the file
         let insertRemoteFileFunc;
         switch (file.repository.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 insertRemoteFileFunc = GitHub.openRemoteFile;
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 insertRemoteFileFunc = GitLab.openRemoteFile;
                 break;
             default:
@@ -2124,7 +2124,7 @@ export class Eagle {
         this.leftWindow().shown(true);
     }
 
-    private updateLogicalGraphFileInfo = (repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, path : string, name : string) : void => {
+    private updateLogicalGraphFileInfo = (repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, path : string, name : string) : void => {
         // update the activeFileInfo with details of the repository the file was loaded from
         this.logicalGraph().fileInfo().repositoryName = repositoryName;
         this.logicalGraph().fileInfo().repositoryBranch = repositoryBranch;
@@ -2233,7 +2233,7 @@ export class Eagle {
             // since changes are now stored locally, the file will have become out of sync with the GitHub repository, so the association should be broken
             // clear the modified flag
             palette.fileInfo().modified = false;
-            palette.fileInfo().repositoryService = Eagle.RepositoryService.Unknown;
+            palette.fileInfo().repositoryService = Repository.Service.Unknown;
             palette.fileInfo().repositoryName = "";
             palette.fileInfo().repositoryUrl = "";
             palette.fileInfo().commitHash = "";
@@ -2282,7 +2282,7 @@ export class Eagle {
             // since changes are now stored locally, the file will have become out of sync with the GitHub repository, so the association should be broken
             // clear the modified flag
             graph.fileInfo().modified = false;
-            graph.fileInfo().repositoryService = Eagle.RepositoryService.File;
+            graph.fileInfo().repositoryService = Repository.Service.File;
             graph.fileInfo().repositoryName = "";
             graph.fileInfo().repositoryUrl = "";
             graph.fileInfo().commitHash = "";
@@ -2296,7 +2296,7 @@ export class Eagle {
 
         const defaultRepository: Repository = new Repository(palette.fileInfo().repositoryService, palette.fileInfo().repositoryName, palette.fileInfo().repositoryBranch, false);
 
-        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(Eagle.RepositoryService.GitHub),  palette.fileInfo().path, palette.fileInfo().name, (completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
+        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(Repository.Service.GitHub),  palette.fileInfo().path, palette.fileInfo().name, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
             // check completed boolean
             if (!completed){
                 console.log("Abort commit");
@@ -2314,10 +2314,10 @@ export class Eagle {
             let token : string;
 
             switch (repositoryService){
-                case Eagle.RepositoryService.GitHub:
+                case Repository.Service.GitHub:
                     token = Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY);
                     break;
-                case Eagle.RepositoryService.GitLab:
+                case Repository.Service.GitLab:
                     token = Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY);
                     break;
                 default:
@@ -4464,7 +4464,7 @@ export class Eagle {
 
         // if we don't know where this file came from then we can't build a URL
         // for example, if the graph was loaded from local disk, then we can't build a URL for others to reach it
-        if (fileInfo.repositoryService === Eagle.RepositoryService.Unknown || fileInfo.repositoryService === Eagle.RepositoryService.File){
+        if (fileInfo.repositoryService === Repository.Service.Unknown || fileInfo.repositoryService === Repository.Service.File){
             Utils.showNotification("Graph URL", "Source of graph is a local file or unknown, unable to create URL for graph.", "danger");
             return;
         }
@@ -4890,14 +4890,6 @@ export namespace Eagle
         Add = "Add",
         Edit = "Edit",
         Field = "Field"
-    }
-
-    export enum RepositoryService {
-        GitHub = "GitHub",
-        GitLab = "GitLab",
-        File = "File",
-        Url = "Url",
-        Unknown = "Unknown"
     }
 
     export enum Direction {

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -3,6 +3,7 @@ import * as ko from "knockout";
 import { Daliuge } from "./Daliuge";
 import { Eagle } from './Eagle';
 import { Errors } from './Errors';
+import { Repository } from "./Repository";
 import { Utils } from './Utils';
 
 
@@ -13,7 +14,7 @@ export class FileInfo {
 
     private _path : ko.Observable<string>;
     private _type : ko.Observable<Eagle.FileType>;
-    private _repositoryService : ko.Observable<Eagle.RepositoryService>;
+    private _repositoryService : ko.Observable<Repository.Service>;
     private _repositoryBranch : ko.Observable<string>;
     private _repositoryName : ko.Observable<string>;
     private _modified : ko.Observable<boolean>;
@@ -41,7 +42,7 @@ export class FileInfo {
 
         this._path = ko.observable("");
         this._type = ko.observable(Eagle.FileType.Unknown);
-        this._repositoryService = ko.observable(Eagle.RepositoryService.Unknown);
+        this._repositoryService = ko.observable(Repository.Service.Unknown);
         this._repositoryBranch = ko.observable("");
         this._repositoryName = ko.observable("");
         this._modified = ko.observable(false);
@@ -103,11 +104,11 @@ export class FileInfo {
         this._type(type);
     }
 
-    get repositoryService() : Eagle.RepositoryService {
+    get repositoryService() : Repository.Service {
         return this._repositoryService();
     }
 
-    set repositoryService(repositoryService : Eagle.RepositoryService){
+    set repositoryService(repositoryService : Repository.Service){
         this._repositoryService(repositoryService);
     }
 
@@ -246,7 +247,7 @@ export class FileInfo {
 
         this._path("");
         this._type(Eagle.FileType.Unknown);
-        this._repositoryService(Eagle.RepositoryService.Unknown);
+        this._repositoryService(Repository.Service.Unknown);
         this._repositoryBranch("");
         this._repositoryName("");
         this._modified(false);
@@ -310,7 +311,7 @@ export class FileInfo {
     }
 
     removeGitInfo = () : void => {
-        this._repositoryService(Eagle.RepositoryService.Unknown);
+        this._repositoryService(Repository.Service.Unknown);
         this._repositoryBranch("");
         this._repositoryName("");
         this._path("");
@@ -339,7 +340,7 @@ export class FileInfo {
 
     getSummaryHTML = (title : string) : string => {
         let text
-        if (this._repositoryService() === Eagle.RepositoryService.Unknown){
+        if (this._repositoryService() === Repository.Service.Unknown){
             text = "- Location -</br>Url:&nbsp;" + this._repositoryUrl() + "</br>Hash:&nbsp;" + this._commitHash();
         } else {
             text = "<p>" + this._repositoryService() + " : " + this._repositoryName() + ((this._repositoryBranch() == "") ? "" : ("(" + this._repositoryBranch() + ")")) + " : " + this._path() + "/" + this._name() + "</p>";
@@ -441,7 +442,7 @@ export class FileInfo {
             result.shortDescription = result.detailedDescription.split('. ', 1)[0];
         }
 
-        result.repositoryService = modelData.repoService ?? Eagle.RepositoryService.Unknown;
+        result.repositoryService = modelData.repoService ?? Repository.Service.Unknown;
         result.repositoryBranch = modelData.repoBranch ?? "";
         result.repositoryName = modelData.repo ?? "";
 

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -45,8 +45,9 @@ export class GitHub {
 
             // remove all GitHub repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Repository.Service.GitHub)
+                if (Repositories.repositories()[i].service === Repository.Service.GitHub){
                     Repositories.repositories.splice(i, 1);
+                }
             }
 
             // add the repositories from the POST response
@@ -95,8 +96,9 @@ export class GitHub {
 
             // remove all GitHub repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Repository.Service.GitHub)
+                if (Repositories.repositories()[i].service === Repository.Service.GitHub){
                     Repositories.repositories.splice(i, 1);
+                }
             }
 
             // add the repositories from the POST response

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -45,13 +45,13 @@ export class GitHub {
 
             // remove all GitHub repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Eagle.RepositoryService.GitHub)
+                if (Repositories.repositories()[i].service === Repository.Service.GitHub)
                     Repositories.repositories.splice(i, 1);
             }
 
             // add the repositories from the POST response
             for (const d of data){
-                Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitHub, d.repository, d.branch, true));
+                Repositories.repositories.push(new Repository(Repository.Service.GitHub, d.repository, d.branch, true));
             }
 
             // search for custom repositories in localStorage, and add them into the list
@@ -62,19 +62,19 @@ export class GitHub {
 
                 // handle legacy repositories where the service and branch are not specified (assume github and master)
                 if (keyExtension === "repository"){
-                    Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitHub, value, "master", false));
+                    Repositories.repositories.push(new Repository(Repository.Service.GitHub, value, "master", false));
                 }
 
                 // handle legacy repositories where the branch is not specified (assume master)
                 if (keyExtension === "github_repository") {
-                    Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitHub, value, "master", false));
+                    Repositories.repositories.push(new Repository(Repository.Service.GitHub, value, "master", false));
                 }
 
                 // handle the current method of storing repositories where both the service and branch are specified
                 if (keyExtension === "github_repository_and_branch"){
                     const repositoryName = value.split("|")[0];
                     const repositoryBranch = value.split("|")[1];
-                    Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitHub, repositoryName, repositoryBranch, false));
+                    Repositories.repositories.push(new Repository(Repository.Service.GitHub, repositoryName, repositoryBranch, false));
                 }
             }
 
@@ -95,13 +95,13 @@ export class GitHub {
 
             // remove all GitHub repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Eagle.RepositoryService.GitHub)
+                if (Repositories.repositories()[i].service === Repository.Service.GitHub)
                     Repositories.repositories.splice(i, 1);
             }
 
             // add the repositories from the POST response
             for (const d of data){
-                Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitHub, d.repository, d.branch, true));
+                Repositories.repositories.push(new Repository(Repository.Service.GitHub, d.repository, d.branch, true));
             }
 
             // sort the repository list
@@ -217,7 +217,7 @@ export class GitHub {
      * Gets the specified remote file from the server
      * @param filePath File path.
      */
-    static openRemoteFile(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
+    static openRemoteFile(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
         const token = Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY);
 
         if (token === null || token === "") {

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -44,8 +44,9 @@ export class GitLab {
 
             // remove all GitLab repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Repository.Service.GitLab)
+                if (Repositories.repositories()[i].service === Repository.Service.GitLab){
                     Repositories.repositories.splice(i, 1);
+                }
             }
 
             // add the repositories from the POST response

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -44,13 +44,13 @@ export class GitLab {
 
             // remove all GitLab repos from the list of repositories
             for (let i = Repositories.repositories().length - 1 ; i >= 0 ; i--){
-                if (Repositories.repositories()[i].service === Eagle.RepositoryService.GitLab)
+                if (Repositories.repositories()[i].service === Repository.Service.GitLab)
                     Repositories.repositories.splice(i, 1);
             }
 
             // add the repositories from the POST response
             for (const d of data){
-                Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitLab, d.repository, d.branch, true));
+                Repositories.repositories.push(new Repository(Repository.Service.GitLab, d.repository, d.branch, true));
             }
 
             // search for custom repositories, and add them into the list.
@@ -61,14 +61,14 @@ export class GitLab {
 
                 // handle legacy repositories where the branch is not specified (assume master)
                 if (keyExtension === "gitlab_repository"){
-                    Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitLab, value, "master", false));
+                    Repositories.repositories.push(new Repository(Repository.Service.GitLab, value, "master", false));
                 }
 
                 // handle the current method of storing repositories where both the service and branch are specified
                 if (keyExtension === "gitlab_repository_and_branch") {
                     const repositoryName = value.split("|")[0];
                     const repositoryBranch = value.split("|")[1];
-                    Repositories.repositories.push(new Repository(Eagle.RepositoryService.GitLab, repositoryName, repositoryBranch, false));
+                    Repositories.repositories.push(new Repository(Repository.Service.GitLab, repositoryName, repositoryBranch, false));
                 }
             }
 
@@ -182,7 +182,7 @@ export class GitLab {
      * Gets the specified remote file from the server
      * @param filePath File path.
      */
-    static openRemoteFile(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
+    static openRemoteFile(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
         const token = Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY);
 
         if (token === null || token === "") {

--- a/src/GraphUpdater.ts
+++ b/src/GraphUpdater.ts
@@ -168,7 +168,7 @@ export class GraphUpdater {
         for (const row of data){
             // determine the correct function to load the file
             let openRemoteFileFunc: any;
-            if (row.service === Eagle.RepositoryService.GitHub){
+            if (row.service === Repository.Service.GitHub){
                 openRemoteFileFunc = GitHub.openRemoteFile;
             } else {
                 openRemoteFileFunc = GitLab.openRemoteFile;

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -152,17 +152,17 @@ export class Modals {
             $('#gitCommitModalAffirmativeButton').trigger("focus");
         });
         $('#gitCommitModal').on('hidden.bs.modal', function(){
-            const callback : (completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void = $('#gitCommitModal').data('callback');
+            const callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void = $('#gitCommitModal').data('callback');
             const completed : boolean = $('#gitCommitModal').data('completed');
 
             // check if the modal was completed (user clicked OK), if not, return false
             if (!completed){
-                callback(false, Eagle.RepositoryService.Unknown, "", "", "", "", "");
+                callback(false, Repository.Service.Unknown, "", "", "", "", "");
                 return;
             }
 
             // check selected option in select tag
-            const repositoryService : Eagle.RepositoryService = <Eagle.RepositoryService>$('#gitCommitModalRepositoryServiceSelect').val();
+            const repositoryService : Repository.Service = <Repository.Service>$('#gitCommitModalRepositoryServiceSelect').val();
             const repositories : Repository[] = $('#gitCommitModal').data('repositories');
             const repositoryNameChoice : number = parseInt($('#gitCommitModalRepositoryNameSelect').val().toString(), 10);
 
@@ -177,7 +177,7 @@ export class Modals {
             callback(true, repositoryService, repositoryName, repositoryBranch, filePath, fileName, commitMessage);
         });
         $('#gitCommitModalRepositoryServiceSelect').on('change', function(){
-            const repositoryService : Eagle.RepositoryService = <Eagle.RepositoryService>$('#gitCommitModalRepositoryServiceSelect').val();
+            const repositoryService : Repository.Service = <Repository.Service>$('#gitCommitModalRepositoryServiceSelect').val();
             const repositories: Repository[] = Repositories.getList(repositoryService);
             $('#gitCommitModal').data('repositories', repositories);
             Utils.updateGitCommitRepositoriesList(repositories, null);

--- a/src/Palette.ts
+++ b/src/Palette.ts
@@ -24,14 +24,15 @@
 
 import * as ko from "knockout";
 
-import {Utils} from './Utils';
-import {Eagle} from './Eagle';
-import {Node} from './Node';
-import {FileInfo} from './FileInfo';
-import {RepositoryFile} from './RepositoryFile';
-import {Errors} from './Errors';
-import {Category} from './Category';
-import {CategoryData} from './CategoryData';
+import { Category } from './Category';
+import { CategoryData } from './CategoryData';
+import { Eagle } from './Eagle';
+import { Errors } from './Errors';
+import { FileInfo } from './FileInfo';
+import { Node } from './Node';
+import { Repository } from "./Repository";
+import { RepositoryFile } from './RepositoryFile';
+import { Utils } from './Utils';
 
 export class Palette {
     fileInfo : ko.Observable<FileInfo>;
@@ -285,7 +286,7 @@ export class Palette {
 
         // if we don't know where this file came from then we can't build a URL
         // for example, if the palette was loaded from local disk, then we can't build a URL for others to reach it
-        if (fileInfo.repositoryService === Eagle.RepositoryService.Unknown || fileInfo.repositoryService === Eagle.RepositoryService.File){
+        if (fileInfo.repositoryService === Repository.Service.Unknown || fileInfo.repositoryService === Repository.Service.File){
             Utils.showNotification("Palette URL", "Source of palette is a local file or unknown, unable to create URL for graph.", "danger");
             return;
         }

--- a/src/PaletteInfo.ts
+++ b/src/PaletteInfo.ts
@@ -1,9 +1,9 @@
 import * as ko from "knockout";
 
-import {Eagle} from './Eagle';
+import { Repository } from "./Repository";
 
 export class PaletteInfo {
-    repositoryService : Eagle.RepositoryService;
+    repositoryService : Repository.Service;
     repositoryName : string;
     repositoryBranch : string;
     name : string
@@ -11,7 +11,7 @@ export class PaletteInfo {
     isFetching: ko.Observable<boolean>
     isSelected: ko.Observable<boolean>
 
-    constructor(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, name : string, path : string){
+    constructor(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, name : string, path : string){
         this.repositoryService = repositoryService;
         this.repositoryName = repositoryName;
         this.repositoryBranch = repositoryBranch;

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -98,10 +98,12 @@ export class Repositories {
             localStorage.setItem(localStorageKey, Utils.getLocalStorageValue(repositoryService, repositoryName, repositoryBranch));
 
             // Reload the repository lists
-            if (repositoryService === Repository.Service.GitHub)
+            if (repositoryService === Repository.Service.GitHub){
                 GitHub.loadRepoList();
-            if (repositoryService === Repository.Service.GitLab)
+            }
+            if (repositoryService === Repository.Service.GitLab){
                 GitLab.loadRepoList();
+            }
         });
     };
 

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -69,7 +69,7 @@ export class Repositories {
 
     // use a custom modal to ask user for repository service and url at the same time
     addCustomRepository = () : void => {
-        Utils.requestUserAddCustomRepository((completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string) : void => {
+        Utils.requestUserAddCustomRepository((completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string) : void => {
             console.log("requestUserAddCustomRepository callback", completed, repositoryService, repositoryName);
 
             if (!completed){
@@ -98,9 +98,9 @@ export class Repositories {
             localStorage.setItem(localStorageKey, Utils.getLocalStorageValue(repositoryService, repositoryName, repositoryBranch));
 
             // Reload the repository lists
-            if (repositoryService === Eagle.RepositoryService.GitHub)
+            if (repositoryService === Repository.Service.GitHub)
                 GitHub.loadRepoList();
-            if (repositoryService === Eagle.RepositoryService.GitLab)
+            if (repositoryService === Repository.Service.GitLab)
                 GitLab.loadRepoList();
         });
     };
@@ -133,13 +133,13 @@ export class Repositories {
 
         // remove from localStorage
         switch(repository.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 localStorage.removeItem(repository.name + ".repository");
                 localStorage.removeItem(repository.name + ".github_repository");
                 localStorage.removeItem(repository.name + "|" + repository.branch + ".github_repository_and_branch");
                 GitHub.loadRepoList();
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 localStorage.removeItem(repository.name + ".gitlab_repository");
                 localStorage.removeItem(repository.name + "|" + repository.branch + ".gitlab_repository_and_branch");
                 GitLab.loadRepoList();
@@ -154,7 +154,7 @@ export class Repositories {
         Repositories.repositories.sort(Repository.repositoriesSortFunc);
     }
 
-    static getList(service : Eagle.RepositoryService) : Repository[]{
+    static getList(service : Repository.Service) : Repository[]{
         const list : Repository[] = [];
 
         for (const repository of Repositories.repositories()){
@@ -166,7 +166,7 @@ export class Repositories {
         return list;
     }
 
-    static get(service : Eagle.RepositoryService, name : string, branch : string) : Repository | null {
+    static get(service : Repository.Service, name : string, branch : string) : Repository | null {
         for (const repository of Repositories.repositories()){
             if (repository.service === service && repository.name === name && repository.branch === branch){
                 return repository;

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -10,7 +10,7 @@ import {GitLab} from "./GitLab";
 export class Repository {
     _id : number
     name : string
-    service : Eagle.RepositoryService
+    service : Repository.Service
     branch : string
     isBuiltIn : boolean
     isFetching: ko.Observable<boolean>
@@ -19,10 +19,10 @@ export class Repository {
     files : ko.ObservableArray<RepositoryFile>
     folders : ko.ObservableArray<RepositoryFolder>
 
-    // NOTE: I think we should be able to use the Eagle.RepositoryService.Unknown enum here, but it causes a javascript error. Not sure why.
-    static readonly DUMMY = new Repository(<Eagle.RepositoryService>"Unknown", "", "", false);
+    // NOTE: I think we should be able to use the Repository.Service.Unknown enum here, but it causes a javascript error. Not sure why.
+    static readonly DUMMY = new Repository(<Repository.Service>"Unknown", "", "", false);
 
-    constructor(service : Eagle.RepositoryService, name : string, branch : string, isBuiltIn : boolean){
+    constructor(service : Repository.Service, name : string, branch : string, isBuiltIn : boolean){
         this._id = Math.floor(Math.random() * 1000000000000);
         this.name = name;
         this.service = service;
@@ -57,10 +57,10 @@ export class Repository {
             this.expanded(!this.expanded());
         } else {
             switch(this.service){
-                case Eagle.RepositoryService.GitHub:
+                case Repository.Service.GitHub:
                     GitHub.loadRepoContent(this);
                     break;
-                case Eagle.RepositoryService.GitLab:
+                case Repository.Service.GitLab:
                     GitLab.loadRepoContent(this);
                     break;
                 default:
@@ -71,10 +71,10 @@ export class Repository {
 
     refresh = () : void => {
         switch(this.service){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 GitHub.loadRepoContent(this);
                 break;
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 GitLab.loadRepoContent(this);
                 break;
             default:
@@ -123,5 +123,15 @@ export class Repository {
         }
 
         return fileNameA.toLowerCase() > fileNameB.toLowerCase() ? 1 : -1;
+    }
+}
+
+export namespace Repository {
+    export enum Service {
+        GitHub = "GitHub",
+        GitLab = "GitLab",
+        File = "File",
+        Url = "Url",
+        Unknown = "Unknown"
     }
 }

--- a/src/RightClick.ts
+++ b/src/RightClick.ts
@@ -4,6 +4,7 @@ import { Field } from './Field';
 import { GraphRenderer } from './GraphRenderer';
 import { Node } from './Node';
 import { Palette } from './Palette';
+import { Repository } from './Repository';
 import { Setting } from './Setting';
 
 
@@ -525,7 +526,7 @@ export class RightClick {
                 if(!data.fileInfo().builtIn){
                     $('#customContextMenu').append('<a onclick="RightClick.rightClickDeletePalette()"><span>Remove Palette</span></a>')
                 }
-                if(data.fileInfo().repositoryService !== Eagle.RepositoryService.Unknown){
+                if(data.fileInfo().repositoryService !== Repository.Service.Unknown){
                     $('#customContextMenu').append('<a onclick="RightClick.rightClickReloadPalette()"><span>Reload Palette</span></a>')
                 }
                 if(Setting.findValue(Setting.ALLOW_PALETTE_EDITING)){
@@ -538,7 +539,7 @@ export class RightClick {
                 if(!data.searchExclude()){
                     $('#customContextMenu').append('<a onclick="RightClick.rightClickToggleSearchExclude(true)"><span>Exclude From Search</span></a>')
                 }
-                if(data.fileInfo().repositoryService !== Eagle.RepositoryService.Unknown && data.fileInfo().repositoryService !== Eagle.RepositoryService.File){
+                if(data.fileInfo().repositoryService !== Repository.Service.Unknown && data.fileInfo().repositoryService !== Repository.Service.File){
                     $('#customContextMenu').append('<a onclick="RightClick.rightClickCopyPaletteUrl()"><span>Copy Palette URL</span></a>')
                 }
             }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -1,6 +1,7 @@
 import * as ko from "knockout";
 
 import { Eagle } from './Eagle';
+import { Repository } from "./Repository";
 import { UiModeSystem } from './UiModes';
 import { Utils } from './Utils';
 
@@ -291,7 +292,10 @@ export class Setting {
 
     static readonly TRANSLATOR_URL : string = "TranslatorURL";
     static readonly TRANSLATOR_ALGORITHM_DEFAULT : string = "TranslatorAlgorithmDefault";
+
+    static readonly EXPLORE_PALETTES_SERVICE : string = "ExplorePalettesService";
     static readonly EXPLORE_PALETTES_REPOSITORY : string = "ExplorePalettesRepository";
+    static readonly EXPLORE_PALETTES_BRANCH : string = "ExplorePalettesBranch";
 
     static readonly TRANSLATE_WITH_NEW_CATEGORIES: string = "TranslateWithNewCategories"; // temp fix for incompatibility with the DaLiuGE translator
 
@@ -409,7 +413,9 @@ const settings : SettingsGroup[] = [
             new Setting(true, "GitLab Access Token", Setting.GITLAB_ACCESS_TOKEN_KEY, "A users access token for GitLab repositories.", true, Setting.Type.Password, "","","", "", ""),
             new Setting(true, "Docker Hub Username", Setting.DOCKER_HUB_USERNAME, "The username to use when retrieving data on images stored on Docker Hub", true, Setting.Type.String, "icrar","icrar","icrar", "icrar", "icrar"),
             new Setting(false, "Default Translation Algorithm", Setting.TRANSLATOR_ALGORITHM_DEFAULT, "Which of the algorithms will be used by default", true, Setting.Type.String, "agl-1", "agl-1", "agl-1", "agl-1", "agl-1"),
-            new Setting(true, "Explore Palettes Repository", Setting.EXPLORE_PALETTES_REPOSITORY, "The repository from which palettes will be fetched by the 'Explore Palettes' feature", true, Setting.Type.String, "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo" )
+            new Setting(true, "Explore Palettes Service", Setting.EXPLORE_PALETTES_SERVICE, "The service hosting the repository from which palettes will be fetched by the 'Explore Palettes' feature", true, Setting.Type.Select, Repository.Service.GitHub, Repository.Service.GitHub, Repository.Service.GitHub, Repository.Service.GitHub, Repository.Service.GitHub, [Repository.Service.GitHub /*, Repository.Service.GitLab*/]),
+            new Setting(true, "Explore Palettes Repository", Setting.EXPLORE_PALETTES_REPOSITORY, "The repository from which palettes will be fetched by the 'Explore Palettes' feature", true, Setting.Type.String, "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo", "ICRAR/EAGLE-graph-repo"),
+            new Setting(true, "Explore Palettes Branch", Setting.EXPLORE_PALETTES_BRANCH, "The branch of the repository from which palettes will be fetched by the 'Explore Palettes' feature", true, Setting.Type.String, "master", "master", "master", "master", "master"),
         ]
     ),
     new SettingsGroup(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -605,14 +605,14 @@ export class Utils {
         $('#confirmModal').modal("toggle");
     }
 
-    static requestUserGitCommit(defaultRepository : Repository, repositories: Repository[], filePath: string, fileName: string, callback : (completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void ) : void {
+    static requestUserGitCommit(defaultRepository : Repository, repositories: Repository[], filePath: string, fileName: string, callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void ) : void {
         $('#gitCommitModal').data('completed', false);
         $('#gitCommitModal').data('callback', callback);
         $('#gitCommitModal').data('repositories', repositories);
         $('#gitCommitModal').modal("toggle");
 
         //
-        let defaultRepositoryService: Eagle.RepositoryService = Eagle.RepositoryService.Unknown;
+        let defaultRepositoryService: Repository.Service = Repository.Service.Unknown;
         if (defaultRepository !== null){
             defaultRepositoryService = defaultRepository.service;
         }
@@ -622,14 +622,14 @@ export class Utils {
 
         // add options to the repository service select tag
         $('#gitCommitModalRepositoryServiceSelect').append($('<option>', {
-            value: Eagle.RepositoryService.GitHub,
-            text: Eagle.RepositoryService.GitHub,
-            selected: defaultRepositoryService === Eagle.RepositoryService.GitHub
+            value: Repository.Service.GitHub,
+            text: Repository.Service.GitHub,
+            selected: defaultRepositoryService === Repository.Service.GitHub
         }));
         $('#gitCommitModalRepositoryServiceSelect').append($('<option>', {
-            value: Eagle.RepositoryService.GitLab,
-            text: Eagle.RepositoryService.GitLab,
-            selected: defaultRepositoryService === Eagle.RepositoryService.GitLab
+            value: Repository.Service.GitLab,
+            text: Repository.Service.GitLab,
+            selected: defaultRepositoryService === Repository.Service.GitLab
         }));
 
         Utils.updateGitCommitRepositoriesList(repositories, defaultRepository);
@@ -647,7 +647,7 @@ export class Utils {
         $('#editFieldModal').modal("toggle");
     }
 
-    static requestUserAddCustomRepository(callback : (completed : boolean, repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string) => void) : void {
+    static requestUserAddCustomRepository(callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string) => void) : void {
         $('#gitCustomRepositoryModalRepositoryNameInput').val("");
         $('#gitCustomRepositoryModalRepositoryBranchInput').val("");
 
@@ -665,7 +665,7 @@ export class Utils {
         $('#gitCustomRepositoryModalRepositoryBranchInput').removeClass('is-invalid');
 
         // check service
-        if (repositoryService.trim() !== Eagle.RepositoryService.GitHub && repositoryService.trim() !== Eagle.RepositoryService.GitLab){
+        if (repositoryService.trim() !== Repository.Service.GitHub && repositoryService.trim() !== Repository.Service.GitLab){
             return false;
         }
 
@@ -743,7 +743,7 @@ export class Utils {
         palette.fileInfo().builtIn = true;
         palette.fileInfo().downloadUrl = paletteListItem.filename;
         palette.fileInfo().type = Eagle.FileType.Palette;
-        palette.fileInfo().repositoryService = Eagle.RepositoryService.Url;
+        palette.fileInfo().repositoryService = Repository.Service.Url;
 
         // sort palette and add to results
         palette.sort();
@@ -759,8 +759,9 @@ export class Utils {
 
         // add parameters in json data
         const jsonData = {
+            service: Setting.findValue(Setting.EXPLORE_PALETTES_SERVICE),
             repository: Setting.findValue(Setting.EXPLORE_PALETTES_REPOSITORY),
-            branch: "master",
+            branch: Setting.findValue(Setting.EXPLORE_PALETTES_BRANCH),
             token: token,
         };
 
@@ -784,7 +785,7 @@ export class Utils {
 
             const explorePalettes: PaletteInfo[] = [];
             for (const palette of data){
-                explorePalettes.push(new PaletteInfo(Eagle.RepositoryService.GitHub, jsonData.repository, jsonData.branch, palette.name, palette.path));
+                explorePalettes.push(new PaletteInfo(jsonData.service, jsonData.repository, jsonData.branch, palette.name, palette.path));
             }
 
             // process files into a more complex structure
@@ -1294,18 +1295,18 @@ export class Utils {
         UiModeSystem.saveToLocalStorage()
     }
 
-    static getLocalStorageKey(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string) : string {
+    static getLocalStorageKey(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string) : string {
         switch (repositoryService){
-            case Eagle.RepositoryService.GitHub:
+            case Repository.Service.GitHub:
                 return repositoryName + "|" + repositoryBranch + ".github_repository_and_branch";
-            case Eagle.RepositoryService.GitLab:
+            case Repository.Service.GitLab:
                 return repositoryName + "|" + repositoryBranch + ".gitlab_repository_and_branch";
             default:
                 return null;
         }
     }
 
-    static getLocalStorageValue(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string) : string {
+    static getLocalStorageValue(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string) : string {
         return repositoryName+"|"+repositoryBranch;
     }
 
@@ -2289,7 +2290,7 @@ export class Utils {
         return result;
     }
 
-    static openRemoteFileFromUrl(repositoryService : Eagle.RepositoryService, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
+    static openRemoteFileFromUrl(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string, data : string) => void ) : void {
         Utils.httpGet(fileName, (data: string) => {callback(null, data)}, (error: string) => {callback(error, null)});
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ $(function(){
     (<any>window).Hierarchy = Hierarchy;
     (<any>window).ParameterTable = ParameterTable;
     (<any>window).Repositories = Repositories;
+    (<any>window).Repository = Repository;
     (<any>window).RightClick = RightClick;
     (<any>window).Setting = Setting;
     (<any>window).SideWindow = SideWindow;
@@ -293,28 +294,28 @@ function autoLoad(eagle: Eagle) {
     const url        = (<any>window).auto_load_url;
 
     // cast the service string to an enum
-    const realService: Eagle.RepositoryService = Eagle.RepositoryService[service as keyof typeof Eagle.RepositoryService];
+    const realService: Repository.Service = Repository.Service[service as keyof typeof Repository.Service];
 
     // skip unknown services
-    if (typeof realService === "undefined" || realService === Eagle.RepositoryService.Unknown){
+    if (typeof realService === "undefined" || realService === Repository.Service.Unknown){
         console.log("No auto load. Service Unknown");
         return;
     }
 
     // skip empty strings
-    if ([Eagle.RepositoryService.GitHub, Eagle.RepositoryService.GitLab].includes(realService) && (repository === "" || branch === "" || filename === "")){
+    if ([Repository.Service.GitHub, Repository.Service.GitLab].includes(realService) && (repository === "" || branch === "" || filename === "")){
         console.log("No auto load. Repository, branch or filename not specified");
         return;
     }
 
     // skip url if url is not specified
-    if (realService === Eagle.RepositoryService.Url && url === ""){
+    if (realService === Repository.Service.Url && url === ""){
         console.log("No auto load. Url not specified");
         return;
     }
 
     // load
-    if (service === Eagle.RepositoryService.Url){
+    if (service === Repository.Service.Url){
         Repositories.selectFile(new RepositoryFile(new Repository(service, "", "", false), "", url));
     } else {
         Repositories.selectFile(new RepositoryFile(new Repository(service, repository, branch, false), path, filename));

--- a/static/components/repository.html
+++ b/static/components/repository.html
@@ -10,10 +10,10 @@
             <i class="material-icons md-18 interactive" data-bs-placement="bottom" data-bind="click: refresh, visible: (folders().length != 0 || files().length != 0)&& fetched, eagleTooltip: 'Refresh'">cloud_done</i>
 
             <!-- ko ifnot: fetched -->
-            <!-- ko if: service === Eagle.RepositoryService.GitHub -->
+            <!-- ko if: service === Repository.Service.GitHub -->
             <img src="static/assets/img/GitHub-Mark-32px.png" data-bind="click: select" width="18px" />
             <!-- /ko -->
-            <!-- ko if: service === Eagle.RepositoryService.GitLab -->
+            <!-- ko if: service === Repository.Service.GitLab -->
             <img src="static/assets/img/fi-cnsuxt-gitlab-alt-solid.png" data-bind="click: select" width="18px"/>
             <!-- /ko -->
             <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -41,7 +41,7 @@
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
                     <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove Palette</span></a>
                     <!-- /ko -->
-                    <!-- ko if: $data.fileInfo().repositoryService !== Eagle.RepositoryService.Unknown -->
+                    <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown -->
                     <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}, clickBubble: false" data-html="true"><span>Reload Palette</span></a>
                     <!-- /ko -->
                     <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
@@ -51,7 +51,7 @@
                     <!-- ko if: $data.searchExclude() -->
                     <a href="#" data-bind="click: function(){$data.setSearchExclude(false)}"><span>Include In Search</span></a>
                     <!-- /ko -->
-                    <!-- ko if: $data.fileInfo().repositoryService !== Eagle.RepositoryService.Unknown && $data.fileInfo().repositoryService !== Eagle.RepositoryService.File -->
+                    <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown && $data.fileInfo().repositoryService !== Repository.Service.File -->
                     <a href="#" data-bind="click: $data.copyUrl"><span>Copy Palette URL</span></a>
                     <!-- /ko -->
                     <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show Palette ModelData</span></a>

--- a/tools/updateGraph.ts
+++ b/tools/updateGraph.ts
@@ -9,6 +9,7 @@ import { FileInfo } from '../src/FileInfo';
 import { GraphUpdater } from '../src/GraphUpdater';
 import { LogicalGraph } from '../src/LogicalGraph';
 import { Node } from '../src/Node';
+import { Repository } from "../src/Repository";
 import { Utils } from '../src/Utils';
 
 
@@ -97,7 +98,7 @@ function readFileInfo(modelData : any, inputFilename : string) : FileInfo {
     result.gitUrl = modelData.git_url;
 
     // NOTE: if the incoming data (modelData) does not indicate the service, assume it is GitHub
-    result.repositoryService = modelData.repoService ?? Eagle.RepositoryService.GitHub;
+    result.repositoryService = modelData.repoService ?? Repository.Service.GitHub;
     result.repositoryName = modelData.repo;
     result.sha = modelData.sha;
 


### PR DESCRIPTION
Moved Eagle.RepositoryService enum to Repository.Service.
Added setting for 'explore palettes' service and branch (Setting.EXPLORE_PALETTES_SERVICE, Setting.EXPLORE_PALETTES_BRANCH)
Minor cleanup.

You can test this buy switching to use ICRAR/EAGLE_test_repo (note underscores) instead of ICRAR/EAGLE-graph-repo (note hyphens) and exploring a different set of palettes.

NOTE: only GitHub repositories are supported on the eagleServer.py side. So I've restricted the options for the repository service setting to just GitHub. I'll add GitLab at some point in the future (EAGLE-1219)