### PR TITLE
EAGLE-1310: Allow users to change node's category, even when the built-in palettes are not loaded

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4584,53 +4584,16 @@ export class Eagle {
             Utils.showNotification(Palette.BUILTIN_PALETTE_NAME + " palette not found", "Unable to transform node according to a template. Instead just changing category.", "warning");
         } else {
             // find node with new type in builtinPalette
-            const oldCategoryPrototype: Node = builtinPalette.findNodeByNameAndCategory(oldNode.getCategory());
-            const newCategoryPrototype: Node = builtinPalette.findNodeByNameAndCategory(newNodeCategory);
+            const oldCategoryTemplate: Node = builtinPalette.findNodeByNameAndCategory(oldNode.getCategory());
+            const newCategoryTemplate: Node = builtinPalette.findNodeByNameAndCategory(newNodeCategory);
 
             // check that prototypes were found for old category and new category
-            if (oldCategoryPrototype === null || newCategoryPrototype === null){
-                console.warn("Prototypes for old and new categories could not be found in palettes", oldCategoryPrototype, newCategoryPrototype);
+            if (oldCategoryTemplate === null || newCategoryTemplate === null){
+                console.warn("Prototypes for old and/or new categories could not be found in palettes", oldNode.getCategory(), newNodeCategory);
                 return;
             }
 
-            // delete non-ports from the old node (loop backwards since we are deleting from the array as we loop)
-            for (let i = oldNode.getFields().length - 1 ; i >= 0; i--){
-                const field: Field = oldNode.getFields()[i];
-
-                if (field.isInputPort() || field.isOutputPort()){
-                    continue;
-                }
-
-                oldNode.removeFieldById(field.getId());
-            }
-
-            // copy non-ports from new category to old node
-            for (const field of newCategoryPrototype.getFields()){
-                if (field.isInputPort() || field.isOutputPort()){
-                    continue;
-                }
-
-                // try to find field in old node that matches by displayText AND parameterType
-                let destField = oldNode.findFieldByDisplayText(field.getDisplayText(), field.getParameterType());
-
-                // if dest field could not be found, then go ahead and add a NEW field to the dest node
-                if (destField === null){
-                    destField = field.clone();
-                    oldNode.addField(destField);
-                }
-            
-                // copy everything about the field from the src (palette), except maintain the existing id and nodeKey
-                destField.copyWithIds(field, destField.getNodeId(), destField.getId());
-            }
-
-            // copy name and description from new category to old node, if old node values are defaults
-            if (oldNode.getName() === oldCategoryPrototype.getName()){
-                oldNode.setName(newCategoryPrototype.getName());
-            }
-
-            if (oldNode.getDescription() === oldCategoryPrototype.getDescription()){
-                oldNode.setDescription(newCategoryPrototype.getDescription());
-            }
+            Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate);
         }
 
         oldNode.setCategory(newNodeCategory);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2546,4 +2546,45 @@ export class Utils {
             return config.getName() + " (Copy)";
         }
     }
+
+    static transformNodeFromTemplates(node: Node, sourceTemplate: Node, destinationTemplate: Node): void {
+        // delete non-ports from the node (loop backwards since we are deleting from the array as we loop)
+        for (let i = node.getFields().length - 1 ; i >= 0; i--){
+            const field: Field = node.getFields()[i];
+
+            if (field.isInputPort() || field.isOutputPort()){
+                continue;
+            }
+
+            node.removeFieldById(field.getId());
+        }
+
+        // copy non-ports from new template to node
+        for (const field of destinationTemplate.getFields()){
+            if (field.isInputPort() || field.isOutputPort()){
+                continue;
+            }
+
+            // try to find field in node that matches by displayText AND parameterType
+            let destField = node.findFieldByDisplayText(field.getDisplayText(), field.getParameterType());
+
+            // if dest field could not be found, then go ahead and add a NEW field to the node
+            if (destField === null){
+                destField = field.clone();
+                node.addField(destField);
+            }
+
+            // copy everything about the field from the src (palette), except maintain the existing id and nodeKey
+            destField.copyWithIds(field, destField.getNodeId(), destField.getId());
+        }
+
+        // copy name and description from new template to node, if node values are defaults
+        if (node.getName() === sourceTemplate.getName()){
+            node.setName(destinationTemplate.getName());
+        }
+
+        if (node.getDescription() === sourceTemplate.getDescription()){
+            node.setDescription(destinationTemplate.getDescription());
+        }
+    }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1084,14 +1084,15 @@ export class Utils {
         return result;
     }
 
-    static getCategoriesWithInputsAndOutputs(categoryType: Category.Type, numRequiredInputs: number, numRequiredOutputs: number) : Category[] {
+    static getCategoriesWithInputsAndOutputs(categoryType: Category.Type) : Category[] {
         const eagle = Eagle.getInstance();
 
         // get a reference to the builtin palette
         const builtinPalette: Palette = eagle.findPalette(Palette.BUILTIN_PALETTE_NAME, false);
         if (builtinPalette === null){
+            // if no built-in palette is found, then build a list from the EAGLE categoryData
             console.warn("Could not find builtin palette", Palette.BUILTIN_PALETTE_NAME);
-            return null;
+            return Utils.buildComponentList((cData: Category.CategoryData) => {return cData.categoryType === categoryType});
         }
 
         const matchingNodes = builtinPalette.getNodesByCategoryType(categoryType)


### PR DESCRIPTION
When the built-in palettes are not loaded. Either because the user has turned off the "Open Default Palette on Startup" setting, or because the user is offline. Previously, a list of categories to change to, could not be built.

Now as a fallback, we build the list of categories from the data in CategoryData.cData

We're unable to add/remove fields to match the template in the built-in palette, but at least it allows users' to change categories.

To test:
- with built-in palettes loaded
- create a File node
- change the category of the node to "S3"  using the drop-down box in the graph inspector
- observe that a number of fields are added to the node
- turn off the "Open Default Palette on Startup" setting
- reload EAGLE
- observe that the built-in palettes were not loaded
- create a File node
- change category to "S3"
- observe that the category does change, but that no fields are added to the node

## Summary by Sourcery

Enable users to change a node's category without relying on built-in palettes by using CategoryData.cData as a fallback. Enhance the logic for determining eligible node categories when no node is selected.

New Features:
- Allow users to change a node's category even when the built-in palettes are not loaded by using data from CategoryData.cData as a fallback.

Enhancements:
- Improve the logic for determining eligible node categories by handling cases where the selected node is null.