### PR TITLE
EAGLE-1263: Add undo snapshot after adding edge between two nodes

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2144,6 +2144,7 @@ export class GraphRenderer {
 
         eagle.addEdge(srcNode, srcPort, destNode, destPort, loopAware, closesLoop, (edge : Edge) : void => {
             eagle.checkGraph();
+            eagle.undo().pushSnapshot(eagle, "Added edge from " + srcNode.getName() + " to " + destNode.getName());
             eagle.logicalGraph.valueHasMutated();
             GraphRenderer.clearEdgeVars();
         });


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that creates an undo snapshot whenever an edge is added between two nodes in the graph. This ensures that users can revert the action if needed.

- **New Features**:
    - Added functionality to create an undo snapshot after adding an edge between two nodes.

<!-- Generated by sourcery-ai[bot]: end summary -->