### PR TITLE
Eagle 1248 - Old graph (cont_img_mvp.graph) with embedded app inside Service breaks EAGLE

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -354,13 +354,15 @@ export class Edge {
 
         // check if source port was found
         if (sourcePort === null) {
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("Source port doesn't exist on source node", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            const issue: Errors.Issue = Errors.ShowFix("Source port (" + sourcePortId + ") doesn't exist on source node (" + sourceNode.getName() + ")", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.addSourcePortToSourceNode(eagle, edgeId)}, "Add source port to source node");
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
             return Eagle.LinkValid.Impossible;
         }
 
         // check if destination port was found
         if (destinationPort === null){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("Destination port doesn't exist on destination node", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            const issue: Errors.Issue = Errors.ShowFix("Destination port (" + destinationPortId + ") doesn't exist on destination node (" + destinationNode.getName() + ")", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.addDestinationPortToDestinationNode(eagle, edgeId)}, "Add destination port to destination node");
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
             return Eagle.LinkValid.Impossible;
         }
 
@@ -372,13 +374,15 @@ export class Edge {
 
         // check that source is output
         if (!sourcePort.isOutputPort()){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("Source port is not output port (" + sourcePort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            const issue: Errors.Issue = Errors.ShowFix("Source port is not output port (" + sourcePort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldUsage(eagle, sourcePort, Daliuge.FieldUsage.OutputPort)}, "Add output usage to source port");
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
             return Eagle.LinkValid.Impossible;
         }
 
         // check that destination in input
         if (!destinationPort.isInputPort()){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("Destination port is not input port (" + destinationPort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            const issue: Errors.Issue = Errors.ShowFix("Destination port is not input port (" + destinationPort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldUsage(eagle, destinationPort, Daliuge.FieldUsage.InputPort)}, "Add input usage to destination port");
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
             return Eagle.LinkValid.Impossible;
         }
 
@@ -431,7 +435,7 @@ export class Edge {
         if (sourcePort !== null && destinationPort !== null){
             // abort if source port and destination port have different data types
             if (!Utils.portsMatch(sourcePort, destinationPort)){
-                const x = Errors.ShowFix("Source and destination ports don't match: sourcePort (" + sourcePort.getDisplayText() + ":" + sourcePort.getType() + ") destinationPort (" + destinationPort.getDisplayText() + ":" + destinationPort.getType() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixPortType(eagle, sourcePort, destinationPort);}, "Overwrite destination port type with source port type");
+                const x = Errors.ShowFix("Source and destination ports don't match data types: sourcePort (" + sourcePort.getDisplayText() + ":" + sourcePort.getType() + ") destinationPort (" + destinationPort.getDisplayText() + ":" + destinationPort.getType() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixPortType(eagle, sourcePort, destinationPort);}, "Overwrite destination port type with source port type");
                 Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1617,7 +1617,11 @@ export class Node {
                 if (node.canHaveInputs()){
                     node.addField(port);
                 } else {
-                    Node.addPortToEmbeddedApplication(node, port, true, errorsWarnings, generateKeyFunc);
+                    if (node.getCategoryType() === Category.Type.Construct){
+                        Node.addPortToEmbeddedApplication(node, port, true, errorsWarnings, generateKeyFunc);
+                    } else {
+                        errorsWarnings.errors.push(Errors.Message("Can't add input field " + inputPort.text + " to node " + node.getName() + ". Node cannot have inputs, and cannot have an embedded input application."));
+                    }
                 }
             }
         }
@@ -1632,7 +1636,11 @@ export class Node {
                 if (node.canHaveOutputs()){
                     node.addField(port);
                 } else {
-                    Node.addPortToEmbeddedApplication(node, port, false, errorsWarnings, generateKeyFunc);
+                    if (node.getCategoryType() === Category.Type.Construct){
+                        Node.addPortToEmbeddedApplication(node, port, false, errorsWarnings, generateKeyFunc);
+                    } else {
+                        errorsWarnings.errors.push(Errors.Message("Can't add output field " + outputPort.text + " to node " + node.getName() + ". Node cannot have outputs, and cannot have an embedded output application."));
+                    }
                 }
             }
         }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1355,7 +1355,7 @@ export class Utils {
     static typesMatch(type0: string, type1: string){
         // check for undefined
         if (typeof type0 === "undefined" || typeof type1 === "undefined"){
-            console.warn("typesMatch(): matching value undefined (type0:", type0, "type1:", type1, ")");
+            //console.warn("typesMatch(): matching value undefined (type0:", type0, "type1:", type1, ")");
             return false;
         }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1862,6 +1862,12 @@ export class Utils {
     }
 
     static fixFieldType(eagle: Eagle, field: Field){
+        // fix for undefined value
+        if (field.getType() === undefined){
+            field.setType(Daliuge.DataType.Object);
+        }
+        
+        // fix for 'Unknown' type
         if (field.getType() === Daliuge.DataType.Unknown){
             field.setType(Daliuge.DataType.Object);
             return;
@@ -1873,11 +1879,76 @@ export class Utils {
             return;
         }
 
+        // abort if this fix has already been done by some other method
+        if (field.getType() === Daliuge.DataType.Object){
+            return;
+        }
+
         field.setType(Daliuge.DataType.Object + "." + field.getType());
     }
 
     static fixFieldKey(eagle: Eagle, node: Node, field: Field){
         field.setNodeKey(node.getKey());
+    }
+
+    static fixFieldUsage(eagle: Eagle, field: Field, usage: Daliuge.FieldUsage){
+        switch(field.getUsage()){
+            case Daliuge.FieldUsage.NoPort:
+                field.setUsage(usage);
+                break;
+            case Daliuge.FieldUsage.InputPort:
+                if (usage = Daliuge.FieldUsage.OutputPort){
+                    field.setUsage(Daliuge.FieldUsage.InputOutput);
+                }
+                break;
+            case Daliuge.FieldUsage.OutputPort:
+                if (usage = Daliuge.FieldUsage.InputPort){
+                    field.setUsage(Daliuge.FieldUsage.InputOutput);
+                }
+                break;
+        }
+    }
+
+    static addSourcePortToSourceNode(eagle: Eagle, edgeId: string){
+        const edge = eagle.logicalGraph().findEdgeById(edgeId);
+        const srcNode = eagle.logicalGraph().findNodeByKey(edge.getSrcNodeKey());
+        const destNode = eagle.logicalGraph().findNodeByKey(edge.getDestNodeKey());
+        const destPort = destNode.findFieldById(edge.getDestPortId());
+
+        // abort fix if source port exists on source node
+        if (srcNode.findFieldById(edge.getSrcPortId()) !== null){
+            return;
+        }
+
+        // determine a sensible type for the new source port
+        const srcPortType = destPort.getType() === undefined ? Daliuge.DataType.Object : destPort.getType();
+
+        // create new source port
+        const srcPort = new Field(edge.getSrcPortId(), destPort.getDisplayText(), "", "", "", false, srcPortType, false, [], false, Daliuge.FieldType.ApplicationArgument, Daliuge.FieldUsage.OutputPort, false);
+
+        // add port to source node
+        srcNode.addField(srcPort);
+    }
+
+    static addDestinationPortToDestinationNode(eagle: Eagle, edgeId: string){
+        const edge = eagle.logicalGraph().findEdgeById(edgeId);
+        const srcNode = eagle.logicalGraph().findNodeByKey(edge.getSrcNodeKey());
+        const destNode = eagle.logicalGraph().findNodeByKey(edge.getDestNodeKey());
+        const srcPort = srcNode.findFieldById(edge.getSrcPortId());
+
+        // abort fix if destination port exists on destination node
+        if (destNode.findFieldById(edge.getDestPortId()) !== null){
+            return;
+        }
+
+        // determine a sensible type for the new destination port
+        const destPortType = srcPort.getType() === undefined ? Daliuge.DataType.Object : srcPort.getType();
+
+        // create new destination port
+        const destPort = new Field(edge.getDestPortId(), srcPort.getDisplayText(), "", "", "", false, destPortType, false, [], false, Daliuge.FieldType.ApplicationArgument, Daliuge.FieldUsage.OutputPort, false);
+
+        // add port to destination node
+        destNode.addField(destPort);
     }
 
     static fixMoveEdgeToEmbeddedApplication(eagle: Eagle, edgeId: string){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1897,12 +1897,12 @@ export class Utils {
                 field.setUsage(usage);
                 break;
             case Daliuge.FieldUsage.InputPort:
-                if (usage = Daliuge.FieldUsage.OutputPort){
+                if (usage === Daliuge.FieldUsage.OutputPort){
                     field.setUsage(Daliuge.FieldUsage.InputOutput);
                 }
                 break;
             case Daliuge.FieldUsage.OutputPort:
-                if (usage = Daliuge.FieldUsage.InputPort){
+                if (usage === Daliuge.FieldUsage.InputPort){
                     field.setUsage(Daliuge.FieldUsage.InputOutput);
                 }
                 break;


### PR DESCRIPTION
The graph JSON indicates that several "Service" nodes, for example "GSM", should have output ports. EAGLE would try to add the output port during load. But according to CategoryData, Service nodes can't have any outputs. So EAGLE would assume that the port belonged on an embedded app within the Service.

The function that adds the port to an embedded app would first check if the embedded app existed. If not, an embedded app would be created. This caused all sorts of mess.

Now EAGLE will not automatically add embedded nodes to non-Constructs.

I also took the opportunity to add several "Fix" functions for errors on that graph:

- Source port doesn't exist on source node
- Destination port doesn't exist on destination node
- Source port is not an output port
- Destination port is not an input port

And improved the fix function for this error
- Source and destination ports don't match

Also, a couple of the fix functions could cause issues if they attempted a fix that was already done. So I've added checks to a couple of the fix functions where they abort the fix if it is no longer required.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a critical bug where EAGLE would incorrectly add output ports to Service nodes, causing issues with embedded applications. It also introduces several enhancements to error handling and fix functions for port-related errors, ensuring more robust and accurate graph validation.

- **Bug Fixes**:
    - Fixed issue where EAGLE would incorrectly add output ports to Service nodes by preventing automatic addition of embedded nodes to non-Constructs.
    - Added checks to prevent fix functions from attempting redundant fixes.
- **Enhancements**:
    - Improved error handling and added fix functions for various port-related errors, including missing source/destination ports and incorrect port types.
    - Enhanced the fix function for mismatched source and destination ports to provide more detailed error messages.

<!-- Generated by sourcery-ai[bot]: end summary -->