### PR TITLE
Eagle 1267

### DIFF
--- a/src/bindingHandlers/eagleTooltip.ts
+++ b/src/bindingHandlers/eagleTooltip.ts
@@ -58,6 +58,7 @@ ko.bindingHandlers.eagleTooltip = {
                 html=html.content
             }
 
+            // when surrounding text in a tooltip with |||, that section will be excluded from the markdown conversion. 
             if(html.includes('|||')){
                 const x = html.split('|||')
                 for(let i = 0 ; i < x.length ; i++){

--- a/static/components/repository-file.html
+++ b/static/components/repository-file.html
@@ -10,7 +10,7 @@
             <!-- /ko -->
         </div>
         <div class="col col-9">
-            <a href="#" data-bind="click: Repositories.selectFile, attr: {id: htmlId}, eagleTooltip: $data.name" data-bs-placement="left">
+            <a href="#" data-bind="click: Repositories.selectFile, attr: {id: htmlId}, eagleTooltip: '|||' + $data.name + '|||'" data-bs-placement="left">
                 <span data-bind="text: $data.name"></span>
             </a>
         </div>

--- a/static/components/repository.html
+++ b/static/components/repository.html
@@ -20,7 +20,7 @@
             <!-- /ko -->
         </div>
         <div class="col-10 col">
-            <a href="" data-bind="attr: {id: htmlId}, click: select, eagleTooltip: name + ' (' + branch + ')'" data-bs-placement="left">
+            <a href="" data-bind="attr: {id: htmlId}, click: select, eagleTooltip: '|||' +  name + ' (' + branch + ') |||'" data-bs-placement="left">
                 <span data-bind="text: name + ' (' + branch + ')'"></span>
             </a>
         </div>


### PR DESCRIPTION
## Summary by Sourcery

Enhance the tooltip functionality by allowing certain text to be excluded from markdown conversion using '|||', and update relevant HTML components to utilize this new format.

Enhancements:
- Modify tooltip binding to exclude certain text from markdown conversion by surrounding it with '|||'.
- Update HTML components to use the new tooltip format for file and repository links.