### PR TITLE
Eagle 1357

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1074,7 +1074,7 @@ export class GraphRenderer {
         }else{
             if(event.shiftKey && event.button === 0){
                 //initiating drag selection region handler
-                GraphRenderer.initiageDragSelection()
+                GraphRenderer.initiateDragSelection()
             }else{
                 //if node is null, the empty canvas has been clicked. clear the selection
                 eagle.setSelection(null, Eagle.FileType.Graph);
@@ -1187,7 +1187,7 @@ export class GraphRenderer {
         eagle.selectedObjects.valueHasMutated()
     }
 
-    static initiageDragSelection() : void {
+    static initiateDragSelection() : void {
         GraphRenderer.isDraggingSelectionRegion = true
         GraphRenderer.selectionRegionStart = {x:GraphRenderer.SCREEN_TO_GRAPH_POSITION_X(null),y:GraphRenderer.SCREEN_TO_GRAPH_POSITION_Y(null)}
         GraphRenderer.selectionRegionEnd = {x:GraphRenderer.SCREEN_TO_GRAPH_POSITION_X(null),y:GraphRenderer.SCREEN_TO_GRAPH_POSITION_Y(null)}
@@ -1266,11 +1266,9 @@ export class GraphRenderer {
         // keep track of whether we would update any node parents
         const allowGraphEditing = Setting.findValue(Setting.ALLOW_GRAPH_EDITING);
         //construct resizing 
-        if(outerMostNode.getParentId() != null){
-            if(oldParent.getRadius()>GraphRenderer.NodeParentRadiusPreDrag+EagleConfig.CONSTRUCT_DRAG_OUT_DISTANCE){
-                oldParent.setRadius(GraphRenderer.NodeParentRadiusPreDrag) //HERE
-                outerMostNode.setParentId(null)
-            }
+        if(outerMostNode.getParentId() != null && oldParent.getRadius()>GraphRenderer.NodeParentRadiusPreDrag+EagleConfig.CONSTRUCT_DRAG_OUT_DISTANCE){
+            oldParent.setRadius(GraphRenderer.NodeParentRadiusPreDrag) //HERE
+            outerMostNode.setParentId(null)
         }
 
         // check for nodes underneath the node we dropped

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1014,6 +1014,7 @@ export class GraphRenderer {
     }
 
     static startDrag(node: Node, event: MouseEvent) : void {
+        //if we click on the title of a node, cancel the drag handler
         if($(event.target).hasClass('changingHeader')){
             event.preventDefault()
             event.stopPropagation()

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1102,18 +1102,21 @@ export class GraphRenderer {
     static mouseMove(eagle: Eagle, event: JQuery.TriggeredEvent) : void {
         const e: MouseEvent = event.originalEvent as MouseEvent;
         GraphRenderer.ctrlDrag = event.ctrlKey;
-
         GraphRenderer.dragCurrentPosition = {x:e.pageX,y:e.pageY}
+
         if (eagle.isDragging()){
             if (eagle.draggingNode() !== null && !GraphRenderer.isDraggingSelectionRegion ){
+                //check and note if the mouse has moved
                 GraphRenderer.simpleSelect = GraphRenderer.dragStartPosition.x - e.movementX < 5 && GraphRenderer.dragStartPosition.y - e.movementY < 5
 
                 //creating an array that contains all of the outermost nodes in the selected array
                 const outermostNodes : Node[] = eagle.getOutermostSelectedNodes()
+                
+                //this is to prevent the de-parent transition effect, which we dont want in this case
+                $('.node.transition').removeClass('transition')
 
-                $('.node.transition').removeClass('transition') //this is to prevent the de-parent effect, which we dont want in this case
+                // move node if the mouse has moved during the drag event
                 if(!GraphRenderer.simpleSelect){
-                    // move node
                     eagle.selectedObjects().forEach(function(obj){
                         if(obj instanceof Node){
                             obj.changePosition(e.movementX/eagle.globalScale(), e.movementY/eagle.globalScale());
@@ -1121,10 +1124,13 @@ export class GraphRenderer {
                     })
                 }
 
+                //look for a construct at the current location that we would parent to
+                //the outermost node is the outermost construct for multiselection 
                 outermostNodes.forEach(function(outerMostNode){
                     GraphRenderer.lookForParent(outerMostNode)
                 })
             } else if(GraphRenderer.isDraggingSelectionRegion){
+                
                 //update selection region position then draw the rectangle
                 GraphRenderer.selectionRegionEnd = {x:GraphRenderer.SCREEN_TO_GRAPH_POSITION_X(null), y:GraphRenderer.SCREEN_TO_GRAPH_POSITION_Y(null)}
                 GraphRenderer.drawSelectionRectangle()

--- a/src/SideWindow.ts
+++ b/src/SideWindow.ts
@@ -50,12 +50,14 @@ export class SideWindow {
         $('#inspector').addClass('linearTransition250')
         $('.rightWindow').addClass('linearTransition250')
         $('.leftWindow').addClass('linearTransition250')
+        $('.bottomWindow').addClass('linearTransition250')
 
         setTimeout(function(){
             $('#statusBar').removeClass('linearTransition250')
             $('#inspector').removeClass('linearTransition250')
             $('.rightWindow').removeClass('linearTransition250')
             $('.leftWindow').removeClass('linearTransition250')
+            $('.bottomWindow').removeClass('linearTransition250')
         },300)
     }
 
@@ -204,13 +206,18 @@ export class SideWindow {
                 Utils.setRightWindowWidth(newSize);
             }
         }else if(eagle.bottomWindow().adjusting()){
+            //converting height values to VH (percentage of the browser window). this is to prevent issues when switching from a large to a smaller screen.
+            //we are only doing it for the bottom window, as it typically takes up a large part of the screen, causing it to become larger than the screen itself if switching from a 4k display to a smaller one.
             newSize = ((window.innerHeight - e.clientY)/window.innerHeight)*100
             //making sure the height we are setting is not smaller than the minimum height
             const minBottomWindowVh = (Setting.find(Setting.BOTTOM_WINDOW_HEIGHT).getPerpetualDefaultVal()/window.innerHeight)*100
+            const maxBottomWindowVh = 80
 
             if(newSize <= minBottomWindowVh){
                 eagle.bottomWindow().size(minBottomWindowVh);
                 Utils.setBottomWindowHeight(minBottomWindowVh);
+            }else if(newSize>maxBottomWindowVh){
+                Utils.setBottomWindowHeight(maxBottomWindowVh)
             }else{
                 eagle.bottomWindow().size(newSize);
                 Utils.setBottomWindowHeight(newSize);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1276,9 +1276,11 @@ export class Utils {
         UiModeSystem.saveToLocalStorage()
     }
 
-    static getBottomWindowHeight() : number {
+    static calculateBottomWindowHeight() : number {
+        //this function exists to prevent the bottom window height value from exceeding its max height value. 
         //if eagle isnt ready or the window is hidden just return 0
-        if(Eagle.getInstance().eagleIsReady() && !Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE)){
+        //TODO This function is only needed for the transition perdiod from pixels to vh. We can get rid of this in the future.
+        if(!Eagle.getInstance().eagleIsReady()){
             return 0
         }
 
@@ -1288,6 +1290,13 @@ export class Utils {
         }
 
         //else return the actual height
+        return Setting.findValue(Setting.BOTTOM_WINDOW_HEIGHT)
+    }
+
+    static getBottomWindowHeight() : number {
+        if(Eagle.getInstance().eagleIsReady() && !Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE)){
+            return 0
+        }
         return Setting.findValue(Setting.BOTTOM_WINDOW_HEIGHT)
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,7 +185,7 @@
                     <div class="rightWindowSizeAdjusterLine"></div>
                 </div>
             </div>
-            <div id="bottomWindow" data-bind="style: { 'visibility':eagle.getEagleIsReady(), height: Utils.getBottomWindowHeight()+'vh', bottom: Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE) ? 0 : -Utils.getBottomWindowHeight()+'vh'}">
+            <div id="bottomWindow" data-bind="style: { 'visibility':eagle.getEagleIsReady(), height: Utils.calculateBottomWindowHeight()+'vh', bottom: Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE) ? 0 : -Utils.calculateBottomWindowHeight()+'vh'}">
                 <div class="wrapper">
                     <div class="dragHandle" draggable="true" data-bind="event: { dragstart: SideWindow.bottomWindowAdjustStart, dragend: SideWindow.sideWindowAdjustEnd }"></div>
                     <div class="tabs">

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -1,5 +1,5 @@
 <!-- Message Modal -->
-<div class="modal fade" id="messageModal" tabindex="-1" role="dialog" aria-labelledby="messageModalTitle" aria-hidden="true">
+<div class="modal fade" id="messageModal" tabindex="-1" role="dialog" aria-labelledby="messageModalTitle">
     <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -17,7 +17,7 @@
 </div>
 
 <!-- Request User Input Modal -->
-<div class="modal fade" id="inputModal" tabindex="-1" role="dialog" aria-labelledby="inputModalTitle" aria-hidden="true">
+<div class="modal fade" id="inputModal" tabindex="-1" role="dialog" aria-labelledby="inputModalTitle">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
i found that this is because i was setting the height to 0 when hiding the window. for the other windows the height stays the same, but we slide the position of the window off screen by the same amount.

this also uncovered an issues with max height on the bottom window. The saved height could be large than the maximum height, and the getBottomWindowHeight function was correcting that by returning the max height value instead if this was the case. ive fixed this as well, the setBottomWindowHeight function will now check that the value does not exceed the maximum height value.

this additional function to get the bottom window height, with some logic in it, ive decided to keep for a while. it still makes sure that the saved height value does not exceed the maximum height. Since the set function now does this, its not really needed, except in one case. When switching from pixel height to percentage height, aka. from the old eagle live version to the next eagle live version. Ive marked this with a TODO, so we can get rid of this in the future when all users have migrated.

## Summary by Sourcery

Refactor the GraphRenderer class to improve drag selection handling and node parenting logic. Fix the bottom window height issue by ensuring it does not exceed the maximum height. Enhance the UI with smoother transitions for the bottom window. Update the bottom window height calculation to support transitioning from pixel to percentage-based heights.

Bug Fixes:
- Fix the issue where the bottom window height could exceed the maximum height by ensuring the setBottomWindowHeight function checks the value.

Enhancements:
- Refactor the drag selection region handling by introducing new methods to initiate and draw the selection rectangle, improving code readability and maintainability.
- Add linear transition effects to the bottom window for smoother UI transitions.