### PR TITLE
EAGLE-1005: Field.isValid now checks if PythonObject self port has multiple inputs

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -24,6 +24,7 @@
 
 import { Category } from './Category';
 import { Field } from './Field';
+import { Node } from './Node';
 
 export class Daliuge {
     // automatically loaded palettes
@@ -32,6 +33,11 @@ export class Daliuge {
 
     // schemas
     static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/daliuge/master/daliuge-translator/dlg/dropmake/lg.graph.schema";
+
+    // NOTE: eventually this can be replaced. Once we have added a new category for PythonInitialiser
+    static isPythonInitialiser(node: Node): boolean {
+        return node.getCategory() === Category.PythonMemberFunction && (node.getName().includes("__init__") || node.getName().includes("__class__"));
+    }
 }
 
 export namespace Daliuge {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3592,7 +3592,7 @@ export class Eagle {
             }
 
             // determine whether we should also generate an object data drop along with this node
-            const generateObjectDataDrop: boolean = newNode.getCategory() === Category.PythonMemberFunction && (newNode.getName().includes("__init__") || newNode.getName().includes("__class__"));
+            const generateObjectDataDrop: boolean = Daliuge.isPythonInitialiser(newNode);
 
             // optionally generate a new PythonObject node
             if (generateObjectDataDrop){

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -873,7 +873,7 @@ export class Field {
             errorsWarnings.warnings.push(issue);
         }
 
-        //chack that the field has a known type
+        // check that the field has a known type
         if (!Utils.validateType(field.getType())) {
             const issue: Errors.Issue = Errors.ShowFix("Node " + node.getKey() + " (" + node.getName() + ") has a component parameter (" + field.getDisplayText() + ") whose type (" + field.getType() + ") is unknown", function(){Utils.showField(eagle, node.getId(),field)}, function(){Utils.fixFieldType(eagle, field)}, "Prepend existing type (" + field.getType() + ") with 'Object.'");
             errorsWarnings.warnings.push(issue);
@@ -885,7 +885,7 @@ export class Field {
             errorsWarnings.errors.push(issue);
         }
 
-        //check that the field has a unique display text on the node
+        // check that the field has a unique display text on the node
         for (let j = 0 ; j < node.getFields().length ; j++){
             const field1 = node.getFields()[j];
             if(field === field1){
@@ -900,6 +900,20 @@ export class Field {
                     const issue: Errors.Issue = Errors.ShowFix("Node " + node.getKey() + " (" + node.getName() + ") has multiple attributes with the same display text (" + field.getDisplayText() + ").", function(){Utils.showField(eagle, node.getId(),field);}, function(){Utils.fixNodeMergeFields(eagle, node, field, field1)}, "Merge fields");
                     errorsWarnings.warnings.push(issue);
                 }
+            }
+        }
+
+        // check that PythonObject's self port is input for only one edge
+        if (node.getCategory() === Category.PythonObject && field.getDisplayText() === Daliuge.FieldName.SELF){
+            let numSelfPortConnections: number = 0;
+            for (const edge of eagle.logicalGraph().getEdges()){
+                if (edge.getDestPortId() === field.getId()){
+                    numSelfPortConnections += 1;
+                }
+            }
+
+            if (numSelfPortConnections > 1){
+                errorsWarnings.errors.push(Errors.Message("Port " + field.getDisplayText() + " on node " + node.getName() + " cannot have multiple inputs."));
             }
         }
 


### PR DESCRIPTION
Mark ports with error if multiple inputs to a single 'self' port on a PythonObject

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhanced the validation logic to check that the 'self' port on a PythonObject node does not have multiple input connections. Introduced a utility function to determine if a node is a PythonInitialiser.

- **Enhancements**:
    - Added validation to ensure that the 'self' port on a PythonObject node cannot have multiple input connections.

<!-- Generated by sourcery-ai[bot]: end summary -->