### PR TITLE
EAGLE-1303: Fixed bug where 'editEdge' modal would not have 'loopAware' and 'closesLoop' checkboxes init to correct values

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -477,9 +477,7 @@ export class Edge {
         }
     }
 
-    private static isValidLog(edge : Edge,draggingPortMode:boolean, linkValid : Errors.Validity, issue: Errors.Issue, showNotification : boolean, showConsole : boolean, errorsWarnings: Errors.ErrorsWarnings) : void {
-       
-
+    private static isValidLog(edge: Edge, draggingPortMode: boolean, linkValid: Errors.Validity, issue: Errors.Issue, showNotification: boolean, showConsole: boolean, errorsWarnings: Errors.ErrorsWarnings): void {
         // determine correct title
         let title = "Edge Valid";
         let type : "success" | "info" | "warning" | "danger" = "success";
@@ -519,8 +517,11 @@ export class Edge {
             errorsWarnings.warnings.push(issue);
         }
 
+        // TODO: maybe this should not be in the logging function, but there doesn't seem to be a better place for it?
         if(!draggingPortMode){
-            edge.issues().push({issue:issue, validity:linkValid})
+            if (edge !== null){
+                edge.issues.push({issue:issue, validity:linkValid})
+            }
         }
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -895,6 +895,10 @@ export class Utils {
                 }));
             }
         }
+
+        // update the loopAware and closesLoop checkboxes
+        $('#editEdgeModalLoopAwareCheckbox').prop('checked', edge.isLoopAware());
+        $('#editEdgeModalClosesLoopCheckbox').prop('checked', edge.isClosesLoop());
     }
 
     /**


### PR DESCRIPTION
Also added a null check to fix a bug in Edge.isValidLog()

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix bugs related to the initialization of checkboxes in the 'editEdge' modal and add a null check in the Edge.isValidLog() method to prevent potential errors.

Bug Fixes:
- Initialize 'loopAware' and 'closesLoop' checkboxes in the 'editEdge' modal to the correct values.
- Add a null check in the Edge.isValidLog() method to prevent errors when accessing edge properties.

<!-- Generated by sourcery-ai[bot]: end summary -->