### PR TITLE
Eagle 1229

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -401,8 +401,8 @@ export class Edge {
         let associatedConstructType : Category = null; //the category type of the parent construct of the source or destination node
 
         //these checks are to see if the source or destination node are embedded apps whose parent is a sibling of the other source or destination node
-        const destPortIsEmbeddedAppOfSibling : boolean =  sourceNode.getParentKey() !== null && destinationNode.getEmbedKey() != null && sourceNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(destinationNode.getEmbedKey()).getParentKey()
-        const srcPortIsEmbeddedAppOfSibling : boolean =  destinationNode.getParentKey() !== null && sourceNode.getEmbedKey() != null && destinationNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(sourceNode.getEmbedKey()).getParentKey()
+        const destPortIsEmbeddedAppOfSibling : boolean =  sourceNode.getParentKey() !== null && destinationNode.getEmbedKey() != null && sourceNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(destinationNode.getEmbedKey())?.getParentKey();
+        const srcPortIsEmbeddedAppOfSibling : boolean =  destinationNode.getParentKey() !== null && sourceNode.getEmbedKey() != null && destinationNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(sourceNode.getEmbedKey())?.getParentKey();
 
         //checking the type of the parent nodes
         if(!isSibling){
@@ -435,7 +435,6 @@ export class Edge {
             const x = Errors.ShowFix("An edge between two siblings should not be loop aware", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDisableEdgeLoopAware(eagle, edgeId);}, "Disable loop aware on the edge.");
             Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, x, showNotification, showConsole, errorsWarnings);
         }
-
 
         // if link is not a parent, child or sibling, then warn user
         if (associatedConstructType != Category.ExclusiveForceNode && associatedConstructType != Category.Loop && !isSibling && !isParentOfConstruct && !isChildOfConstruct && !destPortIsEmbeddedAppOfSibling && !srcPortIsEmbeddedAppOfSibling){

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -424,7 +424,7 @@ export class Edge {
             }
         }
 
-        if(isSibling && loopAware){
+        if(isSibling && loopAware || destPortIsEmbeddedAppOfSibling && loopAware || srcPortIsEmbeddedAppOfSibling && loopAware || sourceNode.getEmbedKey() === destinationNode.getParentKey() && loopAware || destinationNode.getEmbedKey() === sourceNode.getParentKey() && loopAware){
             const x = Errors.ShowFix("An edge between two siblings should not be loop aware", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDisableEdgeLoopAware(eagle, edgeId);}, "Disable loop aware on the edge.");
             Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
         }

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -424,7 +424,6 @@ export class Edge {
             }
         }
 
