### PR TITLE
Modified worstEdgeError to return Invalid instead of Impossible by de…

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2037,7 +2037,7 @@ export class Utils {
 
         if (errorsWarnings.errors.length !== 0){
             // TODO: this actually has no way of knowing whether the errors are of type Invalid or Impossible
-            return Eagle.LinkValid.Impossible;
+            return Eagle.LinkValid.Invalid;
         }
 
         return Eagle.LinkValid.Warning;


### PR DESCRIPTION
…fault.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the `worstEdgeError` function by changing its return value from `Impossible` to `Invalid` when errors are detected, ensuring more accurate error categorization.

- **Bug Fixes**:
    - Modified the `worstEdgeError` function to return `Invalid` instead of `Impossible` when errors are present.

<!-- Generated by sourcery-ai[bot]: end summary -->