### PR TITLE
EAGLE-1276: Use File instead of Memory when connecting an Application to a BashShellApp

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4649,15 +4649,24 @@ export class Eagle {
             y: (srcNodePosition.y + (numIncidentEdges * PORT_HEIGHT) + destNodePosition.y + (numIncidentEdges * PORT_HEIGHT)) / 2.0
         };
 
-        const memoryComponent = Utils.getPaletteComponentByName(Category.Memory);
+        // Normally we can use a Memory component in-between two apps
+        // but if the destination app is a BashShellApp, then a Memory component will cause an error
+        // since the BashShellApp can't read from a memory location
+        // Instead, we use a File component as the intermediary
+        let intermediaryComponent;
+        if (destNode.getCategory() === Category.BashShellApp){
+            intermediaryComponent = Utils.getPaletteComponentByName(Category.File);
+        } else {
+            intermediaryComponent = Utils.getPaletteComponentByName(Category.Memory);
+        }
 
         // if node not found, exit
-        if (memoryComponent === null) {
+        if (intermediaryComponent === null) {
             return;
         }
 
         // Add a duplicate of the memory component to the graph
-        const newNode : Node = this.logicalGraph().addDataComponentToGraph(Utils.duplicateNode(memoryComponent), dataComponentPosition);
+        const newNode : Node = this.logicalGraph().addDataComponentToGraph(Utils.duplicateNode(intermediaryComponent), dataComponentPosition);
 
         // set name of new node (use user-facing name)
         newNode.setName(srcPort.getDisplayText());

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -309,6 +309,11 @@ export class Edge {
             Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Error, Errors.Show("Data nodes may not be connected directly to other Data nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
+        // check that we are not connecting an Application component to an Application component, that is not supported
+        if (sourceNode.getCategoryType() === Category.Type.Application && destinationNode.getCategoryType() === Category.Type.Application){
+            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Error, Errors.Show("Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+        }
+
         // if source node or destination node is a construct, then something is wrong, constructs should not have ports
         if (sourceNode.getCategoryType() === Category.Type.Construct){
             const issue: Errors.Issue = Errors.ShowFix("Edge (" + edgeId + ") cannot have a source node (" + sourceNode.getName() + ") that is a construct", function(){Utils.showEdge(eagle, edgeId)}, function(){Utils.fixMoveEdgeToEmbeddedApplication(eagle, edgeId)}, "Move edge to embedded application");
@@ -468,7 +473,7 @@ export class Edge {
             }
         }
 
-        //the worst edge errror function can only check for entries in errors or warnings, it isnt able to distinguish impossible from invalid
+        //the worst edge error function can only check for entries in errors or warnings, it isn't able to distinguish impossible from invalid
         if(impossibleEdge){
             return Errors.Validity.Impossible
         }else if(draggingEdgeFixable){


### PR DESCRIPTION
When connecting two applications, EAGLE automatically adds a Memory node in the middle. This is OK most of the time, except when the destination node is a BashShellApp. In that case, the edge would be an error, since the BashShellApp can't read data from a memory location.

Instead, we should use a File node.

Also, adds a (missing?) check to the Edge isValid function, that generates an error if an Application is connected directly to an Application.

## Summary by Sourcery

Modify the connection logic to use a File node instead of a Memory node when connecting to a BashShellApp to prevent errors due to BashShellApp's inability to read from memory.

Bug Fixes:
- Fix the connection issue by using a File node instead of a Memory node when the destination application is a BashShellApp, as BashShellApp cannot read from memory.