### PR TITLE
EAGLE-1355: Use the same pattern of ids for Repository and RepositoryFile objects

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -912,7 +912,7 @@ export class Eagle {
         const schemaVersion: Daliuge.SchemaVersion = Utils.determineSchemaVersion(dataObject);
 
         const errorsWarnings: Errors.ErrorsWarnings = {errors: [], warnings: []};
-        const dummyFile: RepositoryFile = new RepositoryFile(Repository.DUMMY, "", fileFullPath);
+        const dummyFile: RepositoryFile = new RepositoryFile(Repository.dummy(), "", fileFullPath);
 
         // check if we need to update the graph from keys to ids
         if (GraphUpdater.usesNodeKeys(dataObject)){
@@ -1234,7 +1234,7 @@ export class Eagle {
         }
 
         const errorsWarnings: Errors.ErrorsWarnings = {"errors":[], "warnings":[]};
-        const p : Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.DUMMY, "", Utils.getFileNameFromFullPath(fileFullPath)), errorsWarnings);
+        const p : Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.dummy(), "", Utils.getFileNameFromFullPath(fileFullPath)), errorsWarnings);
 
         // show errors (if found)
         this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Repository.Service.File);
@@ -1949,7 +1949,7 @@ export class Eagle {
                     // palette fetched successfully
                     complete[index] = true;
 
-                    const palette: Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.DUMMY, "", paletteList[index].name), errorsWarnings);
+                    const palette: Palette = Palette.fromOJSJson(data, new RepositoryFile(Repository.dummy(), "", paletteList[index].name), errorsWarnings);
                     Utils.preparePalette(palette, paletteList[index]);
 
                     // add to results
@@ -1974,7 +1974,7 @@ export class Eagle {
                     } else {
                         console.warn("Unable to fetch palette '" + paletteList[i].name + "'. Palette loaded from localStorage.");
 
-                        const palette: Palette = Palette.fromOJSJson(paletteData, new RepositoryFile(Repository.DUMMY, "", paletteList[i].name), errorsWarnings);
+                        const palette: Palette = Palette.fromOJSJson(paletteData, new RepositoryFile(Repository.dummy(), "", paletteList[i].name), errorsWarnings);
                         Utils.preparePalette(palette, paletteList[i]);
 
                         results[index] = palette;

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -1,14 +1,16 @@
 import * as ko from "knockout";
 
-import {RepositoryFolder} from './RepositoryFolder';
-import {RepositoryFile} from './RepositoryFile';
-import {Eagle} from './Eagle';
-import {Utils} from './Utils';
-import {GitHub} from './GitHub';
-import {GitLab} from "./GitLab";
+import { Branded } from "./main";
+import { Eagle } from './Eagle';
+import { GitHub } from './GitHub';
+import { GitLab } from "./GitLab";
+import { RepositoryFolder } from './RepositoryFolder';
+import { RepositoryFile } from './RepositoryFile';
+import { Utils } from './Utils';
+
 
 export class Repository {
-    _id : number
+    _id : Repository.Id
     name : string
     service : Repository.Service
     branch : string
@@ -19,11 +21,8 @@ export class Repository {
     files : ko.ObservableArray<RepositoryFile>
     folders : ko.ObservableArray<RepositoryFolder>
 
-    // NOTE: I think we should be able to use the Repository.Service.Unknown enum here, but it causes a javascript error. Not sure why.
-    static readonly DUMMY = new Repository(<Repository.Service>"Unknown", "", "", false);
-
     constructor(service : Repository.Service, name : string, branch : string, isBuiltIn : boolean){
-        this._id = Math.floor(Math.random() * 1000000000000);
+        this._id = Utils.generateRepositoryId();
         this.name = name;
         this.service = service;
         this.branch = branch;
@@ -141,6 +140,12 @@ export class Repository {
         }
     }
 
+    // a dummy repository
+    // used by some functions when a repository is not actually required, but a placeholder is required for the input arguments
+    public static dummy(){
+        return new Repository(Repository.Service.Unknown, "", "", false);
+    }
+
     // sorting order
     // 1. alphabetically by service
     // 2. alphabetically by name
@@ -193,4 +198,6 @@ export namespace Repository {
         Url = "Url",
         Unknown = "Unknown"
     }
+
+    export type Id = Branded<string, "Repository.Id">
 }

--- a/src/RepositoryFile.ts
+++ b/src/RepositoryFile.ts
@@ -1,11 +1,12 @@
 import * as ko from "knockout";
 
-import {Eagle} from './Eagle';
-import {Repository} from './Repository';
-import {Utils} from './Utils';
+import { Branded } from "./main";
+import { Eagle } from './Eagle';
+import { Repository } from './Repository';
+import { Utils } from './Utils';
 
 export class RepositoryFile {
-    _id : number
+    _id : RepositoryFile.Id
     repository: Repository
     name : string
     path : string
@@ -13,7 +14,7 @@ export class RepositoryFile {
     isFetching: ko.Observable<boolean>;
 
     constructor(repository : Repository, path : string, name : string){
-        this._id = Math.floor(Math.random() * 1000000000000);
+        this._id = Utils.generateRepositoryFileId();
         this.repository = repository;
         this.name = name;
         this.path = path;
@@ -38,4 +39,8 @@ export class RepositoryFile {
     htmlId : ko.PureComputed<string> = ko.pureComputed(() => {
         return "id_" + this.name.replace('.', '_');
     }, this);
+}
+
+export namespace RepositoryFile {
+    export type Id = Branded<string, "RepositoryFile.Id">
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -42,6 +42,7 @@ import { Node } from './Node';
 import { Palette } from './Palette';
 import { PaletteInfo } from './PaletteInfo';
 import { Repository } from './Repository';
+import { RepositoryFile } from "./RepositoryFile";
 import { Setting } from './Setting';
 import { UiModeSystem } from "./UiModes";
 import { ParameterTable } from "./ParameterTable";
@@ -78,6 +79,14 @@ export class Utils {
 
     static generateGraphConfigId(): GraphConfig.Id {
         return Utils._uuidv4() as GraphConfig.Id;
+    }
+
+    static generateRepositoryId(): Repository.Id {
+        return Utils._uuidv4() as Repository.Id;
+    }
+
+    static generateRepositoryFileId(): RepositoryFile.Id {
+        return Utils._uuidv4() as RepositoryFile.Id;
     }
 
     /**


### PR DESCRIPTION
Previously, the Repository and RepositoryFile objects used a large random number as an id. The id was generated using:
`Math.floor(Math.random() * 1000000000000)`
This MR changes the ids to follow the same pattern as the Node, Edge, Field, GraphConfig etc, to use a uuidv4

This also required a related change to Repository.DUMMY. This started causing a javascript file load order issue. Instead of being generated at load-time, I've changed this to be generated at run-time, as Repository.dummy().

## Summary by Sourcery

Update the ID generation for Repository and RepositoryFile objects to use uuidv4 for consistency with other components. Adjust the Repository.DUMMY to be generated at runtime to fix a load order issue.

Enhancements:
- Change the ID generation for Repository and RepositoryFile objects to use uuidv4 instead of random numbers.
- Modify the Repository.DUMMY to be generated at runtime as Repository.dummy() to resolve a JavaScript file load order issue.