### PR TITLE
EAGLE-1247: Problem when saving graph without ".graph" extension

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1700,7 +1700,7 @@ export class Eagle {
             }
         }
 
-        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(defaultRepository.service), fileInfo().path, fileInfo().name, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
+        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(defaultRepository.service), fileInfo().path, fileInfo().name, fileType, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
             // check completed boolean
             if (!completed){
                 console.log("Abort commit");
@@ -2385,7 +2385,7 @@ export class Eagle {
 
         const defaultRepository: Repository = new Repository(palette.fileInfo().repositoryService, palette.fileInfo().repositoryName, palette.fileInfo().repositoryBranch, false);
 
-        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(Repository.Service.GitHub),  palette.fileInfo().path, palette.fileInfo().name, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
+        Utils.requestUserGitCommit(defaultRepository, Repositories.getList(Repository.Service.GitHub),  palette.fileInfo().path, palette.fileInfo().name, Eagle.FileType.Palette, (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) : void => {
             // check completed boolean
             if (!completed){
                 console.log("Abort commit");

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -410,7 +410,6 @@ export class Modals {
     }
 
     static validateCommitModalFileNameInputText(){
-        console.log("validateCommitModalFileNameInputText()");
         const inputElement = $("#gitCommitModalFileNameInput");
         const fileType : Eagle.FileType = $('#gitCommitModal').data('fileType');
         

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -154,6 +154,7 @@ export class Modals {
         $('#gitCommitModal').on('hidden.bs.modal', function(){
             const callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void = $('#gitCommitModal').data('callback');
             const completed : boolean = $('#gitCommitModal').data('completed');
+            const fileType : Eagle.FileType = $('#gitCommitModal').data('fileType');
 
             // check if the modal was completed (user clicked OK), if not, return false
             if (!completed){
@@ -171,8 +172,16 @@ export class Modals {
             const repositoryBranch : string = repositories[repositoryNameChoice].branch;
 
             const filePath : string = $('#gitCommitModalFilePathInput').val().toString();
-            const fileName : string = $('#gitCommitModalFileNameInput').val().toString();
+            let fileName : string = $('#gitCommitModalFileNameInput').val().toString();
             const commitMessage : string = $('#gitCommitModalCommitMessageInput').val().toString();
+
+            // ensure that the graph filename ends with ".graph" or ".palette" as appropriate
+            if (fileType === Eagle.FileType.Graph && !fileName.endsWith('.graph')){
+                fileName = fileName + '.graph';
+            }
+            if (fileType === Eagle.FileType.Palette && !fileName.endsWith('.palette')){
+                fileName = fileName + '.palette';
+            }
 
             callback(true, repositoryService, repositoryName, repositoryBranch, filePath, fileName, commitMessage);
         });
@@ -398,6 +407,16 @@ export class Modals {
         const isValid = Utils.validateField(realType, value);
 
         Modals._setValidClasses($(event.target), isValid);
+    }
+
+    static validateCommitModalFileNameInputText(){
+        console.log("validateCommitModalFileNameInputText()");
+        const inputElement = $("#gitCommitModalFileNameInput");
+        const fileType : Eagle.FileType = $('#gitCommitModal').data('fileType');
+        
+        const isValid = (fileType === Eagle.FileType.Graph && inputElement.val().toString().endsWith(".graph")) || (fileType === Eagle.FileType.Palette && inputElement.val().toString().endsWith(".palette"));
+
+        Modals._setValidClasses(inputElement, isValid);
     }
 
     static showBrowseDockerHub(image: string, tag: string, callback : (completed : boolean) => void ) : void {

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -176,11 +176,9 @@ export class Modals {
             const commitMessage : string = $('#gitCommitModalCommitMessageInput').val().toString();
 
             // ensure that the graph filename ends with ".graph" or ".palette" as appropriate
-            if (fileType === Eagle.FileType.Graph && !fileName.endsWith('.graph')){
-                fileName = fileName + '.graph';
-            }
-            if (fileType === Eagle.FileType.Palette && !fileName.endsWith('.palette')){
-                fileName = fileName + '.palette';
+            if ((fileType === Eagle.FileType.Graph && !fileName.endsWith('.graph')) ||
+                (fileType === Eagle.FileType.Palette && !fileName.endsWith('.palette'))) {
+                fileName += fileType === Eagle.FileType.Graph ? '.graph' : '.palette';
             }
 
             callback(true, repositoryService, repositoryName, repositoryBranch, filePath, fileName, commitMessage);
@@ -392,7 +390,7 @@ export class Modals {
         });
     }
 
-    static validateFieldModalValueInputText(data: Field, event: Event){
+    static validateFieldModalValueInputText(data: Field, event: Event): void {
         const type: string = data.getType()
         const value: any = $(event.target).val();
         const realType: string = Utils.translateStringToDataType(Utils.dataTypePrefix(type));
@@ -409,11 +407,14 @@ export class Modals {
         Modals._setValidClasses($(event.target), isValid);
     }
 
-    static validateCommitModalFileNameInputText(){
+    static validateCommitModalFileNameInputText(): void {
         const inputElement = $("#gitCommitModalFileNameInput");
-        const fileType : Eagle.FileType = $('#gitCommitModal').data('fileType');
+        const fileTypeData = $('#gitCommitModal').data('fileType');
+        const fileType: Eagle.FileType = fileTypeData ? fileTypeData : Eagle.FileType.Unknown;
         
-        const isValid = (fileType === Eagle.FileType.Graph && inputElement.val().toString().endsWith(".graph")) || (fileType === Eagle.FileType.Palette && inputElement.val().toString().endsWith(".palette"));
+        const isValid = (fileType === Eagle.FileType.Unknown) ||
+            (fileType === Eagle.FileType.Graph && inputElement.val().toString().endsWith(".graph")) ||
+            (fileType === Eagle.FileType.Palette && inputElement.val().toString().endsWith(".palette"));
 
         Modals._setValidClasses(inputElement, isValid);
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -35,6 +35,7 @@ import { Field } from './Field';
 import { FileInfo } from "./FileInfo";
 import { KeyboardShortcut } from './KeyboardShortcut';
 import { LogicalGraph } from './LogicalGraph';
+import { Modals } from "./Modals";
 import { Node } from './Node';
 import { Palette } from './Palette';
 import { PaletteInfo } from './PaletteInfo';
@@ -605,8 +606,9 @@ export class Utils {
         $('#confirmModal').modal("toggle");
     }
 
-    static requestUserGitCommit(defaultRepository : Repository, repositories: Repository[], filePath: string, fileName: string, callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void ) : void {
+    static requestUserGitCommit(defaultRepository : Repository, repositories: Repository[], filePath: string, fileName: string, fileType: Eagle.FileType, callback : (completed : boolean, repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, commitMessage : string) => void ) : void {
         $('#gitCommitModal').data('completed', false);
+        $('#gitCommitModal').data('fileType', fileType);
         $('#gitCommitModal').data('callback', callback);
         $('#gitCommitModal').data('repositories', repositories);
         $('#gitCommitModal').modal("toggle");
@@ -636,6 +638,9 @@ export class Utils {
 
         $('#gitCommitModalFilePathInput').val(filePath);
         $('#gitCommitModalFileNameInput').val(fileName);
+
+        // validate fileName input
+        Modals.validateCommitModalFileNameInputText();
     }
 
     static requestUserEditField(eagle: Eagle, modalType: Eagle.ModalType, parameterType: Daliuge.FieldType, parameterUsage: Daliuge.FieldUsage, field: Field, choices: string[], callback: (completed: boolean, field: Field) => void) : void {

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -191,7 +191,10 @@
                         </div>
                         <div class="col">
                             <div class="input-group mb-3">
-                                <input type="text" class="form-control" id="gitCommitModalFileNameInput">
+                                <input type="text" class="form-control" id="gitCommitModalFileNameInput" data-bind="event: {input: Modals.validateCommitModalFileNameInputText}">
+                                <div id="validationFeedback" class="invalid-feedback">
+                                    Graph fileName must end with '.graph'. Palette fileName must end with '.palette'.
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -193,7 +193,7 @@
                             <div class="input-group mb-3">
                                 <input type="text" class="form-control" id="gitCommitModalFileNameInput" data-bind="event: {input: Modals.validateCommitModalFileNameInputText}">
                                 <div id="validationFeedback" class="invalid-feedback">
-                                    Graph fileName must end with '.graph'. Palette fileName must end with '.palette'.
+                                    Graph file name must end with '.graph'. Palette file name must end with '.palette'.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Adds client-side validation of the graph or palette filename. Uses bootstrap 'is-valid/is-invalid' CSS to display validity.

Note: the "git commit" modal does not actually prevent the user from proceeding with a invalid filename. It just warns the user. However, once the modal is dismissed, if the filename does not end with .graph or .palette as appropriate, that extension will be added to the filename.

To test:
- Open a graph, commit to git using "save as"
- Open a graph, use the navbar button to create new palette from graph nodes, then click the "three dot" menu in the palette header, choose "save as"

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses the issue of saving graph and palette files without the correct extensions by adding client-side validation. The 'git commit' modal now provides visual feedback on filename validity and automatically appends the correct extension if missing.

- **Bug Fixes**:
    - Added client-side validation to ensure graph and palette filenames end with '.graph' and '.palette' respectively.
- **Enhancements**:
    - Updated the 'git commit' modal to display validation feedback using Bootstrap's 'is-valid/is-invalid' CSS classes.

<!-- Generated by sourcery-ai[bot]: end summary -->