### PR TITLE
EAGLE-1292: Add local "Save As..." to Graph and Palette menus

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1538,7 +1538,7 @@ export class Eagle {
             const fileType = this.logicalGraph().fileInfo().type;
 
             if (userChoiceIndex === 0){
-                this.saveFileToLocal(fileType);
+                this.saveAsFileToLocal(fileType);
             } else {
                 this.commitToGitAs(fileType);
             }
@@ -1569,6 +1569,35 @@ export class Eagle {
                 }
 
                 this.savePaletteToDisk(destinationPalette);
+                break;
+            }
+            default:
+                Utils.showUserMessage("Not implemented", "Not sure which fileType is the right one to save locally :" + fileType);
+                break;
+        }
+    }
+
+    saveAsFileToLocal = async (fileType: Eagle.FileType): Promise<void> => {
+        switch (fileType){
+            case Eagle.FileType.Graph:
+                this.saveAsFileToDisk(this.logicalGraph());
+                break;
+            case Eagle.FileType.Palette: {
+                // build a list of palette names
+                const paletteNames: string[] = this.buildReadablePaletteNamesList();
+
+                // ask user to select the palette
+                const paletteName = await Utils.userChoosePalette(paletteNames);
+
+                // get reference to palette (based on paletteName)
+                const destinationPalette = this.findPalette(paletteName, false);
+
+                // check that a palette was found
+                if (destinationPalette === null){
+                    return;
+                }
+
+                this.saveAsFileToDisk(destinationPalette);
                 break;
             }
             default:
@@ -2412,7 +2441,7 @@ export class Eagle {
             return;
         }
 
-        // generate filename if necessary
+        // abort if graph has no filename
         if (graph.fileInfo().name === "") {
             // abort and notify user
             Utils.showNotification("Unable to save Graph with no name", "Please name the graph before saving", "danger");
@@ -2452,6 +2481,30 @@ export class Eagle {
             graph.fileInfo().commitHash = "";
             graph.fileInfo().downloadUrl = "";
             graph.fileInfo.valueHasMutated();
+        });
+    }
+
+    saveAsFileToDisk = (file: LogicalGraph | Palette): void => {
+        console.log("saveAsFileToDisk()");
+
+        // check that file
+
+        Utils.requestUserString("Save As", "Please enter a filename for the " + file.fileInfo().type, file.fileInfo().name, false, (completed: boolean, userString: string) => {
+            // abort if incomplete
+            if (!completed){
+                console.log("User aborted saveAs");
+            }
+
+            file.fileInfo().name = userString;
+
+            switch(file.fileInfo().type){
+                case Eagle.FileType.Graph:
+                    this.saveGraphToDisk(file as LogicalGraph);
+                    break;
+                case Eagle.FileType.Palette:
+                    this.savePaletteToDisk(file as Palette);
+                    break;
+            }
         });
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2489,6 +2489,7 @@ export class Eagle {
             // abort if incomplete
             if (!completed){
                 console.log("User aborted saveAs");
+                return;
             }
 
             file.fileInfo().name = userString;
@@ -2502,6 +2503,7 @@ export class Eagle {
                     break;
                 default:
                     console.warn("saveAsFileToDisk(): fileType", file.fileInfo().type, "not implemented, aborting.");
+                    Utils.showUserMessage("Error", "Unable to save file: file type '" + file.fileInfo().type + "' is not supported.");
             }
         });
     }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2485,10 +2485,6 @@ export class Eagle {
     }
 
     saveAsFileToDisk = (file: LogicalGraph | Palette): void => {
-        console.log("saveAsFileToDisk()");
-
-        // check that file
-
         Utils.requestUserString("Save As", "Please enter a filename for the " + file.fileInfo().type, file.fileInfo().name, false, (completed: boolean, userString: string) => {
             // abort if incomplete
             if (!completed){
@@ -2504,6 +2500,8 @@ export class Eagle {
                 case Eagle.FileType.Palette:
                     this.savePaletteToDisk(file as Palette);
                     break;
+                default:
+                    console.warn("saveAsFileToDisk(): fileType", file.fileInfo().type, "not implemented, aborting.");
             }
         });
     }

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -121,6 +121,7 @@
                         <span class="dropdown-item dropDropDownParent" href="#">Local Storage<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                             <div class="dropDropDown">
                                 <a class="dropdown-item" id="saveGraph" href="#" data-bind="click: function(){saveFileToLocal(Eagle.FileType.Graph)}">Save</a>
+                                <a class="dropdown-item" id="saveAsGraph" href="#" data-bind="click: function(){saveAsFileToLocal(Eagle.FileType.Graph)}">Save As</a>
                                 <a class="dropdown-item" id="loadGraph" href="#" data-bind="click: getGraphFileToLoad">Load
                                     <span data-bind="text: KeyboardShortcut.idToText('open_graph_from_local_disk', true)"></span>
                                 </a>
@@ -166,6 +167,7 @@
                     <span class="dropdown-item dropDropDownParent" href="#">Local Storage<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
                             <a class="dropdown-item" id="savePalette" href="#" data-bind="click: function(){saveFileToLocal(Eagle.FileType.Palette)}">Save</a>
+                            <a class="dropdown-item" id="saveAsPalette" href="#" data-bind="click: function(){saveAsFileToLocal(Eagle.FileType.Palette)}">Save As</a>
                             <a class="dropdown-item" id="loadPalette" href="#" data-bind="click: getPaletteFileToLoad">Load
                                 <span data-bind="text: KeyboardShortcut.idToText('open_palette_from_local_disk', true)"></span>
                             </a>


### PR DESCRIPTION
Added "Save As" items to the Graph and Palette menus in the navbar.

These items first request a filename from the user, then save the file as usual.

## Summary by Sourcery

New Features:
- Add 'Save As' functionality to the Graph and Palette menus, allowing users to specify a filename before saving.