### PR TITLE
EAGLE-1226: Duplicate edge in graph causes issues that can't be fixed

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -443,7 +443,11 @@ export class Edge {
 
         // check if the edge already exists in the graph, there is no point in a duplicate
         for (const edge of eagle.logicalGraph().getEdges()){
-            if (edge.getSrcPortId() === sourcePortId && edge.getDestPortId() === destinationPortId && edge.getId() !== edgeId){
+            if (edge.getSrcNodeKey() === sourceNodeKey &&
+                edge.getSrcPortId() === sourcePortId &&
+                edge.getDestNodeKey() === destinationNodeKey &&
+                edge.getDestPortId() === destinationPortId &&
+                edge.getId() !== edgeId){
                 const x = Errors.ShowFix("Edge is a duplicate. Another edge with the same source port and destination port already exists", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDeleteEdge(eagle, edgeId);}, "Delete edge");
                 Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
             }

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -443,11 +443,10 @@ export class Edge {
 
         // check if the edge already exists in the graph, there is no point in a duplicate
         for (const edge of eagle.logicalGraph().getEdges()){
-            if (edge.getSrcNodeKey() === sourceNodeKey &&
-                edge.getSrcPortId() === sourcePortId &&
-                edge.getDestNodeKey() === destinationNodeKey &&
-                edge.getDestPortId() === destinationPortId &&
-                edge.getId() !== edgeId){
+            const isSrcMatch = edge.getSrcNodeKey() === sourceNodeKey && edge.getSrcPortId() === sourcePortId;
+            const isDestMatch = edge.getDestNodeKey() === destinationNodeKey && edge.getDestPortId() === destinationPortId;
+
+            if ( isSrcMatch && isDestMatch && edge.getId() !== edgeId){
                 const x = Errors.ShowFix("Edge is a duplicate. Another edge with the same source port and destination port already exists", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDeleteEdge(eagle, edgeId);}, "Delete edge");
                 Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
             }

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2214,8 +2214,19 @@ export class GraphRenderer {
         const inputPort = eagle.logicalGraph().findNodeByKeyQuiet(edge.getSrcNodeKey()).findFieldById(edge.getSrcPortId())
         const outputPort = eagle.logicalGraph().findNodeByKeyQuiet(edge.getDestNodeKey()).findFieldById(edge.getDestPortId())
         
-        inputPort.setPeek(value)
-        outputPort.setPeek(value)
+        // if the input port found, set peek
+        if (inputPort !== null){
+            inputPort.setPeek(value);
+        } else {
+            console.warn("Could not find input port of edge. Unable to set peek.")
+        }
+
+        // if the output port found, set peek
+        if (outputPort !== null){
+            outputPort.setPeek(value);
+        } else {
+            console.warn("Could not find output port of edge. Unable to set peek.")
+        }
     }
 
     static edgeGetStrokeColor(edge: Edge) : string {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1456,7 +1456,7 @@ export class Utils {
                         const issue: Errors.Issue = Errors.ShowFix(
                             "Field (" + field.getDisplayText() + ") on node (" + node.getName() + ") does not have a unique id",
                             function(){Utils.showNode(eagle, Eagle.FileType.Graph, node.getId())},
-                            function(){Utils.newId(field)},
+                            function(){Utils.newFieldId(eagle, node, field)},
                             "Assign field a new id"
                         );
                         errorsWarnings.errors.push(issue);
@@ -1985,8 +1985,28 @@ export class Utils {
         eagle.undo().pushSnapshot(eagle, "Fix");
     }
 
-    static newId(object: Node | Edge | Field): void {
+    static newId(object: Node | Edge): void {
         object.setId(Utils.uuidv4());
+    }
+
+    static newFieldId(eagle: Eagle, node: Node, field: Field){
+        const oldId = field.getId();
+        const newId: string = Utils.uuidv4();
+    
+        // loop over all edges
+        for (const edge of eagle.logicalGraph().getEdges()){
+            // update the src port id, if required
+            if (edge.getSrcNodeKey() === node.getKey() && edge.getSrcPortId() === oldId){
+                edge.setSrcPortId(newId);
+            }
+            // update the dest port id, if required
+            if (edge.getDestNodeKey() === node.getKey() && edge.getDestPortId() === oldId){
+                edge.setDestPortId(newId);
+            }
+        }
+
+        // update the field
+        field.setId(newId);
     }
     
     static showEdge(eagle: Eagle, edgeId: string): void {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1989,7 +1989,7 @@ export class Utils {
         object.setId(Utils.uuidv4());
     }
 
-    static newFieldId(eagle: Eagle, node: Node, field: Field){
+    static newFieldId(eagle: Eagle, node: Node, field: Field): void {
         const oldId = field.getId();
         const newId: string = Utils.uuidv4();
     


### PR DESCRIPTION
Fix for errors on this graph:

https://eagle.icrar.org/?service=GitHub&repository=ICRAR/EAGLE_test_repo&branch=master&path=rascil&filename=RascilImagerTest-dev.graph

Prevent duplicate edge error when edges connect ports with duplicate ids, but on different nodes.
Improve fix function for fields with duplicate ids, now also updates associated edges.
Added catch in setPeek for javascript error caused by this issue.