### PR TITLE
more helpful port suggestions while dragging

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2110,11 +2110,11 @@ export class GraphRenderer {
     }
 
     static draggingEdgeGetStrokeColor: ko.PureComputed<string> = ko.pureComputed(() => {
-        let usageArray = GraphRenderer.isDraggingPortValid()
+        let edgeTargetValidity = GraphRenderer.isDraggingPortValid()
 
         //if this is the case, we are not hovering on a port and want the validity of the suggested connection to determine the edge color
-        if(usageArray===Errors.Validity.Unknown){
-            usageArray = GraphRenderer.portDragSuggestionValidity()
+        if(edgeTargetValidity===Errors.Validity.Unknown){
+            edgeTargetValidity = GraphRenderer.portDragSuggestionValidity()
 
             //we are coloring the edge accorting to suggested connections, but the suggestion is not close enough
             if(!GraphRenderer.portMatchCloseEnough()){
@@ -2122,7 +2122,7 @@ export class GraphRenderer {
             }
         }
 
-        switch (usageArray){
+        switch (edgeTargetValidity){
             case Errors.Validity.Unknown:
                 return EagleConfig.getColor("edgeDefault");
             case Errors.Validity.Impossible:

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -297,7 +297,7 @@ export class GraphRenderer {
 
     static portDragSuggestedNode : ko.Observable<Node> = ko.observable(null);
     static portDragSuggestedField : ko.Observable<Field> = ko.observable(null);
-    static portDragSuggestionValidity : ko.Observable<Errors.Validity> = ko.observable(Errors.Validity.Unknown)
+    static portDragSuggestionValidity : ko.Observable<Errors.Validity> = ko.observable(Errors.Validity.Unknown) // this is necessary because we cannot keep the validity on the ege as it does not exist
     static matchingPortList : {field:Field,node:Node,validity: Errors.Validity}[] = []
     static portMatchCloseEnough :ko.Observable<boolean> = ko.observable(false);
 
@@ -1414,12 +1414,12 @@ export class GraphRenderer {
         let findConstructId
         const orderedConstructList:Node[] = []
 
-        constructsList.forEach(function(x){
-            if(x.getParentKey()===null){
+        constructsList.forEach(function(construct){
+            if(construct.getParentKey()===null){
                 let finished = false // while there are child construct found in this construct nest group
 
-                findConstructId = x.getKey()
-                orderedConstructList.unshift(x)
+                findConstructId = construct.getKey()
+                orderedConstructList.unshift(construct)
                 while(!finished){
                     let found = false
                     for(const entry of constructsList){
@@ -1723,8 +1723,8 @@ export class GraphRenderer {
         }
 
         //resetting some global cached variables
-        GraphRenderer.matchingPortList.forEach(function(x){
-            x.field.setPeek(false)
+        GraphRenderer.matchingPortList.forEach(function(matchingPort){
+            matchingPort.field.setPeek(false)
         })
 
         GraphRenderer.matchingPortList = []
@@ -2049,10 +2049,10 @@ export class GraphRenderer {
         GraphRenderer.portMatchCloseEnough(false)
 
         const portList = GraphRenderer.matchingPortList
-        for (const x of portList){
-            const port = x.field
-            const node = x.node
-            const validity = x.validity
+        for (const portInfo of portList){
+            const port = portInfo.field
+            const node = portInfo.node
+            const validity = portInfo.validity
 
             // get position of port
             let portX

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -298,7 +298,7 @@ export class GraphRenderer {
     static portDragSuggestedNode : ko.Observable<Node> = ko.observable(null);
     static portDragSuggestedField : ko.Observable<Field> = ko.observable(null);
     static portDragSuggestionValidity : ko.Observable<Errors.Validity> = ko.observable(Errors.Validity.Unknown) // this is necessary because we cannot keep the validity on the ege as it does not exist
-    static matchingPortList : {field:Field,node:Node,validity: Errors.Validity}[] = []
+    static createEdgeSuggestedPorts : {field:Field,node:Node,validity: Errors.Validity}[] = []
     static portMatchCloseEnough :ko.Observable<boolean> = ko.observable(false);
 
     //node drag handler globals
@@ -1637,7 +1637,7 @@ export class GraphRenderer {
         GraphRenderer.portDragSourcePort(port);
         GraphRenderer.portDragSourcePortIsInput = usage === 'input';      
         GraphRenderer.renderDraggingPortEdge(true);
-        GraphRenderer.matchingPortList = []
+        GraphRenderer.createEdgeSuggestedPorts = []
         
         //take not of the start drag position
         GraphRenderer.portDragStartPos = {x:GraphRenderer.SCREEN_TO_GRAPH_POSITION_X(null),y:GraphRenderer.SCREEN_TO_GRAPH_POSITION_Y(null)}
@@ -1648,7 +1648,7 @@ export class GraphRenderer {
         port.setPeek(true)
 
         // build the list of all ports in the graph that are a valid end-point for an edge starting at this port
-        GraphRenderer.matchingPortList = GraphRenderer.findMatchingPorts(GraphRenderer.portDragSourceNode(), GraphRenderer.portDragSourcePort());
+        GraphRenderer.createEdgeSuggestedPorts = GraphRenderer.findMatchingPorts(GraphRenderer.portDragSourceNode(), GraphRenderer.portDragSourcePort());
     }
 
     static portDragging() : void {
@@ -1723,11 +1723,11 @@ export class GraphRenderer {
         }
 
         //resetting some global cached variables
-        GraphRenderer.matchingPortList.forEach(function(matchingPort){
+        GraphRenderer.createEdgeSuggestedPorts.forEach(function(matchingPort){
             matchingPort.field.setPeek(false)
         })
 
-        GraphRenderer.matchingPortList = []
+        GraphRenderer.createEdgeSuggestedPorts = []
         eagle.logicalGraph.valueHasMutated();
     }
 
@@ -2048,7 +2048,7 @@ export class GraphRenderer {
         let minValidity: Errors.Validity = Errors.Validity.Unknown;
         GraphRenderer.portMatchCloseEnough(false)
 
-        const portList = GraphRenderer.matchingPortList
+        const portList = GraphRenderer.createEdgeSuggestedPorts
         for (const portInfo of portList){
             const port = portInfo.field
             const node = portInfo.node

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2116,7 +2116,7 @@ export class GraphRenderer {
         if(edgeTargetValidity===Errors.Validity.Unknown){
             edgeTargetValidity = GraphRenderer.portDragSuggestionValidity()
 
-            //we are coloring the edge accorting to suggested connections, but the suggestion is not close enough
+            //we are coloring the edge according to suggested connections, but the suggestion is not close enough
             if(!GraphRenderer.portMatchCloseEnough()){
                 return EagleConfig.getColor("edgeDefault")
             }


### PR DESCRIPTION
suggested ports, graph-wide will once again be highlighted purple and their name is displayed.
when close enough to a suggested port, the dragging edge will now also be coloured depending on validity

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the port dragging experience by providing better visual cues. Suggested ports are now highlighted in purple with their names displayed, and the dragging edge color changes based on the connection's validity.

- **Enhancements**:
    - Enhanced port dragging functionality by highlighting suggested ports in purple and displaying their names.
    - Improved visual feedback during port dragging by coloring the dragging edge based on the validity of the connection.

<!-- Generated by sourcery-ai[bot]: end summary -->