### PR TITLE
EAGLE-1333: Remove Eagle.FileType.Daliuge

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1664,7 +1664,6 @@ export class Eagle {
             // determine which object of the given filetype we are committing
             switch (fileType){
                 case Eagle.FileType.Graph:
-                case Eagle.FileType.Daliuge:
                     fileInfo = this.logicalGraph().fileInfo;
                     obj = this.logicalGraph();
                     break;
@@ -1743,7 +1742,6 @@ export class Eagle {
         // determine which object of the given filetype we are committing
         switch (fileType){
             case Eagle.FileType.Graph:
-            case Eagle.FileType.Daliuge:
                 fileInfo = this.logicalGraph().fileInfo;
                 obj = this.logicalGraph();
                 break;
@@ -1785,8 +1783,6 @@ export class Eagle {
                 Utils.showUserMessage('Error', 'Graph is not chosen! Open existing or create a new graph.');
             } else if (fileType == Eagle.FileType.Palette) {
                 Utils.showUserMessage('Error', 'Palette is not chosen! Open existing or create a new palette.');
-            } else if (fileType === Eagle.FileType.Daliuge) {
-                Utils.showUserMessage('Error', 'Daliuge is not chosen! Open existing or create a new daliuge.');
             }
             return;
         }
@@ -1826,7 +1822,6 @@ export class Eagle {
 
         let jsonString: string = "";
         switch (fileType){
-            case Eagle.FileType.Daliuge:
             case Eagle.FileType.Graph:
                 jsonString = LogicalGraph.toOJSJsonString(<LogicalGraph>clone, false);
                 break;
@@ -2016,7 +2011,6 @@ export class Eagle {
             }        
 
             switch (fileTypeLoaded){
-                case Eagle.FileType.Daliuge:
                 case Eagle.FileType.Graph: {
                     // attempt to determine schema version from FileInfo
                     const eagleVersion: string = Utils.determineEagleVersion(dataObject);
@@ -2417,7 +2411,7 @@ export class Eagle {
         console.log("saveGraphToDisk()", graph.fileInfo().name, graph.fileInfo().type);
 
         // check that the fileType has been set for the logicalGraph
-        if (graph.fileInfo().type !== Eagle.FileType.Graph && graph.fileInfo().type !== Eagle.FileType.Daliuge){
+        if (graph.fileInfo().type !== Eagle.FileType.Graph){
             Utils.showUserMessage("Error", "Graph fileType not set correctly. Could not save file.");
             return;
         }
@@ -4828,7 +4822,6 @@ export namespace Eagle
     }
 
     export enum FileType {
-        Daliuge = "Daliuge",
         Graph = "Graph",
         Palette = "Palette",
         JSON = "JSON",

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3918,7 +3918,7 @@ export class Eagle {
         $('#editFieldModalTypeInput').val(newType).trigger("change");
     }
 
-    tableDropdownClick = (newType:string, field: Field) : void => {
+    tableDropdownClick = (newType: Daliuge.DataType, field: Field) : void => {
         // if the field contains no options, then it's value will be immediately set to undefined
         // therefore, we add at least one option, so the value remains well defined
         if (newType === Daliuge.DataType.Select){
@@ -3930,7 +3930,6 @@ export class Eagle {
 
         // update the type of the field
         field.setType(newType);
-
     }
 
     changeNodeParent = () : void => {

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -18,7 +18,7 @@ export class Field {
     private defaultValue : ko.Observable<string>;  // default value
     private description : ko.Observable<string>;
     private readonly : ko.Observable<boolean>;
-    private type : ko.Observable<string>;
+    private type : ko.Observable<Daliuge.DataType>; // NOTE: this is a little unusual (type can have more values than just the enum)
     private precious : ko.Observable<boolean>; // indicates that the field is somehow important and should always be shown to the user
     private options : ko.ObservableArray<string>;
     private positional : ko.Observable<boolean>;
@@ -45,7 +45,7 @@ export class Field {
 
     private issues : ko.ObservableArray<{issue:Errors.Issue, validity:Errors.Validity}>//keeps track of issues on the field
 
-    constructor(id: FieldId, displayText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: string, precious: boolean, options: string[], positional: boolean, parameterType: Daliuge.FieldType, usage: Daliuge.FieldUsage){
+    constructor(id: FieldId, displayText: string, value: string, defaultValue: string, description: string, readonly: boolean, type: Daliuge.DataType, precious: boolean, options: string[], positional: boolean, parameterType: Daliuge.FieldType, usage: Daliuge.FieldUsage){
         this.displayText = ko.observable(displayText);
         this.value = ko.observable(value);
         this.defaultValue = ko.observable(defaultValue);
@@ -176,7 +176,7 @@ export class Field {
         this.readonly(!this.readonly())
     }
 
-    getType = () : string => {
+    getType = () : Daliuge.DataType => {
         return this.type();
     }
 
@@ -204,7 +204,7 @@ export class Field {
         this.defaultValue((!Utils.asBool(this.defaultValue())).toString());
     }
 
-    setType = (type: string) : void => {
+    setType = (type: Daliuge.DataType) : void => {
         this.type(type);
     }
 
@@ -665,7 +665,7 @@ export class Field {
         let name: string = "";
         let description: string = "";
         let readonly: boolean = false;
-        let type: string = Daliuge.DataType.Unknown;
+        let type: Daliuge.DataType = Daliuge.DataType.Unknown;
         let value: string = "";
         let defaultValue: string = "";
         let precious: boolean = false;
@@ -754,7 +754,7 @@ export class Field {
     static fromOJSJsonPort(data : any) : Field {
         let name: string = "";
         let event: boolean = false;
-        let type: string;
+        let type: Daliuge.DataType = Daliuge.DataType.Unknown;
         let description: string = "";
         let encoding: Daliuge.Encoding = Daliuge.Encoding.Pickle;
 

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -412,8 +412,7 @@ export class Modals {
         
         const isValid = (fileType === Eagle.FileType.Unknown) ||
             (fileType === Eagle.FileType.Graph && inputElement.val().toString().endsWith(".graph")) ||
-            (fileType === Eagle.FileType.Palette && inputElement.val().toString().endsWith(".palette")) ||
-            (fileType === Eagle.FileType.Daliuge && inputElement.val().toString().endsWith(".dlg"));
+            (fileType === Eagle.FileType.Palette && inputElement.val().toString().endsWith(".palette"));
 
         Modals._setValidClasses(inputElement, isValid);
     }

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -32,7 +32,7 @@ export class Repositories {
     static selectFile(file : RepositoryFile) : void {
         const eagle: Eagle = Eagle.getInstance();
 
-        if(file.type === Eagle.FileType.Graph || file.type === Eagle.FileType.JSON || file.type === Eagle.FileType.Daliuge){
+        if(file.type === Eagle.FileType.Graph || file.type === Eagle.FileType.JSON){
             eagle.showEagleIsLoading()
         }
 
@@ -48,9 +48,6 @@ export class Repositories {
                 break;
             }
             case Eagle.FileType.JSON:
-                isModified = eagle.logicalGraph().fileInfo().modified;
-                break;
-            case Eagle.FileType.Daliuge:
                 isModified = eagle.logicalGraph().fileInfo().modified;
                 break;
         }

--- a/src/RepositoryFile.ts
+++ b/src/RepositoryFile.ts
@@ -30,8 +30,6 @@ export class RepositoryFile {
                 return "palette";
             case Eagle.FileType.JSON:
                 return "language";
-            case Eagle.FileType.Daliuge:
-                return "construction"; // TODO: better icon
             default:
                 return this.type;
         }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -161,18 +161,16 @@ export class Utils {
     // NOTE: used for sorting files by filetype
     static getFileTypeNum(fileType: Eagle.FileType) : number {
         switch (fileType){
-            case Eagle.FileType.Daliuge:
-                return 0;
             case Eagle.FileType.Palette:
-                return 1;
+                return 0;
             case Eagle.FileType.Graph:
-                return 2;
+                return 1;
             case Eagle.FileType.JSON:
-                return 3;
+                return 2;
             case Eagle.FileType.Markdown:
-                return 4;
+                return 3;
             case Eagle.FileType.Unknown:
-                return 5;
+                return 4;
         }
     }
 
@@ -240,8 +238,6 @@ export class Utils {
             return "graph";
         } else if (fileType == Eagle.FileType.Palette) {
             return "palette";
-        } else if (fileType === Eagle.FileType.Daliuge) {
-            return "dlg";
         } else {
             console.error("Utils.getDiagramExtension() : Unknown file type! (" + fileType + ")");
             return "";
@@ -263,9 +259,6 @@ export class Utils {
         }
         if (fileType.toLowerCase() === "json"){
             return Eagle.FileType.JSON;
-        }
-        if (fileType.toLowerCase() === "daliuge" || fileType.toLowerCase() === "dlg"){
-            return Eagle.FileType.Daliuge;
         }
 
         return Eagle.FileType.Unknown;
@@ -1543,10 +1536,6 @@ export class Utils {
                         break;
                     case Eagle.FileType.Palette:
                         valid = ajv.validate(Utils.ojsPaletteSchema, json) as boolean;
-                        break;
-                    case Eagle.FileType.Daliuge:
-                        // TODO: more here for the other parts of the Daliuge file, or a new schema for the whole thing
-                        valid = ajv.validate(Utils.ojsGraphSchema, json.graph) as boolean;
                         break;
                     default:
                         console.warn("Unknown fileType:", fileType, "version:", version, "Unable to validate JSON");

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1647,7 +1647,6 @@ export class Utils {
         return distance;
     }
 
-
     static async userChoosePalette(paletteNames : string[]) : Promise<string> {
         return new Promise<string>((resolve, reject) => {
 
@@ -1895,7 +1894,7 @@ export class Utils {
         }
 
         // fix for redundant 'Complex' type
-        if (field.getType() === 'Complex'){
+        if (field.getType().toString() === 'Complex'){
             field.setType(Daliuge.DataType.Object);
             return;
         }
@@ -1905,7 +1904,7 @@ export class Utils {
             return;
         }
 
-        field.setType(Daliuge.DataType.Object + "." + field.getType());
+        field.setType((Daliuge.DataType.Object + "." + field.getType()) as Daliuge.DataType);
     }
 
     static fixFieldNodeId(eagle: Eagle, node: Node, field: Field){


### PR DESCRIPTION
This filetype was added back when we were considering having a completely new file type to include the GraphConfigs. A "daliuge" file.
In the end, we just placed the graph configs inside the LogicalGraph, removing the need for a new file type.

Also, changed the "type" attribute on the Field class from a string to a Daliuge.DataType. This is a little unusual, since the "type" for a field can be anything. "MeasurementSet" or "Object.Observation" etc. It doesn't just have to be a known value within the Enum. But typescript allows you to give arbitrary values to Enums, so it is not an issue in practice. And it does have some advantages in code completion/typing.

## Summary by Sourcery

Enhancements:
- Change the 'type' attribute on the Field class from a string to a Daliuge.DataType for improved code completion and typing.