### PR TITLE
EAGLE-1347: Removed the htmlElementLog, that was used a long time ago for debugging

### DIFF
--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -154,9 +154,6 @@ export class GitHub {
 
                 const fileNames : string[] = data[""];
 
-                // debug
-                Utils.addToHTMLElementLog("fileNames:" + fileNames);
-
                 // sort the fileNames
                 fileNames.sort(Repository.fileSortFunc);
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -441,11 +441,6 @@ export class Utils {
         $('#messageModalTitle').text(title);
         $('#messageModalMessage').html(message);
         $('#messageModal').modal("toggle");
-
-        // debug
-        if (title === "Error"){
-            Utils.addToHTMLElementLog(title + ":" + message);
-        }
     }
 
     static showErrorsModal(title: string){
@@ -479,10 +474,6 @@ export class Utils {
             } /*,
             delay:0 */
         });
-    }
-
-    static addToHTMLElementLog(message: string) : void {
-        $('#htmlElementLog').text($('#htmlElementLog').text() + message + "\n");
     }
 
     static requestUserString(title : string, message : string, defaultString: string, isPassword: boolean, callback : (completed : boolean, userString : string) => void ) : void {

--- a/templates/base.html
+++ b/templates/base.html
@@ -261,7 +261,5 @@
                 </div>
             </div>
         </div>
-
-        <div id="htmlElementLog" style="display: none;"></div>
     </body>
 </html>

--- a/tests/load-graph.js
+++ b/tests/load-graph.js
@@ -23,10 +23,6 @@ test('Load graph', async t => {
         .wait(12000);
 
     await t
-        const log = await Selector("#htmlElementLog").innerText;
-        console.log("log:", log);
-
-    await t
         .click('#id_Vitaliy_long_graph')
         .wait(2000)
 
@@ -49,10 +45,6 @@ test('Load palette', async t => {
 
         .click('#ICRAR_EAGLE_test_repo')
         .wait(12000);
-
-    await t
-        const log = await Selector("#htmlElementLog").innerText;
-        console.log("log2:", log);
 
     await t
         .click('#id_HelloWorld_palette')


### PR DESCRIPTION
## Summary by Sourcery

Remove the deprecated 'htmlElementLog' feature and its associated code from the project, including related test code and HTML elements.

Enhancements:
- Remove obsolete debugging feature 'htmlElementLog' from the codebase.

Tests:
- Remove test code related to 'htmlElementLog' from the test suite.