### PR TITLE
when adding a field to a graph configuration, the fields value from t…

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1490,9 +1490,8 @@ export class Eagle {
      */
 
     newConfig = () : void => {
-
         // clone existing active config, assign new id
-        const c: GraphConfig = this.logicalGraph().getActiveGraphConfig().clone();
+        const c: GraphConfig = new GraphConfig
         c.setId(Utils.generateGraphConfigId());
 
         

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -364,7 +364,7 @@ export class ParameterTable {
 
         if (graphConfig){
             if (add){
-                graphConfig.addField(currentField);
+                graphConfig.addValue(currentField.getNodeId(), currentField.getId(), currentField.getValue())
             } else {
                 graphConfig.removeField(currentField);
             }
@@ -386,7 +386,7 @@ export class ParameterTable {
 
                 // add/remove the field that was requested in the first place
                 if (add){
-                    graphConfig.addField(currentField);
+                    graphConfig.addValue(currentField.getNodeId(), currentField.getId(), currentField.getValue())
                 } else {
                     graphConfig.removeField(currentField);
                 }


### PR DESCRIPTION
when adding a field to a graph configuration, the field's value from the graph will be set as the initial configured value in the graph configuration. aka when adding a field to the config, it takes its value with it. 
additionally i fixed an error when creating a new graph config when there is none added in the first place.

## Summary by Sourcery

Enhance the graph configuration process by setting the field's current value as the initial value when adding a field. Fix an error in creating a new graph configuration when none exists by initializing a new GraphConfig.

Bug Fixes:
- Fix an error when creating a new graph configuration when none exists by initializing a new GraphConfig instead of cloning an active one.

Enhancements:
- Ensure that when adding a field to a graph configuration, the field's current value is set as the initial configured value.