### PR TITLE
EAGLE-1336: Fetch the LG schema from EAGLE_test_repo instead of DALiuGE

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -32,7 +32,7 @@ export class Daliuge {
     static readonly TEMPLATE_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE-graph-repo/master/daliuge/daliuge-master-template.palette";
 
     // schemas
-    static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/daliuge/master/daliuge-translator/dlg/dropmake/lg.graph.schema";
+    static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE_test_repo/refs/heads/master/tools/lg.graph.schema";
 
     // NOTE: eventually this can be replaced. Once we have added a new category for PythonInitialiser
     static isPythonInitialiser(node: Node): boolean {

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -32,7 +32,7 @@ export class Daliuge {
     static readonly TEMPLATE_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE-graph-repo/master/daliuge/daliuge-master-template.palette";
 
     // schemas
-    static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE_test_repo/refs/heads/master/tools/lg.graph.schema";
+    static readonly GRAPH_SCHEMA_URL : string = "https://raw.githubusercontent.com/ICRAR/EAGLE_test_repo/master/tools/lg.graph.schema";
 
     // NOTE: eventually this can be replaced. Once we have added a new category for PythonInitialiser
     static isPythonInitialiser(node: Node): boolean {


### PR DESCRIPTION
@myxie has updated the schema in EAGLE_test_repo, so it is now the best place to fetch the schema from

This should stop us seeing some errors when translating that referred to missing 'keyAttribute' attributes within fields in the JSON.

## Summary by Sourcery

Bug Fixes:
- Fix errors related to missing 'keyAttribute' attributes in JSON fields by updating the schema source.