### PR TITLE
Eagle 1368

### DIFF
--- a/static/tables.css
+++ b/static/tables.css
@@ -446,12 +446,19 @@ td:first-child input {
 .eagleTableDisplay  td button.parameterTableDescriptionBtn, .eagleTableDisplay  td button.parameterTableCommentBtn {
     position: absolute;
     right: 4px;
-    top: 2px;
+    top: 4px;
     background-color: #002e5f;
     color: white;
     display: none;
     padding: 1% 0px 0px 0px;
     font-size: 12px;
+}
+
+.eagleTableDisplay  td button.parameterTableDescriptionBtn::before, .eagleTableDisplay  td button.parameterTableCommentBtn::before {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    position: absolute;
 }
 
 .eagleTableDisplay .searchBarContainer{

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="messageModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <span id="messageModalMessage">Message</span>
@@ -22,7 +22,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="inputModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -51,7 +51,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="inputTextModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -83,7 +83,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="choiceModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -123,7 +123,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="confirmModalTitle">Title</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -149,7 +149,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="gitCommitModalTitle">Git Commit</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -224,7 +224,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="gitCustomRepositoryModalTitle">Add Custom Git Repository</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">
@@ -287,7 +287,7 @@
                 <img src="/static/assets/img/favicon.png" class="rounded float-left" alt="EAGLE logo">
                 <span>&nbsp;&nbsp;</span>
                 <h5 class="modal-title" id="aboutModalTitle">About EAGLE</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <h5>Editor for the Advanced Graph Language Environment</h5>

--- a/templates/modals/browse_dockerhub.html
+++ b/templates/modals/browse_dockerhub.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="browseDockerHubModalTitle">Docker Hub Browser</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">

--- a/templates/modals/edit_edge.html
+++ b/templates/modals/edit_edge.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="editEdgeModalTitle">Edit Edge</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="container">

--- a/templates/modals/edit_field.html
+++ b/templates/modals/edit_field.html
@@ -9,7 +9,7 @@
                     <div class="modal-header">
                         <input type="checkbox" tabindex='-1' class="form-control form-check-input material-icons" id="editFieldModalKeyParameterCheckbox">
                         <h5 class="modal-title" id="editFieldModalTitle">Edit Parameter</h5>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
                     </div>
                     <div class="modal-body">
                         <div class="container" id="customParameterOptionsWrapper">

--- a/templates/modals/errors.html
+++ b/templates/modals/errors.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="issuesModalTitle">Graph Issues</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class='accordion' id='issuesModalAccordion'>

--- a/templates/modals/explore_palettes.html
+++ b/templates/modals/explore_palettes.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="explorePalettesModalTitle">Explore Palettes</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div id="explorePalettesPathContainer">
                 <!-- ko ifnot: explorePalettes().showFiles -->

--- a/templates/modals/model_data.html
+++ b/templates/modals/model_data.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="modelDataModalTitle" data-bind="text: $root.currentFileInfoTitle()">ModelData</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <table id="modelDataModalTable" class="table table-striped">

--- a/templates/modals/shortcuts.html
+++ b/templates/modals/shortcuts.html
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="shortcutsModalTitle">Keyboard Shortcuts</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
 

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -36,7 +36,7 @@
     <div class="accordion">
         <div data-bind="foreach: palettes">
             <div class="paletteCardWrapper">
-                <button type="button" class="material-icons md-18 dropdown-toggle paletteTrippleDot" aria-label="Close" data-bs-toggle="dropdown" >more_vert</button>
+                <button type="button" class="material-icons md-18 dropdown-toggle paletteTrippleDot" data-bs-toggle="dropdown" >more_vert</button>
                 <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closePaletteMenus}">
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
                     <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove Palette</span></a>


### PR DESCRIPTION
locked fields are no longer able to be added to configs ( expert mode excepted) 

removed aria-closed tags, to remedy console errors

fixed a css alignment issue on the edit description buttons that are revealed by hovering on a description cell in the parameter tables.

## Summary by Sourcery

Fix console errors by removing aria-label attributes from modal close buttons, adjust CSS for better alignment of edit description buttons, and restrict adding locked fields to configurations except in expert mode.

Bug Fixes:
- Remove aria-label attributes from modal close buttons to fix console errors.
- Fix CSS alignment issue for edit description buttons in parameter tables.

Enhancements:
- Prevent locked fields from being added to configurations, except in expert mode.