### PR TITLE
EAGLE-1337: Fixed bug when loading graphs with no graph configs

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -221,7 +221,12 @@ export class LogicalGraph {
 
             //if the saved 'activeGraphConfigId' is empty or missing, we use the last one in the array, else we set the saved one as active                
             if(dataObject["activeGraphConfigId"] === '' || dataObject["activeGraphConfigId"] === undefined){
-                result.activeGraphConfigId(result.graphConfigs()[result.graphConfigs().length - 1].getId() as GraphConfig.Id)
+                // if graph has no configs, we can't use the last one in the array, so we'll set the active id to 'undefined'
+                if (result.graphConfigs().length === 0){
+                    result.activeGraphConfigId(undefined);
+                } else {
+                    result.activeGraphConfigId(result.graphConfigs()[result.graphConfigs().length - 1].getId() as GraphConfig.Id)
+                }
             }else{
                 result.activeGraphConfigId(dataObject["activeGraphConfigId"] as GraphConfig.Id)
             }


### PR DESCRIPTION
Fixed bug where code would try to set last graph config as active, even when no graph configs exist.

Now the code checks that at least one graph config exists. If none exist, then graph.activeGraphConfigId is set to undefined.

## Summary by Sourcery

Bug Fixes:
- Fix bug where the application attempts to set the last graph configuration as active even when no graph configurations exist by checking if at least one configuration is present before setting the active configuration ID.