### PR TITLE
changed a validity test from error to fixable

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -311,7 +311,7 @@ export class Edge {
 
         // check that we are not connecting an Application component to an Application component, that is not supported
         if (sourceNode.getCategoryType() === Category.Type.Application && destinationNode.getCategoryType() === Category.Type.Application){
-            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Error, Errors.Show("Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Fixable, Errors.Show("Inserted Data node as Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // if source node or destination node is a construct, then something is wrong, constructs should not have ports


### PR DESCRIPTION
when connecting application nodes to other application nodes we were showing an error message, even though we automatically fix this by inserting a data node. ive changed the validity to fixable and edited the message slightly

## Summary by Sourcery

Bug Fixes:
- Change the validity check from an error to a fixable state when connecting application nodes to other application nodes.