### PR TITLE
only showing the encoding tab in the parameter table when looking at …

### DIFF
--- a/templates/parameter_table.html
+++ b/templates/parameter_table.html
@@ -158,7 +158,7 @@
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
                                         <th id="parameter_table_usage" data-bind="eagleTooltip:'InputPorts and OutputPorts are used to specify named inputs and outputs from this Component.'" data-bs-placement="top">Use As</th>
                                         <!-- /ko -->
-                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
+                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode().isApplication()-->
                                         <th id="parameter_table_encoding" data-bind="eagleTooltip:'The way data is encoded when passing through this port.'" data-bs-placement="top">Encoding</th>
                                         <!-- /ko -->
                                         <!-- ko if: ParameterTable.getActiveColumnVisibility().actions() -->
@@ -432,7 +432,7 @@
                                                 </td>
                                                 <!-- /ko -->
 
-                                                <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() -->
+                                                <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode().isApplication() -->
                                                 <td class='columnCell column_Encoding'>
                                                     <!-- ko if: $data.usage() === Daliuge.FieldUsage.NoPort-->
                                                     <span class="faded">N/A</span>


### PR DESCRIPTION
…a application node

## Summary by Sourcery

Bug Fixes:
- Ensure the encoding tab in the parameter table is only displayed when viewing an application node.