### PR TITLE
EAGLE-1311: Fix the "[DOM] Password field is not contained in a form" warning in Chrome

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -817,6 +817,11 @@ color: #00bb00;}
     overflow-y: scroll;
 }
 
+#settingsModal .settingStudentWrapper form{
+    padding: unset;
+    overflow-y: unset;
+}
+
 #settingsModal .modal-body{
     padding: 0px;
     height: unset;

--- a/templates/modals/settings.html
+++ b/templates/modals/settings.html
@@ -98,7 +98,7 @@
                 <!-- ko if: Setting.findValue( Setting.STUDENT_SETTINGS_MODE) -->
                     <!-- we are displaying some settings here in student mode for the admin to double check everything is set up correctly -->
                     <div class="settingStudentWrapper">
-
+                        <form>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.TRANSLATOR_URL).getDescription()" data-bs-placement="left">Translator url</span>
@@ -109,13 +109,13 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.GITHUB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitHub Access Token</span>
                             </div>
-                            <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY)">
+                            <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITHUB_ACCESS_TOKEN_KEY)" autocomplete="off">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" data-bind="eagleTooltip: Setting.find(Setting.GITLAB_ACCESS_TOKEN_KEY).getDescription()" data-bs-placement="left">GitLab Access Token</span>
                             </div>
-                            <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY)">
+                            <input type="password" class="form-control" disabled data-bind="value: Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY)" autocomplete="off">
                         </div>
                         <div class="input-group mb-1">
                             <div class="input-group-prepend">
@@ -129,6 +129,7 @@
                             </div>
                             <input type="text" class="form-control" disabled data-bind="value: Setting.findValue(Setting.EXPLORE_PALETTES_REPOSITORY)">
                         </div>
+                        </form>
                     </div>
                 <!-- /ko -->
             </div>


### PR DESCRIPTION
Added a form around the github and gitlab token entry fields in student mode.

CSS fixes

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the Chrome warning by enclosing the GitHub and GitLab token fields in a form and update CSS to maintain styling consistency.

Bug Fixes:
- Wrap GitHub and GitLab token entry fields in a form to fix the Chrome warning about password fields not being contained in a form.

Enhancements:
- Add CSS rules to ensure proper styling of the form within the settings modal.

<!-- Generated by sourcery-ai[bot]: end summary -->