### PR TITLE
EAGLE-1256: Re-use Edge.isValid within the edge auto-complete system

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2854,8 +2854,8 @@ export class Eagle {
             }
 
             // validate edge
-            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
-            if (isValid === Eagle.LinkValid.Impossible || isValid === Eagle.LinkValid.Invalid || isValid === Eagle.LinkValid.Unknown){
+            const isValid: Edge.Validity = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
+            if (isValid === Edge.Validity.Impossible || isValid === Edge.Validity.Invalid || isValid === Edge.Validity.Unknown){
                 Utils.showUserMessage("Error", "Invalid edge");
                 return;
             }
@@ -2899,8 +2899,8 @@ export class Eagle {
             }
 
             // validate edge
-            const isValid: Eagle.LinkValid = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
-            if (isValid === Eagle.LinkValid.Impossible || isValid === Eagle.LinkValid.Invalid || isValid === Eagle.LinkValid.Unknown){
+            const isValid: Edge.Validity = Edge.isValid(this, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, true, null);
+            if (isValid === Edge.Validity.Impossible || isValid === Edge.Validity.Invalid || isValid === Edge.Validity.Unknown){
                 Utils.showUserMessage("Error", "Invalid edge");
                 return;
             }
@@ -4865,14 +4865,6 @@ export namespace Eagle
         JSON = "JSON",
         Markdown = "Markdown",
         Unknown = "Unknown"
-    }
-
-    export enum LinkValid {
-        Unknown = "Unknown",        // validity of the edge is unknown
-        Impossible = "Impossible",  // never useful or valid
-        Invalid = "Invalid",        // invalid, but possibly useful for expert users?
-        Warning = "Warning",        // valid, but some issue that the user should be aware of
-        Valid = "Valid"             // fine
     }
 
     export enum ModalType {

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -276,38 +276,38 @@ export class Edge {
         return new Edge(edgeData.from, edgeData.fromPort, edgeData.to, edgeData.toPort, edgeData.loopAware, edgeData.closesLoop, false);
     }
 
-    static isValid(eagle: Eagle, edgeId: string, sourceNodeKey : number, sourcePortId : string, destinationNodeKey : number, destinationPortId : string, loopAware: boolean, closesLoop: boolean, showNotification : boolean, showConsole : boolean, errorsWarnings: Errors.ErrorsWarnings) : Eagle.LinkValid {
+    static isValid(eagle: Eagle, edgeId: string, sourceNodeKey : number, sourcePortId : string, destinationNodeKey : number, destinationPortId : string, loopAware: boolean, closesLoop: boolean, showNotification : boolean, showConsole : boolean, errorsWarnings: Errors.ErrorsWarnings) : Edge.Validity {
         // check for problems
         if (isNaN(sourceNodeKey)){
-            return Eagle.LinkValid.Unknown;
+            return Edge.Validity.Unknown;
         }
 
         if (isNaN(destinationNodeKey)){
-            return Eagle.LinkValid.Unknown;
+            return Edge.Validity.Unknown;
         }
 
         if (sourcePortId === ""){
             const issue = Errors.Fix("source port has no id", function(){Utils.fixNodeFieldIds(eagle, sourceNodeKey)}, "Generate ids for ports on source node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Invalid;
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Invalid;
         }
 
         if (destinationPortId === ""){
             const issue = Errors.Fix("destination port has no id", function(){Utils.fixNodeFieldIds(eagle, sourceNodeKey)}, "Generate ids for ports on destination node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Invalid;
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Invalid;
         }
 
         if (sourcePortId === null){
             const issue = Errors.Fix("source port id is null", function(){Utils.fixNodeFieldIds(eagle, sourceNodeKey)}, "Generate ids for ports on source node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Invalid;
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Invalid;
         }
 
         if (destinationPortId === null){
             const issue = Errors.Fix("destination port id is null", function(){Utils.fixNodeFieldIds(eagle, sourceNodeKey)}, "Generate ids for ports on destination node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Invalid;
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Invalid;
         }
 
         // get references to actual source and destination nodes (from the keys)
@@ -315,29 +315,29 @@ export class Edge {
         const destinationNode : Node = eagle.logicalGraph().findNodeByKey(destinationNodeKey);
 
         if (sourceNode === null || typeof sourceNode === "undefined" || destinationNode === null || typeof destinationNode === "undefined"){
-            return Eagle.LinkValid.Unknown;
+            return Edge.Validity.Unknown;
         }
 
         // check that we are not connecting a Data component to a Data component, that is not supported
         if (sourceNode.getCategoryType() === Category.Type.Data && destinationNode.getCategoryType() === Category.Type.Data){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Data nodes may not be connected directly to other Data nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Invalid;
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Data nodes may not be connected directly to other Data nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Invalid;
         }
 
         // if source node or destination node is a construct, then something is wrong, constructs should not have ports
         if (sourceNode.getCategoryType() === Category.Type.Construct){
             const issue: Errors.Issue = Errors.ShowFix("Edge (" + edgeId + ") cannot have a source node (" + sourceNode.getName() + ") that is a construct", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.fixMoveEdgeToEmbeddedApplication(eagle, edgeId)}, "Move edge to embedded application");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
         }
         if (destinationNode.getCategoryType() === Category.Type.Construct){
             const issue: Errors.Issue = Errors.ShowFix("Edge (" + edgeId + ") cannot have a destination node (" + destinationNode.getName() + ") that is a construct", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.fixMoveEdgeToEmbeddedApplication(eagle, edgeId)}, "Move edge to embedded application");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
         }
 
         // check that we are not connecting two ports within the same node
         if (sourceNodeKey === destinationNodeKey){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("sourceNodeKey and destinationNodeKey are the same", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, Errors.Show("sourceNodeKey and destinationNodeKey are the same", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         // if source node is a memory, and destination is a BashShellApp, OR
@@ -346,7 +346,7 @@ export class Edge {
         if ((sourceNode.getCategory() === Category.Memory && destinationNode.getCategory() === Category.BashShellApp) ||
             (sourceNode.getCategory() === Category.Memory && destinationNode.isGroup() && destinationNode.getInputApplication() !== undefined && destinationNode.hasInputApplication() && destinationNode.getInputApplication().getCategory() === Category.BashShellApp)){
             const issue: Errors.Issue = Errors.ShowFix("output from Memory Node cannot be input into a BashShellApp or input into a Group Node with a BashShellApp inputApplicationType", function(){Utils.showNode(eagle, sourceNode.getId())}, function(){Utils.fixNodeCategory(eagle, sourceNode, Category.File, Category.Type.Data)}, "Change data component type to File");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, issue, showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, issue, showNotification, showConsole, errorsWarnings);
         }
 
         const sourcePort : Field = sourceNode.findFieldById(sourcePortId);
@@ -355,41 +355,41 @@ export class Edge {
         // check if source port was found
         if (sourcePort === null) {
             const issue: Errors.Issue = Errors.ShowFix("Source port (" + sourcePortId + ") doesn't exist on source node (" + sourceNode.getName() + ")", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.addSourcePortToSourceNode(eagle, edgeId)}, "Add source port to source node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         // check if destination port was found
         if (destinationPort === null){
             const issue: Errors.Issue = Errors.ShowFix("Destination port (" + destinationPortId + ") doesn't exist on destination node (" + destinationNode.getName() + ")", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.addDestinationPortToDestinationNode(eagle, edgeId)}, "Add destination port to destination node");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         // check that we are not connecting a port to itself
         if (sourcePortId === destinationPortId){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, Errors.Show("Source port and destination port are the same", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, Errors.Show("Source port and destination port are the same", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         // check that source is output
         if (!sourcePort.isOutputPort()){
             const issue: Errors.Issue = Errors.ShowFix("Source port is not output port (" + sourcePort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldUsage(eagle, sourcePort, Daliuge.FieldUsage.OutputPort)}, "Add output usage to source port");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         // check that destination in input
         if (!destinationPort.isInputPort()){
             const issue: Errors.Issue = Errors.ShowFix("Destination port is not input port (" + destinationPort.getUsage() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldUsage(eagle, destinationPort, Daliuge.FieldUsage.InputPort)}, "Add input usage to destination port");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Impossible, issue, showNotification, showConsole, errorsWarnings);
-            return Eagle.LinkValid.Impossible;
+            Edge.isValidLog(edgeId, Edge.Validity.Impossible, issue, showNotification, showConsole, errorsWarnings);
+            return Edge.Validity.Impossible;
         }
 
         if (sourcePort !== null && destinationPort !== null){
             // check that source and destination port are both event, or both not event
             if ((sourcePort.getIsEvent() && !destinationPort.getIsEvent()) || (!sourcePort.getIsEvent() && destinationPort.getIsEvent())){
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Source port and destination port are mix of event and non-event ports", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Source port and destination port are mix of event and non-event ports", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
             }
         }
 
@@ -415,34 +415,34 @@ export class Edge {
 
         // if a node is connecting to its parent, it must connect to the local port
         if (isParent && !destinationNode.hasLocalPortWithId(destinationPortId)){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Source port is connecting to its parent, yet destination port is not local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Source port is connecting to its parent, yet destination port is not local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // if a node is connecting to a child, it must start from the local port
         if (isChild && !sourceNode.hasLocalPortWithId(sourcePortId)){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Source connecting to child, yet source port is not local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Source connecting to child, yet source port is not local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // if destination node is not a child, destination port cannot be a local port
         if (!parentIsEFN && !isParent && destinationNode.hasLocalPortWithId(destinationPortId)){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Source is not a child of destination, yet destination port is local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Source is not a child of destination, yet destination port is local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         if (!parentIsEFN && !isChild && sourceNode.hasLocalPortWithId(sourcePortId)){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, Errors.Show("Destination is not a child of source, yet source port is local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Invalid, Errors.Show("Destination is not a child of source, yet source port is local", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         if (sourcePort !== null && destinationPort !== null){
             // abort if source port and destination port have different data types
             if (!Utils.portsMatch(sourcePort, destinationPort)){
                 const x = Errors.ShowFix("Source and destination ports don't match data types: sourcePort (" + sourcePort.getDisplayText() + ":" + sourcePort.getType() + ") destinationPort (" + destinationPort.getDisplayText() + ":" + destinationPort.getType() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixPortType(eagle, sourcePort, destinationPort);}, "Overwrite destination port type with source port type");
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
         }
 
         // if link is not a parent, child or sibling, then warn user
         if (!parentIsEFN && !isParent && !isChild && !isSibling && !loopAware && !isParentOfConstruct && !isChildOfConstruct){
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge is not child->parent, parent->child or between siblings. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Edge.Validity.Warning, Errors.Show("Edge is not child->parent, parent->child or between siblings. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // check if the edge already exists in the graph, there is no point in a duplicate
@@ -452,7 +452,7 @@ export class Edge {
 
             if ( isSrcMatch && isDestMatch && edge.getId() !== edgeId){
                 const x = Errors.ShowFix("Edge is a duplicate. Another edge with the same source port and destination port already exists", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDeleteEdge(eagle, edgeId);}, "Delete edge");
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
         }
 
@@ -464,44 +464,44 @@ export class Edge {
         if (closesLoop){
             if (!sourceNode.isData()){
                 const x = Errors.Show("Closes Loop Edge (" + edgeId + ") does not start from a Data component.", function(){Utils.showEdge(eagle, edgeId);});
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
 
             if (!destinationNode.isApplication()){
                 const x = Errors.Show("Closes Loop Edge (" + edgeId + ") does not end at an Application component.", function(){Utils.showEdge(eagle, edgeId);});
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
 
             if (!sourceNode.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_END) || !Utils.asBool(sourceNode.getFieldByDisplayText(Daliuge.FieldName.GROUP_END).getValue())){
                 const x = Errors.ShowFix("'Closes Loop' Edge (" + edgeId + ") start node (" + sourceNode.getName() + ") does not have 'group_end' set to true.", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldValue(eagle, sourceNode, Daliuge.groupEndField, "true")}, "Set 'group_end' to true");
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
 
             if (!destinationNode.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_START) || !Utils.asBool(destinationNode.getFieldByDisplayText(Daliuge.FieldName.GROUP_START).getValue())){
                 const x = Errors.ShowFix("'Closes Loop' Edge (" + edgeId + ") end node (" + destinationNode.getName() + ") does not have 'group_start' set to true.", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixFieldValue(eagle, destinationNode, Daliuge.groupStartField, "true")}, "Set 'group_start' to true");
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+                Edge.isValidLog(edgeId, Edge.Validity.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
         }
 
         return Utils.worstEdgeError(errorsWarnings);
     }
 
-    private static isValidLog(edgeId : string, linkValid : Eagle.LinkValid, issue: Errors.Issue, showNotification : boolean, showConsole : boolean, errorsWarnings: Errors.ErrorsWarnings) : void {
+    private static isValidLog(edgeId : string, linkValid : Edge.Validity, issue: Errors.Issue, showNotification : boolean, showConsole : boolean, errorsWarnings: Errors.ErrorsWarnings) : void {
         // determine correct title
         let title = "Edge Valid";
         let type : "success" | "info" | "warning" | "danger" = "success";
         let message = "";
 
         switch (linkValid){
-            case Eagle.LinkValid.Warning:
+            case Edge.Validity.Warning:
                 title = "Edge Warning";
                 type = "warning";
                 break;
-            case Eagle.LinkValid.Impossible:
+            case Edge.Validity.Impossible:
                 title = "Edge Impossible";
                 type = "danger";
                 break;
-            case Eagle.LinkValid.Invalid:
+            case Edge.Validity.Invalid:
                 title = "Edge Invalid";
                 type = "danger";
                 break;

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -527,3 +527,13 @@ export class Edge {
         }
     }
 }
+
+export namespace Edge {
+    export enum Validity {
+        Unknown = "Unknown",        // validity of the edge is unknown
+        Impossible = "Impossible",  // never useful or valid
+        Invalid = "Invalid",        // invalid, but possibly useful for expert users?
+        Warning = "Warning",        // valid, but some issue that the user should be aware of
+        Valid = "Valid"             // fine
+    }
+}

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -302,7 +302,7 @@ export class GraphRenderer {
 
     //port drag handler globals
     static draggingPort : boolean = false;
-    static isDraggingPortValid: ko.Observable<Eagle.LinkValid> = ko.observable(<Eagle.LinkValid>"Unknown");
+    static isDraggingPortValid: ko.Observable<Edge.Validity> = ko.observable(Edge.Validity.Unknown);
     static destinationNode : Node = null;
     static destinationPort : Field = null;
     
@@ -983,7 +983,7 @@ export class GraphRenderer {
     }
 
     static editNodeTitleInGraph (data:Node,event: JQuery.TriggeredEvent) : void {
-        GraphRenderer.editNodeName = true //used to prevent other drag funcitons if this feature is active
+        GraphRenderer.editNodeName = true //used to prevent other drag functions if this feature is active
         const target = event.target
         $(target).hide()
         const input = $(target).parent().find('.header-input')
@@ -1762,11 +1762,11 @@ export class GraphRenderer {
         }
 
         // check if link is valid
-        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, null, realSourceNode.getKey(), realSourcePort.getId(), realDestinationNode.getKey(), realDestinationPort.getId(), false, false, true, true, {errors:[], warnings:[]});
+        const linkValid : Edge.Validity = Edge.isValid(eagle, null, realSourceNode.getKey(), realSourcePort.getId(), realDestinationNode.getKey(), realDestinationPort.getId(), false, false, true, true, {errors:[], warnings:[]});
 
         // abort if edge is invalid
-        if ((Setting.findValue(Setting.ALLOW_INVALID_EDGES) && linkValid === Eagle.LinkValid.Invalid) || linkValid === Eagle.LinkValid.Valid || linkValid === Eagle.LinkValid.Warning){
-            if (linkValid === Eagle.LinkValid.Warning){
+        if ((Setting.findValue(Setting.ALLOW_INVALID_EDGES) && linkValid === Edge.Validity.Invalid) || linkValid === Edge.Validity.Valid || linkValid === Edge.Validity.Warning){
+            if (linkValid === Edge.Validity.Warning){
                 GraphRenderer.addEdge(realSourceNode, realSourcePort, realDestinationNode, realDestinationPort, true, false);
             } else {
                 GraphRenderer.addEdge(realSourceNode, realSourcePort, realDestinationNode, realDestinationPort, false, false);
@@ -2026,8 +2026,8 @@ export class GraphRenderer {
 
         for (const node of eagle.logicalGraph().getNodes()){
             for (const port of node.getPorts()){
-                const isValid: Eagle.LinkValid = Edge.isValid(eagle, "", sourceNode.getKey(), sourcePort.getId(), node.getKey(), port.getId(), false, false, false, false, {errors:[], warnings:[]});
-                const isValidIndex: number = Object.values(Eagle.LinkValid).indexOf(isValid);
+                const isValid: Edge.Validity = Edge.isValid(eagle, "", sourceNode.getKey(), sourcePort.getId(), node.getKey(), port.getId(), false, false, false, false, {errors:[], warnings:[]});
+                const isValidIndex: number = Object.values(Edge.Validity).indexOf(isValid);
 
                 if (isValidIndex >= minValidityIndex){
                     result.push({node: node, field: port});
@@ -2100,20 +2100,22 @@ export class GraphRenderer {
         GraphRenderer.destinationPort = null;
         GraphRenderer.destinationNode = null;
 
-        GraphRenderer.isDraggingPortValid(Eagle.LinkValid.Unknown);
+        GraphRenderer.isDraggingPortValid(Edge.Validity.Unknown);
     }
 
     static draggingEdgeGetStrokeColor: ko.PureComputed<string> = ko.pureComputed(() => {
         switch (GraphRenderer.isDraggingPortValid()){
-            case Eagle.LinkValid.Unknown:
+            case Edge.Validity.Unknown:
                 return "black";
-            case Eagle.LinkValid.Impossible:
-            case Eagle.LinkValid.Invalid:
+            case Edge.Validity.Impossible:
+            case Edge.Validity.Invalid:
                 return GraphConfig.getColor("edgeInvalid");
-            case Eagle.LinkValid.Warning:
+            case Edge.Validity.Warning:
                 return GraphConfig.getColor("edgeWarning");
-            case Eagle.LinkValid.Valid:
+            case Edge.Validity.Valid:
                 return GraphConfig.getColor("edgeValid");
+            default:
+                return GraphConfig.getColor("edgeDefault");
         }
     }, this);
 
@@ -2229,14 +2231,14 @@ export class GraphRenderer {
         }
 
         // check if link has a warning or is invalid
-        const linkValid : Eagle.LinkValid = Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, false, {errors:[], warnings:[]});
+        const linkValid : Edge.Validity = Edge.isValid(eagle, edge.getId(), edge.getSrcNodeKey(), edge.getSrcPortId(), edge.getDestNodeKey(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, false, {errors:[], warnings:[]});
 
-        if (linkValid === Eagle.LinkValid.Invalid || linkValid === Eagle.LinkValid.Impossible){
+        if (linkValid === Edge.Validity.Invalid || linkValid === Edge.Validity.Impossible){
             normalColor = GraphConfig.getColor('edgeInvalid');
             selectedColor = GraphConfig.getColor('edgeInvalidSelected');
         }
 
-        if (linkValid === Eagle.LinkValid.Warning){
+        if (linkValid === Edge.Validity.Warning){
             normalColor = GraphConfig.getColor('edgeWarning');
             selectedColor = GraphConfig.getColor('edgeWarningSelected');
         }

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2021,12 +2021,16 @@ export class GraphRenderer {
         const eagle = Eagle.getInstance();
         const result: {node: Node, field: Field}[] = [];
 
+        const minValidity: Edge.Validity = Setting.findValue(Setting.AUTO_COMPLETE_EDGES_LEVEL);
+        const minValidityIndex: number = Object.values(Edge.Validity).indexOf(minValidity);
+
         for (const node of eagle.logicalGraph().getNodes()){
             for (const port of node.getPorts()){
                 const isValid: Eagle.LinkValid = Edge.isValid(eagle, "", sourceNode.getKey(), sourcePort.getId(), node.getKey(), port.getId(), false, false, false, false, {errors:[], warnings:[]});
+                const isValidIndex: number = Object.values(Eagle.LinkValid).indexOf(isValid);
 
-                if (isValid === Eagle.LinkValid.Valid){
-                    result.push({node: node, field: port})
+                if (isValidIndex >= minValidityIndex){
+                    result.push({node: node, field: port});
                 }
             }
         }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -1,6 +1,7 @@
 import * as ko from "knockout";
 
 import { Eagle } from './Eagle';
+import { Edge } from "./Edge";
 import { Repository } from "./Repository";
 import { UiModeSystem } from './UiModes';
 import { Utils } from './Utils';
@@ -287,6 +288,7 @@ export class Setting {
     static readonly ALLOW_SET_KEY_PARAMETER : string = "AllowSetKeyParameter"
     static readonly STUDENT_SETTINGS_MODE : string = "StudentSettingsMode"
     static readonly VALUE_EDITING_PERMS : string = "ValueEditingPerms"
+    static readonly AUTO_COMPLETE_EDGES_LEVEL : string = "AutoCompleteEdgesLevel"
 
     static readonly TRANSLATOR_URL : string = "TranslatorURL";
     static readonly TRANSLATOR_ALGORITHM_DEFAULT : string = "TranslatorAlgorithmDefault";
@@ -400,6 +402,7 @@ const settings : SettingsGroup[] = [
             new Setting(true, "Filter Node Suggestions", Setting.FILTER_NODE_SUGGESTIONS, "Filter Node Options When Drawing Edges Into Empty Space", false, Setting.Type.Boolean,true,true,true,true,false),
             new Setting(false, "STUDENT_SETTINGS_MODE", Setting.STUDENT_SETTINGS_MODE, "Mode disabling setting editing for students.", false, Setting.Type.Boolean, true, false,false, false, false),
             new Setting(true, "Value Editing", Setting.VALUE_EDITING_PERMS, "Set which values are allowed to be edited.", false, Setting.Type.Select, Setting.valueEditingPerms.KeyOnly,Setting.valueEditingPerms.Normal,Setting.valueEditingPerms.Normal,Setting.valueEditingPerms.ReadOnly,Setting.valueEditingPerms.ReadOnly, Object.values(Setting.valueEditingPerms)),
+            new Setting(true, "Auto-complete edges level", Setting.AUTO_COMPLETE_EDGES_LEVEL, "Specifies the minimum validity level of auto-complete edges displayed when dragging a new edge", false, Setting.Type.Select, Edge.Validity.Valid, Edge.Validity.Valid, Edge.Validity.Warning, Edge.Validity.Warning, Edge.Validity.Invalid, [Edge.Validity.Invalid, Edge.Validity.Warning, Edge.Validity.Valid]),
         ]
     ),
     new SettingsGroup(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2174,22 +2174,22 @@ export class Utils {
     }
 
     // only update result if it is worse that current result
-    static worstEdgeError(errorsWarnings: Errors.ErrorsWarnings) : Eagle.LinkValid {
+    static worstEdgeError(errorsWarnings: Errors.ErrorsWarnings) : Edge.Validity {
         if (errorsWarnings === null){
             console.warn("errorsWarnings is null");
-            return Eagle.LinkValid.Valid;
+            return Edge.Validity.Valid;
         }
 
         if (errorsWarnings.warnings.length === 0 && errorsWarnings.errors.length === 0){
-            return Eagle.LinkValid.Valid;
+            return Edge.Validity.Valid;
         }
 
         if (errorsWarnings.errors.length !== 0){
             // TODO: this actually has no way of knowing whether the errors are of type Invalid or Impossible
-            return Eagle.LinkValid.Invalid;
+            return Edge.Validity.Invalid;
         }
 
-        return Eagle.LinkValid.Warning;
+        return Edge.Validity.Warning;
     }
 
     static printCategories() : void {


### PR DESCRIPTION
The edge auto-complete system had a seperate and not-quite-as-good implementation of checking for suitable edges. I've updated it to re-use the Edge.isValid function.

This allowed findMatchingNodes() to be removed, and findMatchingPorts() could be simplified.

EAGLE remains performant, because the check for suitable destination ports only happens once, when dragging from an edge first starts.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the edge auto-complete system to reuse the Edge.isValid function, leading to the removal of the findMatchingNodes function and simplification of the findMatchingPorts function. These changes enhance the consistency and maintainability of the codebase.

- **Enhancements**:
    - Refactored the edge auto-complete system to reuse the Edge.isValid function, improving consistency and maintainability.
    - Simplified the findMatchingPorts function by removing redundant logic and directly using Edge.isValid for validation.

<!-- Generated by sourcery-ai[bot]: end summary -->