### PR TITLE
EAGLE-1268: Delete files from git repositories within EAGLE

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -736,6 +736,29 @@ def open_git_hub_file():
     return response
 
 
+@app.route("/deleteRemoteGithubFile", methods=["POST"])
+def delete_git_hub_file():
+    """
+    FLASK POST routing method for '/deleteRemoteGithubFile'
+
+    Deletes a file from a GitHub repository. The POST request content is a JSON string containing the file name, repository name, branch, access token.
+    """
+    content = request.get_json(silent=True)
+    repo_name = content["repositoryName"]
+    repo_branch = content["repositoryBranch"]
+    repo_service = content["repositoryService"]
+    repo_token = content["token"]
+    filename = content["filename"]
+    extension = os.path.splitext(filename)[1]
+
+    print("delete_git_hub_file()", "repo_name", repo_name, "repo_service", repo_service, "repo_branch", repo_branch, "repo_token", repo_token, "filename", filename, "extension:" + extension + ":")
+
+    import time
+    time.sleep(3)
+
+    return json.dumps({'success':True}), 200, {'ContentType':'application/json'}
+
+
 @app.route("/openRemoteGitlabFile", methods=["POST"])
 def open_git_lab_file():
     """

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -240,4 +240,26 @@ export class GitHub {
 
         Utils.httpPostJSON('/openRemoteGithubFile', jsonData, callback);
     }
+
+    static deleteRemoteFile(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string) => void ) : void {
+        const token = Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY);
+
+        if (token === null || token === "") {
+            Utils.showUserMessage("Access Token", "The GitHub access token is not set! To open GitHub repositories, set the token via settings.");
+            return;
+        }
+
+        const fullFileName : string = Utils.joinPath(filePath, fileName);
+
+        // Add parameters in json data.
+        const jsonData = {
+            repositoryName: repositoryName,
+            repositoryBranch: repositoryBranch,
+            repositoryService: repositoryService,
+            token: token,
+            filename: fullFileName
+        };
+
+        Utils.httpPostJSON('/deleteRemoteGithubFile', jsonData, callback);
+    }
 }

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -204,4 +204,26 @@ export class GitLab {
 
         Utils.httpPostJSON('/openRemoteGitlabFile', jsonData, callback);
     }
+
+    static deleteRemoteFile(repositoryService : Repository.Service, repositoryName : string, repositoryBranch : string, filePath : string, fileName : string, callback: (error : string) => void ) : void {
+        const token = Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY);
+
+        if (token === null || token === "") {
+            Utils.showUserMessage("Access Token", "The GitLab access token is not set! To open GitLab repositories, set the token via settings.");
+            return;
+        }
+
+        const fullFileName : string = Utils.joinPath(filePath, fileName);
+
+        // Add parameters in json data.
+        const jsonData = {
+            repositoryName: repositoryName,
+            repositoryBranch: repositoryBranch,
+            repositoryService: repositoryService,
+            token: token,
+            filename: fullFileName
+        };
+
+        Utils.httpPostJSON('/deleteRemoteGitlabFile', jsonData, callback);
+    }
 }

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -82,6 +82,30 @@ export class Repository {
         }
     }
 
+    deleteFile = (file: RepositoryFile) : void => {
+        let pointer: Repository | RepositoryFolder = this;
+
+        if (file.path !== ""){
+            // traverse down the folder structure
+            const pathParts: string[] = file.path.split('/');
+            for (const pathPart of pathParts){
+                for (const folder of pointer.folders()){
+                    if (folder.name === pathPart){
+                        pointer = folder;
+                    }
+                }
+            }
+        }
+
+        // remove the file here
+        for (let i = 0 ; i < pointer.files().length; i++){
+            if (pointer.files()[i]._id === file._id){
+                pointer.files.splice(i, 1);
+                break;
+            }
+        }
+    }
+
     // sorting order
     // 1. alphabetically by service
     // 2. alphabetically by name

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -84,13 +84,16 @@ export class Repository {
 
     deleteFile = (file: RepositoryFile) : void => {
         let pointer: Repository | RepositoryFolder = this;
+        let lastPointer: Repository | RepositoryFolder = null;
+        const fileIsInTopLevelOfRepo: boolean = file.path === "";
 
-        if (file.path !== ""){
+        if (!fileIsInTopLevelOfRepo){
             // traverse down the folder structure
             const pathParts: string[] = file.path.split('/');
             for (const pathPart of pathParts){
                 for (const folder of pointer.folders()){
                     if (folder.name === pathPart){
+                        lastPointer = pointer;
                         pointer = folder;
                     }
                 }
@@ -102,6 +105,18 @@ export class Repository {
             if (pointer.files()[i]._id === file._id){
                 pointer.files.splice(i, 1);
                 break;
+            }
+        }
+
+        // check if we removed the last file in the folder
+        // if so, the remove the folder too
+        if (!fileIsInTopLevelOfRepo){
+            if (pointer.files().length === 0){
+                for (let i = 0; i < lastPointer.folders().length ; i++){
+                    if (lastPointer.folders()[i].name === pointer.name){
+                        lastPointer.folders.splice(i, 1);
+                    }
+                }
             }
         }
     }

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -275,6 +275,7 @@ export class Setting {
     static readonly CONFIRM_NODE_CATEGORY_CHANGES : string = "ConfirmNodeCategoryChanges";
     static readonly CONFIRM_REMOVE_REPOSITORIES : string = "ConfirmRemoveRepositories";
     static readonly CONFIRM_RELOAD_PALETTES : string = "ConfirmReloadPalettes";
+    static readonly CONFIRM_DELETE_FILES : string = "ConfirmDeleteFiles";
     static readonly CONFIRM_DELETE_OBJECTS : string = "ConfirmDeleteObjects";
 
     static readonly SHOW_FILE_LOADING_ERRORS : string = "ShowFileLoadingErrors";
@@ -365,8 +366,8 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Confirm Node Category Changes", Setting.CONFIRM_NODE_CATEGORY_CHANGES, "Prompt user to confirm that changing the node category may break the node.",false, Setting.Type.Boolean, true, true,true,true,true),
             new Setting(false, "Confirm Remove Repositories", Setting.CONFIRM_REMOVE_REPOSITORIES, "Prompt user to confirm removing a repository from the list of known repositories.",false , Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Confirm Reload Palettes", Setting.CONFIRM_RELOAD_PALETTES, "Prompt user to confirm when loading a palette that is already loaded.",false , Setting.Type.Boolean,true,true,true,true,true),
-            new Setting(false, "Confirm Delete", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
-            new Setting(false, "Confirm Delete", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
+            new Setting(false, "Confirm Delete Files", Setting.CONFIRM_DELETE_FILES, "Prompt user to confirm when deleting files from a repository.", false, Setting.Type.Boolean, true,true,true,true,true),
+            new Setting(false, "Confirm Delete Objects", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
             new Setting(true, "Open Default Palette on Startup", Setting.OPEN_DEFAULT_PALETTE, "Open a default palette on startup. The palette contains an example of all known node categories", false, Setting.Type.Boolean, false,false,true,true,true, [], function(){Eagle.getInstance().toggleDefaultPalettes();}),
             new Setting(true, "Disable JSON Validation", Setting.DISABLE_JSON_VALIDATION, "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", false, Setting.Type.Boolean, false,false,false,false,false),
             new Setting(true, "Overwrite Existing Translator Tab", Setting.OVERWRITE_TRANSLATION_TAB, "When translating a graph, overwrite an existing translator tab", false, Setting.Type.Boolean, true,true,true,true,true),

--- a/static/base.css
+++ b/static/base.css
@@ -1603,7 +1603,6 @@ select.form-control{
 
 #repositoryList .col-9{
     max-width: 79%;
-    width: auto;
 }
 
 #repositoryList .col-10{
@@ -1635,6 +1634,15 @@ select.form-control{
 #repositoryList ul.repositories i.material-icons.md-18 {
     position: relative;
     top: 4px;
+    font-size: 22px;
+}
+
+#repositoryList ul.repositories .repo-actions i.material-icons.md-18 {
+    visibility: hidden;
+}
+
+#repositoryList ul.repositories .repoFile:hover .repo-actions i.material-icons.md-18 {
+    visibility: visible;
 }
 
 #nodeList ul.nodes {

--- a/static/components/repository-file.html
+++ b/static/components/repository-file.html
@@ -18,6 +18,9 @@
             <div class="col col-1">
                 <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.insertRemoteFile, eagleTooltip: 'Insert'">add_box</i>
             </div>
+            <div class="col col-1">
+                <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.deleteRemoteFile, eagleTooltip: 'Delete'">delete</i>
+            </div>
         <!-- /ko -->
     </div>
 </div>

--- a/static/components/repository-file.html
+++ b/static/components/repository-file.html
@@ -1,4 +1,4 @@
-<div class="repoIndent">
+<div class="repoIndent repoFile">
     <div class="row">
         <div class="col col-1">
             <!-- ko if: isFetching -->
@@ -9,17 +9,15 @@
             <i class="material-icons md-18" data-bind="text: getIconUrl"></i>
             <!-- /ko -->
         </div>
-        <div class="col col-10">
+        <div class="col col-9">
             <a href="#" data-bind="click: Repositories.selectFile, attr: {id: htmlId}, eagleTooltip: $data.name" data-bs-placement="left">
                 <span data-bind="text: $data.name"></span>
             </a>
         </div>
-        <!-- ko if: getIconUrl() === "device_hub" -->
-            <div class="col col-1">
+        <div class="col col-2 repo-actions">
+            <!-- ko if: getIconUrl() === "device_hub" -->
                 <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.insertRemoteFile, eagleTooltip: 'Insert'">add_box</i>
-            </div>
-        <!-- /ko -->
-        <div class="col col-1">
+            <!-- /ko -->
             <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.deleteRemoteFile, eagleTooltip: 'Delete'">delete</i>
         </div>
     </div>

--- a/static/components/repository-file.html
+++ b/static/components/repository-file.html
@@ -18,9 +18,9 @@
             <div class="col col-1">
                 <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.insertRemoteFile, eagleTooltip: 'Insert'">add_box</i>
             </div>
-            <div class="col col-1">
-                <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.deleteRemoteFile, eagleTooltip: 'Delete'">delete</i>
-            </div>
         <!-- /ko -->
+        <div class="col col-1">
+            <i class="material-icons md-18" data-bs-placement="left" style="cursor:pointer;top:3px;" data-bind="click: $root.deleteRemoteFile, eagleTooltip: 'Delete'">delete</i>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Adds a "trash can" icon next to each file in the repository tab. Clicking the icon deletes the file from the repository.

There is a user confirmation step before the deletion. The confirmation step can be skipped using a new setting CONFIRM_DELETE_FILES.

Both GitLab and GitHub repositories are supported.

Once the file is deleted, we could trigger a refresh of the repository listing to visualise the change, but that is slow. So instead we just remove the file from the client-side repository file hierarchy, assuming this will exactly mirror the state of the remote repository.

Considered adding a "delete directory" button, but git directories only exist when a file exists within them. So removing all files from a directory will delete the directory from git.

Every delete results in one commit to the repository.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add functionality to delete files from GitHub and GitLab repositories within EAGLE, including a user confirmation step and client-side updates to the file hierarchy.

New Features:
- Introduce a feature to delete files from GitHub and GitLab repositories directly from the EAGLE interface, with a user confirmation step that can be bypassed using a new setting.

Enhancements:
- Update the client-side repository file hierarchy to reflect file deletions without refreshing the entire repository listing.

<!-- Generated by sourcery-ai[bot]: end summary -->