### PR TITLE
Better delete message that doesn't 'double count' children of selected objects

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3324,7 +3324,29 @@ export class Eagle {
         // find child nodes
         for (const object of data){
             if (object instanceof Node){
-                childNodes.push(...this._findChildren(object));
+                // find children of this node
+                const children = this._findChildren(object);
+
+                for (const child of children){
+                    // check each child is not already in selectedObjects
+                    if (this.objectIsSelected(child)){
+                        continue;
+                    }
+
+                    // check each child is not already in childNodes
+                    let found: boolean = false;
+                    for (const cn of childNodes){
+                        if (cn.getId() === child.getId()){
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    // add to childNodes
+                    if (!found){
+                        childNodes.push(child);
+                    }
+                }
             }
         }
 
@@ -3332,7 +3354,12 @@ export class Eagle {
         for (const edge of this.logicalGraph().getEdges()){
             for (const node of childNodes){
                 if (edge.getSrcNodeKey() === node.getKey() || edge.getDestNodeKey() === node.getKey()){
-                    // check if edge as already in the list
+                    // TODO: check if edge is already in selectedObjects
+                    if (this.objectIsSelected(edge)){
+                        continue;
+                    }
+
+                    // check if edge as already in the childEdges list
                     let found = false;
                     for (const e of childEdges){
                         if (e.getId() === edge.getId()){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3354,12 +3354,12 @@ export class Eagle {
         for (const edge of this.logicalGraph().getEdges()){
             for (const node of childNodes){
                 if (edge.getSrcNodeKey() === node.getKey() || edge.getDestNodeKey() === node.getKey()){
-                    // TODO: check if edge is already in selectedObjects
+                    // check if edge is already in selectedObjects
                     if (this.objectIsSelected(edge)){
                         continue;
                     }
 
-                    // check if edge as already in the childEdges list
+                    // check if edge is already in the childEdges list
                     let found = false;
                     for (const e of childEdges){
                         if (e.getId() === edge.getId()){


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the deletion process by ensuring that child nodes of selected objects are not double-counted. The changes involve checking if child nodes and edges are already in the selected objects or child nodes list before adding them.

- **Bug Fixes**:
    - Fixed issue where child nodes of selected objects were being double-counted in the deletion process.

<!-- Generated by sourcery-ai[bot]: end summary -->