### PR TITLE
EAGLE-1291: Added backup method for determining version and commit_hash on EAGLE

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -94,8 +94,8 @@ except:
 # to find the version and commit_hash
 if version == "Unknown" and commit_hash == "Unknown":
     try:
-        version = subprocess.check_output("git describe --abbrev=0 --tags", shell=True).decode("utf-8").strip() + " (dev)"
-        commit_hash = subprocess.check_output("git rev-parse --short=8 HEAD", shell=True).decode("utf-8").strip()
+        version = subprocess.run(["git", "describe", "--abbrev=0", "--tags"], capture_output=True, text=True).stdout.strip() + " (dev)"
+        commit_hash = subprocess.run(["git", "rev-parse", "--short=8", "HEAD"], capture_output=True, text=True).stdout.strip()
     except:
         print("Unable to run git commands to determine version")
 

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -86,9 +86,8 @@ try:
                 continue
             if "COMMIT_HASH" in line:
                 commit_hash = line.split("COMMIT_HASH ")[1].strip()[1:-1]
-                continue
-except:
-    print("Unable to load VERSION file")
+except Exception as e:
+    print(f"Unable to load VERSION file: {e}")
 
 # if the first method was unsuccessful, then run some git commands
 # to find the version and commit_hash

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -31,6 +31,7 @@ import os
 import sys
 import tempfile
 import six
+import subprocess
 
 import urllib.request
 import ssl
@@ -74,6 +75,9 @@ app.config.from_object("config")
 
 version = "Unknown"
 commit_hash = "Unknown"
+
+# first look for the version and commit_hash in the VERSION file
+# that was generated during the build process
 try:
     with open(staticdir+"/VERSION") as vfile:
         for line in vfile.readlines():
@@ -85,6 +89,12 @@ try:
                 continue
 except:
     print("Unable to load VERSION file")
+
+# if the first method was unsuccessful, then run some git commands
+# to find the version and commit_hash
+if version == "Unknown" and commit_hash == "Unknown":
+    version = subprocess.check_output("git describe --abbrev=0 --tags", shell=True).decode("utf-8").strip() + " (dev)"
+    commit_hash = subprocess.check_output("git rev-parse --short=8 HEAD", shell=True).decode("utf-8").strip()
 
 print("Version: " + version + " Commit Hash: " + commit_hash)
 

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -96,8 +96,12 @@ if version == "Unknown" and commit_hash == "Unknown":
     try:
         version = subprocess.run(["git", "describe", "--abbrev=0", "--tags"], capture_output=True, text=True).stdout.strip() + " (dev)"
         commit_hash = subprocess.run(["git", "rev-parse", "--short=8", "HEAD"], capture_output=True, text=True).stdout.strip()
-    except:
-        print("Unable to run git commands to determine version")
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: {e}")
+    except FileNotFoundError:
+        print("Git executable not found. Ensure git is installed and in the system PATH.")
+    except Exception as e:
+        print(f"Unexpected error determining version: {e}")
 
 print("Version: " + version + " Commit Hash: " + commit_hash)
 

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -93,8 +93,11 @@ except:
 # if the first method was unsuccessful, then run some git commands
 # to find the version and commit_hash
 if version == "Unknown" and commit_hash == "Unknown":
-    version = subprocess.check_output("git describe --abbrev=0 --tags", shell=True).decode("utf-8").strip() + " (dev)"
-    commit_hash = subprocess.check_output("git rev-parse --short=8 HEAD", shell=True).decode("utf-8").strip()
+    try:
+        version = subprocess.check_output("git describe --abbrev=0 --tags", shell=True).decode("utf-8").strip() + " (dev)"
+        commit_hash = subprocess.check_output("git rev-parse --short=8 HEAD", shell=True).decode("utf-8").strip()
+    except:
+        print("Unable to run git commands to determine version")
 
 print("Version: " + version + " Commit Hash: " + commit_hash)
 


### PR DESCRIPTION
When deployed for real, EAGLE's build process runs a script, which generates a VERSION file. The VERSION file is read at startup and the version and commit_hash are passed to EAGLE client.

However, during some methods of development, the script is not run, and the VERSION file is unavailable.

The PR adds a backup method of determining the version and commit_hash. If the info is not found in the VERSION file, then it will run some git commands to determine the values.

It uses `git describe --abbrev=0 --tags` to get the most recent tag, but adds `(dev)` to the end to indicate it is not that version exactly, but that version plus some development.

It uses `git rev-parse --short=8 HEAD` to get the latest commit.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a backup mechanism to determine the version and commit hash using git commands if the VERSION file is not present during development. This ensures that version information is available even when the build script is not executed.

New Features:
- Introduce a backup method for determining the version and commit hash in EAGLE when the VERSION file is unavailable.

<!-- Generated by sourcery-ai[bot]: end summary -->