### PR TITLE
Check and use alternate docker compose option

### DIFF
--- a/build_eagle.sh
+++ b/build_eagle.sh
@@ -1,23 +1,32 @@
+COMPOSE="docker-compose"
+
+# Check if the user has a different docker compose setup
+if ! command -v $COMPOSE
+then
+    COMPOSE="docker compose"
+fi
+
+
 case "$1" in
     "dep")
         export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
         echo "Building EAGLE version ${VCS_TAG}"
         python updateVersion.py
-        docker-compose -f ./docker/docker-compose.dep.yml build
+        $COMPOSE -f ./docker/docker-compose.dep.yml build
         echo "Build finished!"
         exit 1 ;;
     "dev")
         export VCS_TAG=`git rev-parse --abbrev-ref HEAD`
         echo "Building EAGLE development version"
         python updateVersion.py
-	docker-compose -f ./docker/docker-compose.dev.yml build
+	$COMPOSE -f ./docker/docker-compose.dev.yml build
         echo "Build finished!"
         exit 1;;
     "slim")
         export VCS_TAG=`git describe --tags --abbrev=0|sed s/v//`
         echo "Building EAGLE slim version ${VCS_TAG}"
         python updateVersion.py
-        docker-compose -f ./docker/docker-compose.dep.yml build
+        $COMPOSE -f ./docker/docker-compose.dep.yml build
         echo "Build finished! Slimming the image now"
         echo "This requires to interact with the intermediate server."
         echo "Please open the EAGLE settings and put the gitHub and gitLab API keys in"


### PR DESCRIPTION
This aims to resolve #721 by checking to see if the `docker-compose` utility exists on the user's machine; if not, we try and build EAGLE using the newer plugin approach with `docker compose`.  

(Apologies in advance for naiming the branch incorrectly; the problem with having too many repos open at once!).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the build script to support both 'docker-compose' and 'docker compose' commands, ensuring compatibility with different Docker setups.

- **Enhancements**:
    - Added a check to determine if 'docker-compose' is available and fallback to 'docker compose' if not.

<!-- Generated by sourcery-ai[bot]: end summary -->