### PR TITLE
small css change

### DIFF
--- a/static/tables.css
+++ b/static/tables.css
@@ -340,6 +340,7 @@ td:first-child input {
     width: 100%;
     height: 100%;
     color: white;
+    outline: none;
 }
 
 .issuesDisplay  .text-center, .eagleTableDisplay .text-center{


### PR DESCRIPTION
to prevent the whole bottom window mode becoming focused

## Summary by Sourcery

Enhancements:
- Remove focus outline from table cell inputs to prevent the entire bottom window mode from becoming focused.