-        // console.log('src: '+sourceNode.getName() + ' -> dest: '+ destinationNode.getName(), srcPortIsEmbeddedAppOfSibling,destPortIsEmbeddedAppOfSibling, loopAware)
         //checking if the edge is un-neccessarily loopAware
         if(    isSibling && loopAware 
             || destPortIsEmbeddedAppOfSibling && loopAware 
@@ -434,7 +433,7 @@ export class Edge {
             || associatedConstructType != Category.Loop && loopAware
         ){
             const x = Errors.ShowFix("An edge between two siblings should not be loop aware", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDisableEdgeLoopAware(eagle, edgeId);}, "Disable loop aware on the edge.");
-            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, x, showNotification, showConsole, errorsWarnings);
         }
 
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -400,13 +400,18 @@ export class Edge {
         const isSibling : boolean = sourceNode.getParentKey() === destinationNode.getParentKey(); // do the two nodes have the same parent
         let associatedConstructType : Category = null; //the category type of the parent construct of the source or destination node
 
+        //these checks are to see if the source or destination node are embedded apps whose parent is a sibling of the other source or destination node
+        const destPortIsEmbeddedAppOfSibling : boolean =  sourceNode.getParentKey() !== null && destinationNode.getEmbedKey() != null && sourceNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(destinationNode.getEmbedKey()).getParentKey()
+        const srcPortIsEmbeddedAppOfSibling : boolean =  destinationNode.getParentKey() !== null && sourceNode.getEmbedKey() != null && destinationNode.getParentKey() === eagle.logicalGraph().findNodeByKeyQuiet(sourceNode.getEmbedKey()).getParentKey()
+
         //checking the type of the parent nodes
         if(!isSibling){
             const srcNodeParent = eagle.logicalGraph().findNodeByKeyQuiet(sourceNode.getParentKey())
             const destNodeParent = eagle.logicalGraph().findNodeByKeyQuiet  (destinationNode.getParentKey())
+
             if(destNodeParent != null && destNodeParent.getCategory() === Category.Loop || srcNodeParent != null && srcNodeParent.getCategory() === Category.Loop){
                 associatedConstructType = Category.Loop
-            }else if(destNodeParent.getCategory() === Category.ExclusiveForceNode || srcNodeParent.getCategory() === Category.ExclusiveForceNode){
+            }else if(destNodeParent != null && destNodeParent.getCategory() === Category.ExclusiveForceNode || srcNodeParent != null && srcNodeParent.getCategory() === Category.ExclusiveForceNode){
                 associatedConstructType = Category.ExclusiveForceNode
             }
         }
@@ -425,11 +430,11 @@ export class Edge {
         }
 
         // if link is not a parent, child or sibling, then warn user
-        if (associatedConstructType != Category.ExclusiveForceNode && !isSibling && !loopAware && !isParentOfConstruct && !isChildOfConstruct){
+        if (associatedConstructType != Category.ExclusiveForceNode && !isSibling && !loopAware && !isParentOfConstruct && !isChildOfConstruct && !destPortIsEmbeddedAppOfSibling && !srcPortIsEmbeddedAppOfSibling){
             if(associatedConstructType === Category.Loop){
                 Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge will be connected to each instance of the Loop", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
             }else{
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge is not between siblings, or between a child and its parents embedded Application. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);    
+                Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge is not between siblings, or between a child and its parent's embedded Application. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);    
             }
         }
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -400,12 +400,11 @@ export class Edge {
         const isSibling : boolean = sourceNode.getParentKey() === destinationNode.getParentKey(); // do the two nodes have the same parent
         let associatedConstructType : Category = null; //the category type of the parent construct of the source or destination node
 
-        //checking the type of the 
+        //checking the type of the parent nodes
         if(!isSibling){
             const srcNodeParent = eagle.logicalGraph().findNodeByKeyQuiet(sourceNode.getParentKey())
             const destNodeParent = eagle.logicalGraph().findNodeByKeyQuiet  (destinationNode.getParentKey())
             if(destNodeParent != null && destNodeParent.getCategory() === Category.Loop || srcNodeParent != null && srcNodeParent.getCategory() === Category.Loop){
-            //edge wil be connected to each loop instance
                 associatedConstructType = Category.Loop
             }else if(destNodeParent.getCategory() === Category.ExclusiveForceNode || srcNodeParent.getCategory() === Category.ExclusiveForceNode){
                 associatedConstructType = Category.ExclusiveForceNode
@@ -418,6 +417,11 @@ export class Edge {
                 const x = Errors.ShowFix("Source and destination ports don't match data types: sourcePort (" + sourcePort.getDisplayText() + ":" + sourcePort.getType() + ") destinationPort (" + destinationPort.getDisplayText() + ":" + destinationPort.getType() + ")", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixPortType(eagle, sourcePort, destinationPort);}, "Overwrite destination port type with source port type");
                 Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
             }
+        }
+
+        if(isSibling && loopAware){
+            const x = Errors.ShowFix("An edge between two siblings should not be loop aware", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDisableEdgeLoopAware(eagle, edgeId);}, "Disable loop aware on the edge.");
+            Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
         }
 
         // if link is not a parent, child or sibling, then warn user

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -424,10 +424,19 @@ export class Edge {
             }
         }
 
-        if(isSibling && loopAware || destPortIsEmbeddedAppOfSibling && loopAware || srcPortIsEmbeddedAppOfSibling && loopAware || sourceNode.getEmbedKey() === destinationNode.getParentKey() && loopAware || destinationNode.getEmbedKey() === sourceNode.getParentKey() && loopAware){
+        // console.log('src: '+sourceNode.getName() + ' -> dest: '+ destinationNode.getName(), srcPortIsEmbeddedAppOfSibling,destPortIsEmbeddedAppOfSibling, loopAware)
+        //checking if the edge is un-neccessarily loopAware
+        if(    isSibling && loopAware 
+            || destPortIsEmbeddedAppOfSibling && loopAware 
+            || srcPortIsEmbeddedAppOfSibling && loopAware 
+            || sourceNode.getEmbedKey() != null && sourceNode.getEmbedKey() === destinationNode.getParentKey() && loopAware 
+            || destinationNode.getEmbedKey() != null && destinationNode.getEmbedKey() === sourceNode.getParentKey() && loopAware
+            || associatedConstructType != Category.Loop && loopAware
+        ){
             const x = Errors.ShowFix("An edge between two siblings should not be loop aware", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixDisableEdgeLoopAware(eagle, edgeId);}, "Disable loop aware on the edge.");
             Edge.isValidLog(edgeId, Eagle.LinkValid.Invalid, x, showNotification, showConsole, errorsWarnings);
         }
