### PR TITLE
EAGLE-1253: Only show Parameter Table encoding drop-down for fields being used as ports.

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -54,7 +54,7 @@ export class Field {
         this.options = ko.observableArray(options);
         this.positional = ko.observable(positional);
         this.keyAttribute = ko.observable(keyAttribute);
-        this.encoding = ko.observable(Daliuge.Encoding.UTF8);
+        this.encoding = ko.observable(Daliuge.Encoding.Pickle);
 
         this.id = ko.observable(id);
         this.parameterType = ko.observable(parameterType);
@@ -391,7 +391,7 @@ export class Field {
         this.parameterType(Daliuge.FieldType.Unknown);
         this.usage(Daliuge.FieldUsage.NoPort);
         this.keyAttribute(false);
-        this.encoding(Daliuge.Encoding.UTF8);
+        this.encoding(Daliuge.Encoding.Pickle);
 
         this.id("");
         this.isEvent(false);
@@ -691,7 +691,7 @@ export class Field {
         let usage: Daliuge.FieldUsage = Daliuge.FieldUsage.NoPort;
         let isEvent: boolean = false;
         let keyAttribute: boolean = false;
-        let encoding: Daliuge.Encoding = Daliuge.Encoding.UTF8;
+        let encoding: Daliuge.Encoding = Daliuge.Encoding.Pickle;
 
         if (typeof data.id !== 'undefined')
             id = data.id;
@@ -776,7 +776,7 @@ export class Field {
         let type: string;
         let description: string = "";
         let keyAttribute: boolean = false;
-        let encoding: Daliuge.Encoding = Daliuge.Encoding.UTF8;
+        let encoding: Daliuge.Encoding = Daliuge.Encoding.Pickle;
 
         if (typeof data.name !== 'undefined')
             name = data.name;

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -631,7 +631,7 @@ export class ColumnVisibilities {
 const columnVisibilities : ColumnVisibilities[] = [
     new ColumnVisibilities("Student", false, true,false,true,true,false,false,false,false,false,false,false,false),
     new ColumnVisibilities("Minimal", true, true,false,true,true,false,false,false,false,false,false,true,false),
-    new ColumnVisibilities("Graph", true, true,false,true,true,true,false,true,true,true,true,true,true),
-    new ColumnVisibilities("Component", true, true,false,true,true,true,true,true,true,true,true,true,true),
+    new ColumnVisibilities("Graph", true, true,false,true,true,true,false,true,true,true,false,true,true),
+    new ColumnVisibilities("Component", true, true,false,true,true,true,true,true,true,true,false,true,true),
     new ColumnVisibilities("Expert", true, true,false,true,true,true,true,true,true,true,true,true,true)
 ]

--- a/static/base.css
+++ b/static/base.css
@@ -512,6 +512,10 @@ td:first-child input {
     font-size: 12px;
 }
 
+#parameterTableModal .column_Encoding .faded{
+    color: #5b5b5b;
+}
+
 #parameterTableVisibilityContainer{
     position:absolute;
     right: 320px;

--- a/templates/modals/parameter_table.html
+++ b/templates/modals/parameter_table.html
@@ -322,9 +322,14 @@
 
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
                                         <td class='columnCell column_Encoding'>
+                                            <!-- ko if: $data.usage() === Daliuge.FieldUsage.NoPort-->
+                                            <span>N/A</span>
+                                            <!-- /ko -->
+                                            <!-- ko ifnot: $data.usage() === Daliuge.FieldUsage.NoPort-->
                                             <select class="tbaleFieldEncoding" data-bind="options: Object.values(Daliuge.Encoding), value: encoding, disabled: $root.parameterTable().getParamsTableEditState() , event: {change: ParameterTable.encodingChanged}">
                                                 <!-- options are added dynamically -->
                                             </select>
+                                            <!-- /ko -->
                                         </td>
                                         <!-- /ko -->
                                         

--- a/templates/modals/parameter_table.html
+++ b/templates/modals/parameter_table.html
@@ -323,7 +323,7 @@
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
                                         <td class='columnCell column_Encoding'>
                                             <!-- ko if: $data.usage() === Daliuge.FieldUsage.NoPort-->
-                                            <span>N/A</span>
+                                            <span class="faded">N/A</span>
                                             <!-- /ko -->
                                             <!-- ko ifnot: $data.usage() === Daliuge.FieldUsage.NoPort-->
                                             <select class="tbaleFieldEncoding" data-bind="options: Object.values(Daliuge.Encoding), value: encoding, disabled: $root.parameterTable().getParamsTableEditState() , event: {change: ParameterTable.encodingChanged}">


### PR DESCRIPTION
Only show Parameter Table encoding column by default in expert mode.
Default encoding is now Pickle instead of UTF8.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Updated the default encoding to Pickle instead of UTF8 and modified the Parameter Table to only show the encoding drop-down for fields being used as ports.

- **Enhancements**:
    - Parameter Table encoding column is now only shown for fields being used as ports.

<!-- Generated by sourcery-ai[bot]: end summary -->