### PR TITLE
EAGLE-1228: Removed Performance Display

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -14,7 +14,7 @@ The settings in Eagle include user experience and interface related options. By 
 UI Modes
 --------
 
-Ui modes are collections of settings creating seperate workspaces, each designed with a specific use case in mind.
+Ui modes are collections of settings creating separate workspaces, each designed with a specific use case in mind.
 
 **Minimal** - Designed for student use or when the goal is loading a graph, tweaking its key attributes and executing it through the translator.
 
@@ -111,9 +111,9 @@ Developer
 
 **Translate With New Categories** - Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.
 
-**Open Tanslator In Current Tab** - When translating a graph, display the output of the translator in the current tab.
+**Open Translator In Current Tab** - When translating a graph, display the output of the translator in the current tab.
 
-**Creat Applications For Construct Ports** - When loading old graph files with ports on construct nodes, move the port to an embedded application.
+**Create Applications For Construct Ports** - When loading old graph files with ports on construct nodes, move the port to an embedded application.
 
 **Skip 'Closes Loop' Edges In JSON Output** - We've recently added edges to the LinkDataArray that 'close' loop constructs and set the 'group_start' and 'group_end' automatically. In the short-term, such edges are not supported by the translator. This setting will keep the new edges during saving/loading, but remove them before sending the graph to the translator.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -109,8 +109,6 @@ External Services
 Developer
 """""""""
 
-**Enable Performance Display** - Display the frame time of the graph renderer.
-
 **Translate With New Categories** - Replace the old categories with new names when exporting. For example, replace 'Component' with 'PythonApp' category.
 
 **Open Tanslator In Current Tab** - When translating a graph, display the output of the translator in the current tab.

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -94,11 +94,6 @@ export class Eagle {
     quickActionSearchTerm : ko.Observable<string>;
     quickActionOpen : ko.Observable<boolean>;
 
-    rendererFrameDisplay : ko.Observable<string>;
-    rendererFrameMax : number;
-    rendererFrameCountRender : number;
-    rendererFrameCountTick : number;
-
     explorePalettes : ko.Observable<ExplorePalettes>;
     dockerHubBrowser : ko.Observable<DockerHubBrowser>;
 
@@ -183,11 +178,6 @@ export class Eagle {
         this.quickActionSearchTerm = ko.observable('')
         this.quickActionOpen = ko.observable(false)
 
-        this.rendererFrameDisplay = ko.observable("");
-        this.rendererFrameMax = 0;
-        this.rendererFrameCountRender = 0;
-        this.rendererFrameCountTick = 0;
-
         this.explorePalettes = ko.observable(new ExplorePalettes());
         this.dockerHubBrowser = ko.observable(new DockerHubBrowser());
 
@@ -246,10 +236,6 @@ export class Eagle {
 
         return null;
     }
-
-    showPerformanceDisplay : ko.PureComputed<boolean> = ko.pureComputed(() => {
-        return Setting.findValue(Setting.ENABLE_PERFORMANCE_DISPLAY);
-    }, this);
 
     types : ko.PureComputed<string[]> = ko.pureComputed(() => {
         // add all the built-in types

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -310,7 +310,6 @@ export class Setting {
     static readonly DOCKER_HUB_USERNAME: string = "DockerHubUserName";
     static readonly OPEN_TRANSLATOR_IN_CURRENT_TAB: string = "OpenTranslatorInCurrentTab";
     static readonly OVERWRITE_TRANSLATION_TAB: string = "OverwriteTranslationTab";
-    static readonly ENABLE_PERFORMANCE_DISPLAY: string = "EnablePerformanceDisplay";
     static readonly SHOW_DEVELOPER_TAB: string = "ShowDeveloperTab";
 
     static readonly GRAPH_ZOOM_DIVISOR: string = "GraphZoomDivisor";
@@ -428,7 +427,6 @@ const settings : SettingsGroup[] = [
         "Developer",
         () => {return false;},
         [
-            new Setting(true, "Enable Performance Display", Setting.ENABLE_PERFORMANCE_DISPLAY, "Display the frame time of the graph renderer", false, Setting.Type.Boolean, false,false,false, false, false),
             new Setting(true, "Show File Loading Warnings", Setting.SHOW_FILE_LOADING_ERRORS, "Display list of issues with files encountered during loading.", false, Setting.Type.Boolean, false,false, false, false, false),
             new Setting(true, "Open Translator In Current Tab", Setting.OPEN_TRANSLATOR_IN_CURRENT_TAB, "When translating a graph, display the output of the translator in the current tab", false, Setting.Type.Boolean, false,false,false, false, false),
             new Setting(true, "Create Applications for Construct Ports", Setting.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, "When loading old graph files with ports on construct nodes, move the port to an embedded application",false, Setting.Type.Boolean, true,true,true, true, true),

--- a/static/base.css
+++ b/static/base.css
@@ -23,17 +23,6 @@ body {
     padding-right: 0px;
 }
 
-#performance {
-    position: absolute;
-    right: 0px;
-    bottom: 0px;
-    background-color: black;
-    z-index: 1000;
-    padding: 2px;
-    color: white;
-    font-family: monospace;
-}
-
 .navbar-light .navbar-brand {
     color: rgba(230, 230, 230, 1);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -228,7 +228,6 @@
             </div>
         </div>
 
-        <span id="performance" data-bind="text: rendererFrameDisplay, visible: $root.showPerformanceDisplay"></span>
         <div id="htmlElementLog" style="display: none;"></div>
     </body>
 </html>


### PR DESCRIPTION
Removed the docs, html, CSS, setting and observables for Performance Display/Renderer Frame Time

Since the rendering is largely driven by updating observables, it is not immediately obvious how we would time the update from start to finish. So it is difficult to determine a real frame time. Rather than try to work something out, we're just removing the feature and the associated setting.

## Summary by Sourcery

Remove the performance display feature from the application, including its observables, settings, CSS, and HTML elements.

Enhancements:
- Remove the performance display feature, including its associated observables, settings, and HTML elements.