### PR TITLE
EAGLE-1218: Specify height of the git commit modal

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1424,9 +1424,12 @@ select.form-control{
     height: 100%;
 }
 
-
 #inputTextModalInput {
     font-family: monospace;
+}
+
+#gitCommitModal .modal-content{
+    height: 420px;
 }
 
 #nodeInspector select{


### PR DESCRIPTION
Just wanted to check with you that this is the best way to fix the problem

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the user interface by setting a fixed height for the git commit modal, ensuring consistent display across different scenarios.

- **Enhancements**:
    - Added a fixed height of 420px to the git commit modal for better UI consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->