### PR TITLE
Eagle 1265

### DIFF
--- a/src/Hierarchy.ts
+++ b/src/Hierarchy.ts
@@ -7,7 +7,7 @@ import { Node } from './Node';
 export class Hierarchy {
 
     static updateDisplay() : void {
-        const eagle: Eagle = Eagle.getInstance()
+        const eagle: Eagle = Eagle.getInstance();
 
         $("#hierarchyEdgesSvg").empty()
         

--- a/src/Hierarchy.ts
+++ b/src/Hierarchy.ts
@@ -7,7 +7,7 @@ import { Node } from './Node';
 export class Hierarchy {
 
     static updateDisplay() : void {
-        const eagle: Eagle = Eagle.getInstance();
+        const eagle: Eagle = Eagle.getInstance()
 
         $("#hierarchyEdgesSvg").empty()
         
@@ -168,7 +168,6 @@ export class Hierarchy {
 
         // check that HTML elements for the src and dest node already exist, otherwise we can't draw this edge, so abort
         if (typeof srcNodeElement === 'undefined' || typeof destNodeElement === 'undefined'){
-            console.warn("Hierarchy.drawEdge() srcNode (" + srcId + ") or destNode (" + destId + ") element not ready");
             return;
         }
 

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -28,6 +28,7 @@ import {Eagle} from './Eagle';
 import {LogicalGraph} from './LogicalGraph';
 import {Setting} from './Setting';
 import {Utils} from './Utils';
+import { Hierarchy } from "./Hierarchy";
 
 
 class Snapshot {
@@ -126,6 +127,11 @@ export class Undo {
         eagle.checkGraph();
 
         this._updateSelection();
+
+        //we need to update the hierarchy view. this needs a small timeout to wait for the undo to complete
+        setTimeout(function(){
+            Hierarchy.updateDisplay()
+        },100)
     }
 
     nextSnapshot = (eagle: Eagle) : void => {
@@ -144,7 +150,11 @@ export class Undo {
 
         eagle.checkGraph();
 
+        //we need to update the hierarchy view. this needs a small timeout to wait for the undo to complete
         this._updateSelection();
+        setTimeout(function(){
+            Hierarchy.updateDisplay()
+        },100)
     }
 
     toString = () : string => {

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -150,8 +150,9 @@ export class Undo {
 
         eagle.checkGraph();
 
-        //we need to update the hierarchy view. this needs a small timeout to wait for the undo to complete
         this._updateSelection();
+
+        //we need to update the hierarchy view. this needs a small timeout to wait for the undo to complete
         setTimeout(function(){
             Hierarchy.updateDisplay()
         },100)


### PR DESCRIPTION
fixing a bug where undoing the deletion of an edge while having a connected node selected would result in the edge being re-added to the graph, but the hierarchy didnt update to show it. now it does.

## Summary by Sourcery

Fix the hierarchy update issue when undoing edge deletions and remove an unnecessary console warning in the hierarchy drawing logic.

Bug Fixes:
- Fix the bug where undoing the deletion of an edge with a connected node selected did not update the hierarchy to show the re-added edge.

Enhancements:
- Remove unnecessary console warning in Hierarchy.drawEdge when source or destination node elements are not ready.