### PR TITLE
EAGLE-1350: Error "Active Graph Config Id (null) does not match a known graph config" should not be an error

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -139,13 +139,7 @@ export class LogicalGraph {
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += "{\n";
         result += '"modelData": ' + JSON.stringify(json.modelData, null, EagleConfig.JSON_INDENT) + ",\n";
-
-        // write either null or a string
-        if (json.activeGraphConfigId === null){
-            result += '"activeGraphConfigId": null,\n';
-        } else {
-            result += '"activeGraphConfigId": "' + json.activeGraphConfigId + '",\n';
-        }
+        result += '"activeGraphConfigId": ' + JSON.stringify(json.activeGraphConfigId) + ',\n';
 
         // if we are sending this graph for translation, then only provide the "active" graph configuration, or an empty array if none exist
         // otherwise, add all graph configurations

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -139,7 +139,13 @@ export class LogicalGraph {
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += "{\n";
         result += '"modelData": ' + JSON.stringify(json.modelData, null, EagleConfig.JSON_INDENT) + ",\n";
-        result += '"activeGraphConfigId": "' + json.activeGraphConfigId + '",\n';
+
+        // write either null or a string
+        if (json.activeGraphConfigId === null){
+            result += '"activeGraphConfigId": null,\n';
+        } else {
+            result += '"activeGraphConfigId": "' + json.activeGraphConfigId + '",\n';
+        }
 
         // if we are sending this graph for translation, then only provide the "active" graph configuration, or an empty array if none exist
         // otherwise, add all graph configurations


### PR DESCRIPTION
Fixed bug where activeGraphConfigId is null, but was written as 'null' (a string) into the output JSON

## Summary by Sourcery

Bug Fixes:
- Fix the bug where 'activeGraphConfigId' was incorrectly serialized as the string 'null' instead of a JSON null value.