### PR TITLE
EAGLE-1340: Fix for translating graphs with no graph configs

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1493,7 +1493,6 @@ export class Eagle {
         // clone existing active config, assign new id
         const c: GraphConfig = new GraphConfig
         c.setId(Utils.generateGraphConfigId());
-
         
         c.setName('newConfig');
 


### PR DESCRIPTION
This was caused (I think) by removing the last config from a graph, which did not reset the activeGraphConfigId. So therefore the activeGraphConfigId referred to a missing config, which broke the translator.

I fixed a few things:
- Make sure LogicalGraph.activeGraphConfigId is always **null** or an **id**. Previously we allowed the active id to be 'undefined', but this was just resulting in a lot of checks everywhere for a number of different states. Much simpler to just use a valid id or null.
- Also removed the part of the graph loading code that, when a active config id was missing, would set the last graph as the active config. This seems like an unexpected change, and there is no problem leaving the active config as null.
- Make sure LogicalGraph.removeGraphConfig calls Eagle.checkGraph after the removal
- Make sure LogicalGraph.removeGraphConfig checks if the removed config was the active one, if so, reset the active config id

To test this PR:

1. Load http://localhost:8888/?service=GitHub&repository=ICRAR/EAGLE-graph-repo&branch=master&path=examples&filename=astropy_SkyCoords_Constellations.graph
2. Remove the graph config
3. Translate the graph
4. Observe that the translation works correctly

## Summary by Sourcery

Fix issues with graph translation by ensuring activeGraphConfigId is always null or a valid id, and remove logic that sets the last graph as active when the id is missing.

Bug Fixes:
- Ensure that the activeGraphConfigId is always set to null or a valid id, preventing undefined states that could break the graph translator.

Enhancements:
- Remove logic that automatically sets the last graph as the active config when the active config id is missing, allowing it to remain null instead.