### PR TITLE
fixed positioning of nodes using getnewnodeposition function

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4290,7 +4290,8 @@ export class Eagle {
             let minX = Setting.findValue(Setting.LEFT_WINDOW_VISIBLE) ? this.leftWindow().size()+MARGIN: 0+MARGIN;
             let maxX = Setting.findValue(Setting.RIGHT_WINDOW_VISIBLE) ? $('#logicalGraphParent').width() - this.rightWindow().size() - MARGIN : $('#logicalGraphParent').width() - MARGIN;
             let minY = 0 + navBarHeight + MARGIN;
-            let maxY = $('#logicalGraphParent').height() - MARGIN + navBarHeight;
+            //using jquery here to get the bottom window height because it is internally saved in VH (percentage screen height). Doing it this way means we dont have to convert it to pixels
+            let maxY = $('#logicalGraphParent').height() - $('#bottomWindow').height() - MARGIN + navBarHeight;
             if(increaseSearchArea){
                 minX = minX - 300
                 maxX = maxX + 300


### PR DESCRIPTION
it will now take the bottom window height into account

## Summary by Sourcery

Bug Fixes:
- Fix node positioning by accounting for the bottom window height in the getNewNodePosition function.