### PR TITLE
EAGLE-1352: New GraphConfig, created by "favourite"-ing a field, has null id

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1490,10 +1490,7 @@ export class Eagle {
      */
 
     newConfig = () : void => {
-        // clone existing active config, assign new id
-        const c: GraphConfig = new GraphConfig
-        c.setId(Utils.generateGraphConfigId());
-        
+        const c: GraphConfig = new GraphConfig();
         c.setName('newConfig');
 
         // adding a new graph config to the array, then setting it as active

--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -19,7 +19,7 @@ export class GraphConfig {
     private lastModifiedDatetime : ko.Observable<number>;
     
     constructor(){
-        this.id = ko.observable(null);
+        this.id = ko.observable(Utils.generateGraphConfigId());
         this.name = ko.observable("");
         this.description = ko.observable("");
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -381,6 +381,7 @@ export class ParameterTable {
             }
         } else {
             graphConfig = new GraphConfig()
+
             Utils.requestUserString("New Configuration", "Enter a name for the new configuration", Utils.generateGraphConfigName(graphConfig), false, (completed : boolean, userString : string) : void => {
                 ParameterTable.openTable(Eagle.BottomWindowMode.ParameterTable, ParameterTable.SelectType.Normal);
 
@@ -392,7 +393,8 @@ export class ParameterTable {
                     return;
                 }
 
-                // set name and set modified flag
+                // set id and name
+                graphConfig.setId(Utils.generateGraphConfigId());
                 graphConfig.setName(userString);
 
                 // add/remove the field that was requested in the first place

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -380,8 +380,7 @@ export class ParameterTable {
                 graphConfig.removeField(currentField);
             }
         } else {
-            graphConfig = new GraphConfig()
-
+            graphConfig = new GraphConfig();
             Utils.requestUserString("New Configuration", "Enter a name for the new configuration", Utils.generateGraphConfigName(graphConfig), false, (completed : boolean, userString : string) : void => {
                 ParameterTable.openTable(Eagle.BottomWindowMode.ParameterTable, ParameterTable.SelectType.Normal);
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -393,8 +393,7 @@ export class ParameterTable {
                     return;
                 }
 
-                // set id and name
-                graphConfig.setId(Utils.generateGraphConfigId());
+                // set name
                 graphConfig.setName(userString);
 
                 // add/remove the field that was requested in the first place


### PR DESCRIPTION
Added generation of GraphConfig id to the GraphConfig constructor, so it's impossible to forget.
Removed some places in the code where the id was set manually.

## Summary by Sourcery

Generate GraphConfig id in the constructor to prevent null ids and remove manual id assignments.

Bug Fixes:
- Ensure GraphConfig instances have a non-null id by generating the id in the constructor.

Enhancements:
- Remove manual id setting for GraphConfig instances throughout the codebase.