### PR TITLE
Eagle 1345

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2144,6 +2144,7 @@ export class Utils {
     }
 
     static showField(eagle: Eagle, nodeId: NodeId, field: Field) :void {
+        console.log('request show field')
         this.showNode(eagle, nodeId)
         setTimeout(function(){
             const node = eagle.selectedNode()

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2144,7 +2144,6 @@ export class Utils {
     }
 
     static showField(eagle: Eagle, nodeId: NodeId, field: Field) :void {
-        console.log('request show field')
         this.showNode(eagle, nodeId)
         setTimeout(function(){
             const node = eagle.selectedNode()

--- a/static/tables.css
+++ b/static/tables.css
@@ -93,7 +93,7 @@ td:first-child input {
     border:solid 1px #000c1a;
     border-radius: 6px;
     position: absolute;
-    z-index: 100;
+    z-index: 120;
     background-color: #0059a5;
 }
 
@@ -210,6 +210,14 @@ td:first-child input {
 
 #parameterTable .tableBody{
     padding: 0px;
+}
+
+#parameterTable .column_NodeName input{
+    pointer-events: none;
+}
+
+#parameterTable .configFieldsTable .column_DisplayText input{
+    pointer-events: none;
 }
 
 .eagleTableWrapper{

--- a/templates/parameter_table.html
+++ b/templates/parameter_table.html
@@ -84,7 +84,7 @@
                         <input id="tableInspectorValue" type="text" placeholder="Content" data-bind="value: ParameterTable.formatTableInspectorValue(), readonly: ParameterTable.selectionReadonly(), event: {keyup: ParameterTable.tableInspectorUpdateSelection($element.value)}">
                     </div>
                     <div class="scrollWrapper">
-                        <table class="eagleTableWrapper" id="paramsTableWrapper">
+                        <table class="eagleTableWrapper" id="paramsTableWrapper" data-bind="css: {configFieldsTable: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphConfigAttributesTable}">
                             <thead>
                                 <tr>
                                     <!-- ko if: ParameterTable.getActiveColumnVisibility().keyAttribute() -->
@@ -177,12 +177,12 @@
                                             </td>
                                             <!-- /ko -->
                                             <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphConfigAttributesTable -->
-                                                <td class='columnCell column_NodeName'>
+                                                <td class='columnCell column_NodeName' data-bind="click: function(){Utils.showField($root, nodeId(), $data)}">
                                                     <input class="tableParameter" type="string" data-bind="value: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getName(), disabled: true, eagleTooltip: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getDescription()">
                                                 </td>
                                             <!-- /ko -->
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
-                                                <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description">
+                                                <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description, click: function(){Utils.showField($root, nodeId(), $data)}">
                                                     <input class="tableParameter selectionTargets tableFieldDisplayName" placeholder="New Parameter" type="string" data-bind="value: displayText, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')} ,keyup: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}}">
                                                     
                                                     <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.ParameterTable && Eagle.selectedLocation() === Eagle.FileType.Graph -->
@@ -201,7 +201,7 @@
                                             <!-- /ko -->
                                             <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.ParameterTable -->
                                                 <!-- ko if: ParameterTable.getActiveColumnVisibility().fieldId() -->
-                                                    <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('fieldId', $data) },eagleTooltip:id">
+                                                    <td class='columnCell column_FieldId' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('fieldId', $data) },eagleTooltip:id">
                                                         <input class="tableParameter selectionTargets tableFieldFieldId" type="string" disabled data-bind="value: id, valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.fieldId(), 'fieldId', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')}, keyup: function(event, data){ParameterTable.select($data.fieldId(), 'fieldId', $data, $index())}}">
                                                     </td>
                                                 <!-- /ko -->


### PR DESCRIPTION
can now click on the node name or the field name in the graph config fields table to select and view that field in the node fields table directly.
some additional small fixes

## Summary by Sourcery

Enable direct selection and viewing of fields in the node fields table by clicking on node or field names in the graph config fields table. Enhance UI layering by adjusting z-index values.

New Features:
- Enable clicking on node names and field names in the graph config fields table to directly select and view them in the node fields table.

Enhancements:
- Increase the z-index of certain elements to improve layering and visibility.