### PR TITLE
EAGLE-1231: Added 'encoding' attribute to fields

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -85,6 +85,15 @@ export namespace Daliuge {
         Python = "Python"
     }
 
+    export enum Encoding {
+        Binary = "binary",
+        Pickle = "pickle",
+        Dill = "dill",
+        Npy = "npy",
+        Base64 = "base64",
+        UTF8 = "utf-8"
+    }
+
     export enum FieldType {
         ApplicationArgument = "ApplicationArgument",
         ComponentParameter = "ComponentParameter",

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -15,6 +15,7 @@ export class Field {
     private options : ko.ObservableArray<string>;
     private positional : ko.Observable<boolean>;
     private keyAttribute : ko.Observable<boolean>;
+    private encoding : ko.Observable<Daliuge.Encoding>;
 
     // port-specific attributes
     private id : ko.Observable<string>;
@@ -45,6 +46,7 @@ export class Field {
         this.options = ko.observableArray(options);
         this.positional = ko.observable(positional);
         this.keyAttribute = ko.observable(keyAttribute);
+        this.encoding = ko.observable(Daliuge.Encoding.UTF8);
 
         this.id = ko.observable(id);
         this.parameterType = ko.observable(parameterType);
@@ -180,6 +182,14 @@ export class Field {
 
     toggleKeyAttribute = () => {
         this.keyAttribute(!this.keyAttribute())
+    }
+
+    setEncoding = (encoding: Daliuge.Encoding) => {
+        this.encoding(encoding);
+    }
+
+    getEncoding = () : Daliuge.Encoding => {
+        return this.encoding();
     }
 
     valIsTrue = (val:string) : boolean => {
@@ -333,6 +343,7 @@ export class Field {
         this.parameterType(Daliuge.FieldType.Unknown);
         this.usage(Daliuge.FieldUsage.NoPort);
         this.keyAttribute(false);
+        this.encoding(Daliuge.Encoding.UTF8);
 
         this.id("");
         this.isEvent(false);
@@ -346,8 +357,9 @@ export class Field {
         }
 
         const f = new Field(this.id(), this.displayText(), this.value(), this.defaultValue(), this.description(), this.readonly(), this.type(), this.precious(), options, this.positional(), this.parameterType(), this.usage(), this.keyAttribute());
-        f.setIsEvent(this.isEvent());
-        f.setNodeKey(this.nodeKey());
+        f.encoding(this.encoding());
+        f.isEvent(this.isEvent());
+        f.nodeKey(this.nodeKey());
         return f;
     }
 
@@ -375,7 +387,8 @@ export class Field {
         this.positional(src.positional());
         this.parameterType(src.parameterType());
         this.usage(src.usage());
-        this.setKeyAttribute(src.keyAttribute());
+        this.keyAttribute(src.keyAttribute());
+        this.encoding(src.encoding());
         this.isEvent(src.isEvent());
 
         // NOTE: these two are not copied from the src, but come from the function's parameters
@@ -573,6 +586,7 @@ export class Field {
             options:field.options(),
             positional:field.positional(),
             keyAttribute:field.keyAttribute(),
+            encoding:field.encoding(),
             id: field.id(),
             parameterType: field.parameterType(),
             usage: field.usage(),
@@ -593,6 +607,7 @@ export class Field {
             options:field.options(),
             positional: field.positional(),
             keyAttribute:field.keyAttribute(),
+            encoding:field.encoding(),
             id: field.id(),
             parameterType: field.parameterType(),
             usage: field.usage()
@@ -608,7 +623,8 @@ export class Field {
             event:field.isEvent(),
             type:field.type(),
             description:field.description(),
-            keyAttribute:field.keyAttribute()
+            keyAttribute:field.keyAttribute(),
+            encoding:field.encoding()
         };
     }
 
@@ -627,6 +643,7 @@ export class Field {
         let usage: Daliuge.FieldUsage = Daliuge.FieldUsage.NoPort;
         let isEvent: boolean = false;
         let keyAttribute: boolean = false;
+        let encoding: Daliuge.Encoding = Daliuge.Encoding.UTF8;
 
         if (typeof data.id !== 'undefined')
             id = data.id;
@@ -697,8 +714,11 @@ export class Field {
             isEvent = data.event;
         if (typeof data.keyAttribute !== 'undefined')
             keyAttribute = data.keyAttribute;
+        if (typeof data.encoding !== 'undefined')
+            encoding = data.encoding;
         const result = new Field(id, name, value, defaultValue, description, readonly, type, precious, options, positional, parameterType, usage, keyAttribute);
-        result.setIsEvent(isEvent);
+        result.isEvent(isEvent);
+        result.encoding(encoding);
         return result;
     }
 
@@ -708,6 +728,7 @@ export class Field {
         let type: string;
         let description: string = "";
         let keyAttribute: boolean = false;
+        let encoding: Daliuge.Encoding = Daliuge.Encoding.UTF8;
 
         if (typeof data.name !== 'undefined')
             name = data.name;
@@ -719,6 +740,8 @@ export class Field {
             description = data.description;
         if (typeof data.keyAttribute !== 'undefined')
             keyAttribute = data.keyAttribute;
+        if (typeof data.encoding !== 'undefined')
+            encoding = data.encoding;
 
         // avoid empty text fields if we can
         if (name === ""){
@@ -726,7 +749,8 @@ export class Field {
         }
      
         const f = new Field(data.Id, name, "", "", description, false, type, false, [], false, Daliuge.FieldType.Unknown, Daliuge.FieldUsage.NoPort, keyAttribute);
-        f.setIsEvent(event);
+        f.isEvent(event);
+        f.encoding(encoding);
         return f;
     }
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -567,19 +567,45 @@ export class ColumnVisibilities {
         }else{
             columnVisibilitiesObjArray.forEach(function(columnvisibility){
                 const columnVisActual:ColumnVisibilities = that.getModeByName(columnvisibility.name)
-                columnVisActual.setKeyAttribute(columnvisibility.keyAttribute)
-                columnVisActual.setDisplayText(columnvisibility.displayText)
-                columnVisActual.setFieldId(columnvisibility.fieldId)
-                columnVisActual.setValue(columnvisibility.value)
-                columnVisActual.setReadOnly(columnvisibility.readOnly)
-                columnVisActual.setDefaultValue(columnvisibility.defaultValue)
-                columnVisActual.setDescription(columnvisibility.description)
-                columnVisActual.setType(columnvisibility.type)
-                columnVisActual.setParameterType(columnvisibility.parameterType)
-                columnVisActual.setUsage(columnvisibility.usage)
-                columnVisActual.setEncoding(columnvisibility.encoding)
-                columnVisActual.setFlags(columnvisibility.flags)
-                columnVisActual.setActions(columnvisibility.actions)
+                if(columnvisibility.keyAttribute){
+                    columnVisActual.setKeyAttribute(columnvisibility.keyAttribute)
+                }
+                if(columnvisibility.displayText){
+                    columnVisActual.setDisplayText(columnvisibility.displayText)
+                }
+                if(columnvisibility.fieldId){
+                    columnVisActual.setFieldId(columnvisibility.fieldId)
+                }
+                if(columnvisibility.value){
+                    columnVisActual.setValue(columnvisibility.value)
+                }
+                if(columnvisibility.readOnly){
+                    columnVisActual.setReadOnly(columnvisibility.readOnly)
+                }
+                if(columnvisibility.defaultValue){
+                    columnVisActual.setDefaultValue(columnvisibility.defaultValue)
+                }
+                if(columnvisibility.description){
+                    columnVisActual.setDescription(columnvisibility.description)
+                }
+                if(columnvisibility.type){
+                    columnVisActual.setType(columnvisibility.type)
+                }
+                if(columnvisibility.parameterType){
+                    columnVisActual.setParameterType(columnvisibility.parameterType)
+                }
+                if(columnvisibility.usage){
+                    columnVisActual.setUsage(columnvisibility.usage)
+                }
+                if(columnvisibility.encoding){
+                    columnVisActual.setEncoding(columnvisibility.encoding)
+                }
+                if(columnvisibility.flags){
+                    columnVisActual.setFlags(columnvisibility.flags)
+                }
+                if(columnvisibility.actions){
+                    columnVisActual.setActions(columnvisibility.actions)
+                }
             })
         }
     }

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -367,10 +367,11 @@ export class ColumnVisibilities {
     private type:ko.Observable<boolean>
     private parameterType:ko.Observable<boolean>
     private usage:ko.Observable<boolean>
+    private encoding:ko.Observable<boolean>
     private flags:ko.Observable<boolean>
     private actions:ko.Observable<boolean>
 
-    constructor(uiModeName:string, keyAttribute:boolean, displayText:boolean,fieldId:boolean,value:boolean,readOnly:boolean,defaultValue:boolean,description:boolean,type:boolean,parameterType:boolean,usage:boolean,flags:boolean,actions:boolean){
+    constructor(uiModeName:string, keyAttribute:boolean, displayText:boolean,fieldId:boolean,value:boolean,readOnly:boolean,defaultValue:boolean,description:boolean,type:boolean,parameterType:boolean,usage:boolean,encoding:boolean,flags:boolean,actions:boolean){
 
         this.uiModeName = uiModeName;
         this.keyAttribute = ko.observable(keyAttribute);
@@ -383,6 +384,7 @@ export class ColumnVisibilities {
         this.type = ko.observable(type);
         this.parameterType = ko.observable(parameterType);
         this.usage = ko.observable(usage);
+        this.encoding = ko.observable(encoding);
         this.flags = ko.observable(flags);
         this.actions = ko.observable(actions);
 
@@ -454,6 +456,10 @@ export class ColumnVisibilities {
         this.usage(value);
     }
 
+    private setEncoding = (value:boolean) : void => {
+        this.encoding(value);
+    }
+
     private setFlags = (value:boolean) : void => {
         this.flags(value);
     }
@@ -513,6 +519,11 @@ export class ColumnVisibilities {
         this.saveToLocalStorage()
     }
 
+    private toggleEncoding = () : void => {
+        this.encoding(!this.encoding());
+        this.saveToLocalStorage()
+    }
+
     private toggleFlags = () : void => {
         this.flags(!this.flags());
         this.saveToLocalStorage()
@@ -538,6 +549,7 @@ export class ColumnVisibilities {
                 type : columnVis.type(),
                 parameterType : columnVis.parameterType(),
                 usage : columnVis.usage(),
+                encoding : columnVis.encoding(),
                 flags : columnVis.flags(),
                 actions : columnVis.actions(),
                 
@@ -565,6 +577,7 @@ export class ColumnVisibilities {
                 columnVisActual.setType(columnvisibility.type)
                 columnVisActual.setParameterType(columnvisibility.parameterType)
                 columnVisActual.setUsage(columnvisibility.usage)
+                columnVisActual.setEncoding(columnvisibility.encoding)
                 columnVisActual.setFlags(columnvisibility.flags)
                 columnVisActual.setActions(columnvisibility.actions)
             })
@@ -575,9 +588,9 @@ export class ColumnVisibilities {
 
 // name, keyAttribute,displayText,value,readOnly,defaultValue,description,type,parameterType,usage,flags,actions
 const columnVisibilities : ColumnVisibilities[] = [
-    new ColumnVisibilities( "Student", false, true,false,true,true,false,false,false,false,false,false,false),
-    new ColumnVisibilities("Minimal", true, true,false,true,true,false,false,false,false,false,true,false),
-    new ColumnVisibilities("Graph", true, true,false,true,true,true,false,true,true,true,true,true),
-    new ColumnVisibilities("Component", true, true,false,true,true,true,true,true,true,true,true,true),
-    new ColumnVisibilities("Expert", true, true,false,true,true,true,true,true,true,true,true,true),
+    new ColumnVisibilities("Student", false, true,false,true,true,false,false,false,false,false,false,false,false),
+    new ColumnVisibilities("Minimal", true, true,false,true,true,false,false,false,false,false,true,false,false),
+    new ColumnVisibilities("Graph", true, true,false,true,true,true,false,true,true,true,true,true,true),
+    new ColumnVisibilities("Component", true, true,false,true,true,true,true,true,true,true,true,true,true),
+    new ColumnVisibilities("Expert", true, true,false,true,true,true,true,true,true,true,true,true,true),
 ]

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -589,8 +589,8 @@ export class ColumnVisibilities {
 // name, keyAttribute,displayText,value,readOnly,defaultValue,description,type,parameterType,usage,flags,actions
 const columnVisibilities : ColumnVisibilities[] = [
     new ColumnVisibilities("Student", false, true,false,true,true,false,false,false,false,false,false,false,false),
-    new ColumnVisibilities("Minimal", true, true,false,true,true,false,false,false,false,false,true,false,false),
+    new ColumnVisibilities("Minimal", true, true,false,true,true,false,false,false,false,false,false,true,false),
     new ColumnVisibilities("Graph", true, true,false,true,true,true,false,true,true,true,true,true,true),
     new ColumnVisibilities("Component", true, true,false,true,true,true,true,true,true,true,true,true,true),
-    new ColumnVisibilities("Expert", true, true,false,true,true,true,true,true,true,true,true,true,true),
+    new ColumnVisibilities("Expert", true, true,false,true,true,true,true,true,true,true,true,true,true)
 ]

--- a/templates/modals/parameter_table.html
+++ b/templates/modals/parameter_table.html
@@ -33,6 +33,7 @@
                             <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFlags()}"><span>Flags</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().flags()"></div>
                             <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleParameterType()}"><span>Parameter Type</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().parameterType()"></div>
                             <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleUsage()}"><span>Use As</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().usage()"></div>
+                            <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleEncoding()}"><span>Encoding</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().encoding()"></div>
                             <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleActions()}"><span>Actions</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().actions()"></div>
                         </div>
                     </div>
@@ -107,7 +108,10 @@
                                     <th id="parameter_table_parameter_type" data-bind="eagleTooltip:'The way this parameter will be used by the component. ComponentParameters are passed to the DALiuGE execution framework. ApplicationArguments are passed to the Application executed by this component.'" data-bs-placement="top">Parameter Type</th>
                                 <!-- /ko -->
                                 <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
-                                    <th id="parameter_table_usage" data-bind="eagleTooltip:'InputPorts and OutputPorts are used to specify named inputs and outputs from this Component.'" data-bs-placement="top">Use As</th>
+                                <th id="parameter_table_usage" data-bind="eagleTooltip:'InputPorts and OutputPorts are used to specify named inputs and outputs from this Component.'" data-bs-placement="top">Use As</th>
+                                <!-- /ko -->
+                                <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
+                                <th id="parameter_table_encoding" data-bind="eagleTooltip:'The way data is encoded when passing through this port.'" data-bs-placement="top">Encoding</th>
                                 <!-- /ko -->
                                 <!-- ko if: ParameterTable.getActiveColumnVisibility().actions() -->
                                     <th id="parameter_table_actions" data-bind="eagleTooltip:'Additional operations that are possible on this parameter (e.g. Delete, Duplicate etc)'" data-bs-placement="top">Actions</th>
@@ -304,11 +308,19 @@
                                         <!-- /ko -->
                                         
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
-                                            <td class='columnCell column_Usage'>
-                                                <select class="tbaleFieldUseAs" data-bind="options: Object.values(Daliuge.FieldUsage), value: usage, disabled: $root.parameterTable().getParamsTableEditState() , event: {change: ParameterTable.fieldUsageChanged}">
-                                                    <!-- options are added dynamically -->
-                                                </select>
-                                            </td>
+                                        <td class='columnCell column_Usage'>
+                                            <select class="tbaleFieldUseAs" data-bind="options: Object.values(Daliuge.FieldUsage), value: usage, disabled: $root.parameterTable().getParamsTableEditState() , event: {change: ParameterTable.fieldUsageChanged}">
+                                                <!-- options are added dynamically -->
+                                            </select>
+                                        </td>
+                                        <!-- /ko -->
+
+                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
+                                        <td class='columnCell column_Encoding'>
+                                            <select class="tbaleFieldEncoding" data-bind="options: Object.values(Daliuge.Encoding), value: encoding, disabled: $root.parameterTable().getParamsTableEditState() , event: {change: ParameterTable.encodingChanged}">
+                                                <!-- options are added dynamically -->
+                                            </select>
+                                        </td>
                                         <!-- /ko -->
                                         
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().actions() -->


### PR DESCRIPTION
Added an Enum to Daliuge class for all possible encoding values.
Updated ParameterTable with an additional column that displays the encoding values.

NOTE: The 'encoding' column in the table seems to default to 'not shown'. The user has to manually enable the column in the column visibilities.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds an 'encoding' attribute to the Field class and updates the ParameterTable to include a new column for encoding values. The encoding column is not shown by default and must be manually enabled by the user.

* **New Features**:
    - Introduced an 'encoding' attribute to the Field class to specify data encoding types.
* **Enhancements**:
    - Updated the ParameterTable to include an additional column for displaying encoding values, which can be toggled by the user.

<!-- Generated by sourcery-ai[bot]: end summary -->