+
 
         // if link is not a parent, child or sibling, then warn user
         if (associatedConstructType != Category.ExclusiveForceNode && associatedConstructType != Category.Loop && !isSibling && !isParentOfConstruct && !isChildOfConstruct && !destPortIsEmbeddedAppOfSibling && !srcPortIsEmbeddedAppOfSibling){

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -430,12 +430,8 @@ export class Edge {
         }
 
         // if link is not a parent, child or sibling, then warn user
-        if (associatedConstructType != Category.ExclusiveForceNode && !isSibling && !loopAware && !isParentOfConstruct && !isChildOfConstruct && !destPortIsEmbeddedAppOfSibling && !srcPortIsEmbeddedAppOfSibling){
-            if(associatedConstructType === Category.Loop){
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge will be connected to each instance of the Loop", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
-            }else{
-                Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge is not between siblings, or between a child and its parent's embedded Application. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);    
-            }
+        if (associatedConstructType != Category.ExclusiveForceNode && associatedConstructType != Category.Loop && !isSibling && !isParentOfConstruct && !isChildOfConstruct && !destPortIsEmbeddedAppOfSibling && !srcPortIsEmbeddedAppOfSibling){
+                Edge.isValidLog(edgeId, Eagle.LinkValid.Warning, Errors.Show("Edge is not between siblings, or between a child and its parent's embedded Application. It could be incorrect or computationally expensive", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // check if the edge already exists in the graph, there is no point in a duplicate

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2331,6 +2331,8 @@ export class GraphRenderer {
     static edgeGetStrokeType(edge:Edge) : string {
         if(edge.isClosesLoop()){
             return ' 15, 8, 5, 8'
+        }else if(edge.isLoopAware()){
+            return '4,6'
         }else{
             return ''
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -412,27 +412,6 @@ export class Node {
         return this.outputApplication().getOutputPorts();
     }
 
-    hasLocalPortWithId = (id : string) : boolean => {
-        // check output ports of input application, if one exists
-        if (this.hasInputApplication()){
-            for (const outputPort of this.inputApplication().getOutputPorts()){
-                if (outputPort.getId() === id){
-                    return true;
-                }
-            }
-        }
-        // check input ports of outputApplication, if one exists
-        if (this.hasOutputApplication()){
-            for (const inputPort of this.outputApplication().getInputPorts()){
-                if (inputPort.getId() === id){
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     getFieldByDisplayText = (displayText : string) : Field | null => {
         for (const field of this.fields()){
             if (field.getDisplayText() === displayText){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1753,6 +1753,10 @@ export class Utils {
         eagle.logicalGraph().removeEdgeById(edgeId);
     }
 
+    static fixDisableEdgeLoopAware(eagle: Eagle, edgeId: string): void {
+        eagle.logicalGraph().findEdgeById(edgeId).setLoopAware(false)
+    }
+
     static fixPortType(eagle: Eagle, sourcePort: Field, destinationPort: Field): void {
         destinationPort.setType(sourcePort.getType());
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1754,7 +1754,7 @@ export class Utils {
     }
 
     static fixDisableEdgeLoopAware(eagle: Eagle, edgeId: string): void {
-        eagle.logicalGraph().findEdgeById(edgeId).setLoopAware(false)
+        eagle.logicalGraph().findEdgeById(edgeId)?.setLoopAware(false)
     }
 
     static fixPortType(eagle: Eagle, sourcePort: Field, destinationPort: Field): void {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the relationship checks between nodes in Edge.ts, introduces a new utility method to disable loop awareness on edges, updates the edge stroke type handling for loop-aware edges, and removes an obsolete method from Node.ts.

- **Enhancements**:
    - Refactored relationship checks between source and destination nodes in Edge.ts to improve clarity and maintainability.
    - Introduced a new method fixDisableEdgeLoopAware in Utils.ts to disable loop awareness on edges.
    - Updated edgeGetStrokeType method in GraphRenderer.ts to handle loop-aware edges with a new stroke type.
- **Chores**:
    - Removed the hasLocalPortWithId method from Node.ts as it is no longer needed.

<!-- Generated by sourcery-ai[bot]: end summary -->