### PR TITLE
LIU-406: Update palette URL to point to EAGLE-graph-repo.

### DIFF
--- a/docs/palettes.rst
+++ b/docs/palettes.rst
@@ -36,9 +36,9 @@ We have a method for automatically generating component descriptions from source
 
   * Uses doxygen to process the source code and output XML documentation
   * Processes the XML with a EAGLE script called xml2palette.py
-  * Commit/push the resulting palette JSON to the ICRAR/EAGLE_test_repo repository inside a directory named after the project
+  * Commit/push the resulting palette JSON to the ICRAR/EAGLE-graph-repo repository inside a directory named after the project
 
-This process is described in further detail within the `DALiuGE Documentation <https://daliuge.readthedocs.io/en/latest/development/app_development/eagle_integration.html>`_
+This process is described in further detail within the `DALiuGE Documentation <https://daliuge.readthedocs.io/en/latest/development/app_development/eagle_app_integration.html>`_
 
 
 Creating Palettes within EAGLE

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -28,8 +28,8 @@ import { Node } from './Node';
 
 export class Daliuge {
     // automatically loaded palettes
-    static readonly PALETTE_URL : string  = "https://raw.githubusercontent.com/ICRAR/EAGLE_test_repo/master/daliuge/daliuge-master.palette";
-    static readonly TEMPLATE_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE_test_repo/master/daliuge/daliuge-master-template.palette";
+    static readonly PALETTE_URL : string  = "https://raw.githubusercontent.com/ICRAR/EAGLE-graph-repo/master/daliuge/daliuge-master.palette";
+    static readonly TEMPLATE_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE-graph-repo/master/daliuge/daliuge-master-template.palette";
 
     // schemas
     static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/daliuge/master/daliuge-translator/dlg/dropmake/lg.graph.schema";


### PR DESCRIPTION
# Summary

As part of [ongoing work](https://icrar.atlassian.net/jira/software/c/projects/LIU/boards/26/backlog?selectedIssue=LIU-405) to improve our synchronisation of graphs between unit-tests, DALiuGE, and EAGLE, we are updating where we store the operational palettes for EAGLE. This PR updates the repository that we access palettes, from the EAGLE_test_repo to the EAGLE-graph-repo. 

The reciprocal [DALiuGE PR](https://github.com/ICRAR/daliuge/pull/286) contains the relevant changes to update the automatic workflow; the workflows are already being updated as demonstrated in [this commit created by the PR](https://github.com/ICRAR/EAGLE-graph-repo/commit/21f5ec182b21ec03a2cd15ed8f20567b53fa788a).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the operational palette URLs in the Daliuge class to use the new EAGLE-graph-repo, aligning with ongoing efforts to improve graph synchronization across unit-tests, DALiuGE, and EAGLE.

Enhancements:
- Update the URLs for the PALETTE_URL and TEMPLATE_URL in the Daliuge class to point to the EAGLE-graph-repo instead of the EAGLE_test_repo.

<!-- Generated by sourcery-ai[bot]: end summary -->