### PR TITLE
EAGLE-1322: Stop EAGLE applying graph configuration before translation

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1664,7 +1664,7 @@ export class Eagle {
         Utils.httpPostJSONString(url, jsonString, (error : string, data: string) : void => {
             if (error !== null){
                 Utils.showUserMessage("Error", data + "<br/><br/>These error messages provided by " + repository.service + " are not very helpful. Please contact EAGLE admin to help with further investigation.");
-                console.error("Error: " + JSON.stringify(error, null, 2) + " Data: " + data);
+                console.error("Error: " + JSON.stringify(error, null, EagleConfig.JSON_INDENT) + " Data: " + data);
                 return;
             }
 
@@ -3143,7 +3143,7 @@ export class Eagle {
         };
         
         // write to clipboard
-        navigator.clipboard.writeText(JSON.stringify(clipboard)).then(
+        navigator.clipboard.writeText(JSON.stringify(clipboard, null, EagleConfig.JSON_INDENT)).then(
             () => {
                 // success
                 Utils.showNotification("Copied to clipboard", "Copied " + clipboard.nodes.length + " nodes and " + clipboard.edges.length + " edges.", "info");

--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -134,6 +134,9 @@ export class EagleConfig {
     public static readonly CONSTRUCT_MARGIN: number = 30;
     public static readonly CONSTRUCT_DRAG_OUT_DISTANCE: number = 200;
 
+    // number of spaces used for indenting output JSON, makes everything human-readable
+    public static readonly JSON_INDENT: number = 4;
+
     static getColor(name:string) : string {
         let result: string = null;
 

--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -2,6 +2,7 @@ import * as ko from "knockout";
 
 import { Branded } from "./main";
 import { Eagle } from "./Eagle";
+import { EagleConfig } from "./EagleConfig";
 import { Errors } from "./Errors";
 import { Field } from "./Field";
 import { LogicalGraph } from "./LogicalGraph";
@@ -406,7 +407,7 @@ export class GraphConfig {
         const json: any = GraphConfig.toJson(graphConfig);
 
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
-        result += JSON.stringify(json, null, 4);
+        result += JSON.stringify(json, null, EagleConfig.JSON_INDENT);
 
         return result;
     }

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -131,13 +131,23 @@ export class LogicalGraph {
 
     static toOJSJsonString(graph : LogicalGraph, forTranslation : boolean) : string {
         let result: string = "";
-
         const json: any = LogicalGraph.toOJSJson(graph, forTranslation);
 
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += "{\n";
         result += '"modelData": ' + JSON.stringify(json.modelData, null, 4) + ",\n";
-        result += '"graphConfigurations": ' + JSON.stringify(json.graphConfigurations, null, 4) + ",\n";
+
+        // if we are sending this graph for translation, then only provide the "active" graph configuration
+        // otherwise, add all graph configurations
+        if (forTranslation){
+            const graphConfigurations: any = {};
+            graphConfigurations[graph.activeGraphConfig().getId().toString()] = GraphConfig.toJson(graph.activeGraphConfig());
+
+            result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, 4) + ",\n";
+        } else {
+            result += '"graphConfigurations": ' + JSON.stringify(json.graphConfigurations, null, 4) + ",\n";
+        }
+
         result += '"nodeDataArray": ' + JSON.stringify(json.nodeDataArray, null, 4) + ",\n";
         result += '"linkDataArray": ' + JSON.stringify(json.linkDataArray, null, 4) + "\n";
         result += "}\n";
@@ -429,6 +439,9 @@ export class LogicalGraph {
         for (const graphConfig of this.graphConfigs()){
             result.graphConfigs.push(graphConfig.clone());
         }
+
+        // copy active graph config
+        result.activeGraphConfig(this.activeGraphConfig().clone());
 
         return result;
     }

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -140,7 +140,6 @@ export class LogicalGraph {
         // if we are sending this graph for translation, then only provide the "active" graph configuration, or an empty array if none exist
         // otherwise, add all graph configurations
         if (forTranslation){
-
             if (graph.activeGraphConfig().getId() === null){
                 result += '"graphConfigurations": {},\n';
             } else {

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -135,7 +135,7 @@ export class LogicalGraph {
 
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += "{\n";
-        result += '"modelData": ' + JSON.stringify(json.modelData, null, 4) + ",\n";
+        result += '"modelData": ' + JSON.stringify(json.modelData, null, EagleConfig.JSON_INDENT) + ",\n";
 
         // if we are sending this graph for translation, then only provide the "active" graph configuration, or an empty array if none exist
         // otherwise, add all graph configurations
@@ -146,14 +146,14 @@ export class LogicalGraph {
                 const graphConfigurations: any = {};
                 graphConfigurations[graph.activeGraphConfig().getId().toString()] = GraphConfig.toJson(graph.activeGraphConfig());
 
-                result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, 4) + ",\n";
+                result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, EagleConfig.JSON_INDENT) + ",\n";
             }
         } else {
-            result += '"graphConfigurations": ' + JSON.stringify(json.graphConfigurations, null, 4) + ",\n";
+            result += '"graphConfigurations": ' + JSON.stringify(json.graphConfigurations, null, EagleConfig.JSON_INDENT) + ",\n";
         }
 
-        result += '"nodeDataArray": ' + JSON.stringify(json.nodeDataArray, null, 4) + ",\n";
-        result += '"linkDataArray": ' + JSON.stringify(json.linkDataArray, null, 4) + "\n";
+        result += '"nodeDataArray": ' + JSON.stringify(json.nodeDataArray, null, EagleConfig.JSON_INDENT) + ",\n";
+        result += '"linkDataArray": ' + JSON.stringify(json.linkDataArray, null, EagleConfig.JSON_INDENT) + "\n";
         result += "}\n";
 
         return result;

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -137,13 +137,18 @@ export class LogicalGraph {
         result += "{\n";
         result += '"modelData": ' + JSON.stringify(json.modelData, null, 4) + ",\n";
 
-        // if we are sending this graph for translation, then only provide the "active" graph configuration
+        // if we are sending this graph for translation, then only provide the "active" graph configuration, or an empty array if none exist
         // otherwise, add all graph configurations
         if (forTranslation){
-            const graphConfigurations: any = {};
-            graphConfigurations[graph.activeGraphConfig().getId().toString()] = GraphConfig.toJson(graph.activeGraphConfig());
 
-            result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, 4) + ",\n";
+            if (graph.activeGraphConfig().getId() === null){
+                result += '"graphConfigurations": {},\n';
+            } else {
+                const graphConfigurations: any = {};
+                graphConfigurations[graph.activeGraphConfig().getId().toString()] = GraphConfig.toJson(graph.activeGraphConfig());
+
+                result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, 4) + ",\n";
+            }
         } else {
             result += '"graphConfigurations": ' + JSON.stringify(json.graphConfigurations, null, 4) + ",\n";
         }

--- a/src/Palette.ts
+++ b/src/Palette.ts
@@ -27,6 +27,7 @@ import * as ko from "knockout";
 import { Category } from './Category';
 import { CategoryData } from './CategoryData';
 import { Eagle } from './Eagle';
+import { EagleConfig } from "./EagleConfig";
 import { Errors } from './Errors';
 import { FileInfo } from './FileInfo';
 import { Node } from './Node';
@@ -127,9 +128,9 @@ export class Palette {
 
         // manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += "{\n";
-        result += '"modelData": ' + JSON.stringify(json.modelData, null, 4) + ",\n";
-        result += '"nodeDataArray": ' + JSON.stringify(json.nodeDataArray, null, 4) + ",\n";
-        result += '"linkDataArray": ' + JSON.stringify(json.linkDataArray, null, 4) + "\n";
+        result += '"modelData": ' + JSON.stringify(json.modelData, null, EagleConfig.JSON_INDENT) + ",\n";
+        result += '"nodeDataArray": ' + JSON.stringify(json.nodeDataArray, null, EagleConfig.JSON_INDENT) + ",\n";
+        result += '"linkDataArray": ' + JSON.stringify(json.linkDataArray, null, EagleConfig.JSON_INDENT) + "\n";
         result += "}\n";
 
         return result;

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -144,12 +144,6 @@ export class Translator {
 
         // clone the logical graph
         const lgClone: LogicalGraph = eagle.logicalGraph().clone();
-        const activeConfig: GraphConfig = eagle.logicalGraph().getActiveGraphConfig();
-
-        // if there is a GraphConfig, apply GraphConfig to logicalGraph
-        if (activeConfig !== null){
-            GraphConfig.apply(lgClone, activeConfig);
-        }
 
         // get json for logical graph
         let jsonString: string;

--- a/tools/loadSaveGraph.ts
+++ b/tools/loadSaveGraph.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 
-import {LogicalGraph} from '../src/LogicalGraph';
+import { EagleConfig } from "../src/EagleConfig";
+import { LogicalGraph } from '../src/LogicalGraph';
 
 // check command line arguments
 if (process.argv.length < 3){
@@ -20,7 +21,7 @@ const inputString : string = data.toString();
 const inputGraph : LogicalGraph = LogicalGraph.fromOJSJson(inputString);
 
 // write the logical graph to disk using the outputFilename
-const outputString : string = JSON.stringify(LogicalGraph.toOJSJson(inputGraph), null, 4);
+const outputString : string = JSON.stringify(LogicalGraph.toOJSJson(inputGraph), null, EagleConfig.JSON_INDENT);
 
 // check that the input and output are the same
 const match : boolean = inputString === outputString;

--- a/tools/updateGraph.ts
+++ b/tools/updateGraph.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import { Category } from '../src/Category';
 import { Daliuge } from "../src/Daliuge";
 import { Eagle } from '../src/Eagle';
+import { EagleConfig } from "../src/EagleConfig";
 import { Edge } from '../src/Edge';
 import { Field } from '../src/Field';
 import { FileInfo } from '../src/FileInfo';
@@ -74,7 +75,7 @@ for (const node of outputGraph.getNodes()){
 }
 
 // write the logical graph to disk using the outputFilename
-fs.writeFileSync(outputFilename, JSON.stringify(LogicalGraph.toOJSJson(outputGraph, false), null, 4));
+fs.writeFileSync(outputFilename, JSON.stringify(LogicalGraph.toOJSJson(outputGraph, false), null, EagleConfig.JSON_INDENT));
 
 // finish
 process.exit();


### PR DESCRIPTION
At the moment, EAGLE applies the active graph configuration to the logical graph before translation. That is, it replaces values of node parameters with the values specified in the active graph configuration.

This PR removes that functionality, which will now be performed by the translator.

EAGLE now sends a slightly modified version of the LogicalGraph JSON to the DALiuGE translator. This version contains only the "active" graph configuration, or an empty dict, if no active graph configuration exists.

This PR also fixes a bug where cloning a LogicalGraph would NOT clone the state of the activeGraphConfiguration attribute.

## Summary by Sourcery

Remove the functionality of applying the active graph configuration to the logical graph before translation, delegating this task to the translator. Update the LogicalGraph to send only the active graph configuration to the DALiuGE translator. Fix a bug related to cloning the LogicalGraph's activeGraphConfiguration state.

Bug Fixes:
- Fix cloning of LogicalGraph to include the state of the activeGraphConfiguration attribute.

Enhancements:
- Modify LogicalGraph to send only the active graph configuration or an empty dict to the DALiuGE translator.