### PR TITLE
EAGLE-1367: Remove orphaned graph config fields when the parent Logical Graph node is removed

### DIFF
--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -124,6 +124,15 @@ export class GraphConfig {
         }
     }
 
+    removeNodeById = (nodeId: NodeId): void => {
+        for (let i = this.nodes().length - 1; i >= 0 ; i--){
+            if (this.nodes()[i].getId() === nodeId){
+                this.nodes.splice(i, 1);
+                break;
+            }
+        }
+    }
+
     removeField = (field: Field): void => {
         // get reference to the GraphConfigNode containing the field
         const graphConfigNode: GraphConfigNode = this.findNodeById(field.getNodeId());

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -549,6 +549,11 @@ export class LogicalGraph {
     removeNode = (node: Node) : void => {
         const id = node.getId();
 
+        // first, delete any field in any graph config, that belongs to this node
+        for (const graphConfig of this.graphConfigs()){
+            graphConfig.removeNodeById(node.getId());
+        }
+
         // NOTE: this section handles an unusual case where:
         //  - the removed node is an embedded node within a construct
         //  - there are edge(s) connected to a port on the embedded node

--- a/templates/config_parameter_table.html
+++ b/templates/config_parameter_table.html
@@ -34,135 +34,133 @@
     </div>
     <div class="tableBody">
         <div class="wrapper">
-            <!-- ko if: eagle.selectedNode() != null -->
-                <!-- ko if: ParameterTable.getTableFields().length === 0 -->
-                    <div class="container h-100">
-                        <div class="row align-items-center h-100">
-                            <div class="col-md-12 text-center">
-                                <span class="fs-3">No fields</span>
-                                <br/>
-                                <span class="fs-6">Fields can be added from the Fields Table when a graph node is selected</span>
-                            </div>
+            <!-- ko if: ParameterTable.getTableFields().length === 0 -->
+                <div class="container h-100">
+                    <div class="row align-items-center h-100">
+                        <div class="col-md-12 text-center">
+                            <span class="fs-3">No fields in Graph Configuration</span>
+                            <br/>
+                            <span class="fs-6">Fields can be added from the Fields Table when a graph node is selected</span>
                         </div>
                     </div>
-                <!-- /ko -->
-                <!-- ko if: ParameterTable.getTableFields().length !== 0 -->
-                    <div class="tableInspector">
-                        <input id="configTableInspectorSelection" type="text" placeholder="Selection" data-bind="value: ParameterTable.formatTableInspectorSelection()" readonly>
-                        <input id="configTableInspectorValue" type="text" placeholder="Content" data-bind="value: ParameterTable.formatTableInspectorValue(), readonly: ParameterTable.selectionReadonly(), event: {keyup: ParameterTable.tableInspectorUpdateSelection($element.value)}">
-                    </div>
-                    <div class="scrollWrapper">
-                        <table class="eagleTableWrapper configFieldsTable paramsTableWrapper">
-                            <thead>
-                                <tr>
-                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().keyAttribute() -->
-                                        <th class="parameter_table_isKeyAttribute" data-bind="eagleTooltip:'Add/remove Field from Graph Config'" data-bs-placement="top"></th>
-                                    <!-- /ko -->
-                                    <th class="parameter_table_node_name" data-bind="eagleTooltip:`This Parameter's Parent Node Name`" data-bs-placement="top">
-                                        Node Name
-                                        <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_node_name') === true}"></div>
+                </div>
+            <!-- /ko -->
+            <!-- ko if: ParameterTable.getTableFields().length !== 0 -->
+                <div class="tableInspector">
+                    <input id="configTableInspectorSelection" type="text" placeholder="Selection" data-bind="value: ParameterTable.formatTableInspectorSelection()" readonly>
+                    <input id="configTableInspectorValue" type="text" placeholder="Content" data-bind="value: ParameterTable.formatTableInspectorValue(), readonly: ParameterTable.selectionReadonly(), event: {keyup: ParameterTable.tableInspectorUpdateSelection($element.value)}">
+                </div>
+                <div class="scrollWrapper">
+                    <table class="eagleTableWrapper configFieldsTable paramsTableWrapper">
+                        <thead>
+                            <tr>
+                                <!-- ko if: ParameterTable.getActiveColumnVisibility().keyAttribute() -->
+                                    <th class="parameter_table_isKeyAttribute" data-bind="eagleTooltip:'Add/remove Field from Graph Config'" data-bs-placement="top"></th>
+                                <!-- /ko -->
+                                <th class="parameter_table_node_name" data-bind="eagleTooltip:`This Parameter's Parent Node Name`" data-bs-placement="top">
+                                    Node Name
+                                    <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_node_name') === true}"></div>
+                                </th>
+                                <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
+                                    <th class="parameter_table_text" data-bind="eagleTooltip:'User-facing name'" data-bs-placement="top">
+                                        Attribute Name
+                                        <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_text') === true}"></div>
                                     </th>
-                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
-                                        <th class="parameter_table_text" data-bind="eagleTooltip:'User-facing name'" data-bs-placement="top">
-                                            Attribute Name
-                                            <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_text') === true}"></div>
-                                        </th>
-                                    <!-- /ko -->
-                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().value() -->
-                                        <th class="parameter_table_value" data-bind="eagleTooltip:'The value of this parameter'" data-bs-placement="top">
-                                            <span>Configured Value</span>
-                                            <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_value') === true}"></div>
-                                        </th>
-                                    <!-- /ko -->
-                                    <th class="parameter_table_comment" data-bind="eagleTooltip:'A user comment outlining the reason for the change to this field'" data-bs-placement="top">
-                                        Comment
-                                        <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_comment') === true}"></div>
+                                <!-- /ko -->
+                                <!-- ko if: ParameterTable.getActiveColumnVisibility().value() -->
+                                    <th class="parameter_table_value" data-bind="eagleTooltip:'The value of this parameter'" data-bs-placement="top">
+                                        <span>Configured Value</span>
+                                        <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_value') === true}"></div>
                                     </th>
-                                    <th class="parameter_table_remove" data-bind="eagleTooltip:'Remove this field from the graph configuration'" data-bs-placement="top">
-                                        Remove
-                                        <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_remove') === true}"></div>
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody data-bind="foreach: ParameterTable.getTableFields()">
-                                <!-- ko if: $data.fitsTableSearchQuery() -->
-                                    <!-- ko if: Setting.findValue(Setting.SHOW_NON_KEY_PARAMETERS) || $root.logicalGraph().getActiveGraphConfig()?.hasField($data) -->
-                                        <tr data-bind="attr: {'id' : 'tableRow_'+$data.getId()}">
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().keyAttribute() -->
-                                            <td class='columnCell column_KeyAttr'>
-                                                <!-- kept for now as we will need the space for the row drag handle -->
+                                <!-- /ko -->
+                                <th class="parameter_table_comment" data-bind="eagleTooltip:'A user comment outlining the reason for the change to this field'" data-bs-placement="top">
+                                    Comment
+                                    <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_comment') === true}"></div>
+                                </th>
+                                <th class="parameter_table_remove" data-bind="eagleTooltip:'Remove this field from the graph configuration'" data-bs-placement="top">
+                                    Remove
+                                    <div data-bind="css: {resizer: ParameterTable.setUpColumnResizer('parameter_table_remove') === true}"></div>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="foreach: ParameterTable.getTableFields()">
+                            <!-- ko if: $data.fitsTableSearchQuery() -->
+                                <!-- ko if: Setting.findValue(Setting.SHOW_NON_KEY_PARAMETERS) || $root.logicalGraph().getActiveGraphConfig()?.hasField($data) -->
+                                    <tr data-bind="attr: {'id' : 'tableRow_'+$data.getId()}">
+                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().keyAttribute() -->
+                                        <td class='columnCell column_KeyAttr'>
+                                            <!-- kept for now as we will need the space for the row drag handle -->
+                                        </td>
+                                        <!-- /ko -->
+                                        <td class='columnCell column_NodeName' data-bind="click: function(){Utils.showField($root, nodeId(), $data)}">
+                                            <input class="tableParameter" type="string" data-bind="value: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getName(), disabled: true, eagleTooltip: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getDescription()">
+                                        </td>
+                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
+                                            <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description, click: function(){Utils.showField($root, nodeId(), $data)}">
+                                                <input class="tableParameter selectionTargets tableFieldDisplayName" placeholder="New Parameter" type="string" data-bind="value: displayText, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')} ,keyup: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}}">
                                             </td>
-                                            <!-- /ko -->
-                                            <td class='columnCell column_NodeName' data-bind="click: function(){Utils.showField($root, nodeId(), $data)}">
-                                                <input class="tableParameter" type="string" data-bind="value: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getName(), disabled: true, eagleTooltip: $root.logicalGraph().findNodeByIdQuiet(nodeId())?.getDescription()">
-                                            </td>
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
-                                                <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description, click: function(){Utils.showField($root, nodeId(), $data)}">
-                                                    <input class="tableParameter selectionTargets tableFieldDisplayName" placeholder="New Parameter" type="string" data-bind="value: displayText, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')} ,keyup: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}}">
-                                                </td>
-                                            <!-- /ko -->
-                                             
-                                            <!-- value fields -->
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().value()  -->
-                                                <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
-                                                    <!-- ko if: $data.getType() === 'Integer' -->    
-                                                        <td class='columnCell column_Value'>
-                                                            <!-- ko if: $data.getGraphConfigField() -->
-                                                                <input class="tableParameter" min="0" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}}" type="number">
-                                                            <!-- /ko -->
-                                                        </td>
-                                                    <!-- /ko -->
-                                                    <!-- ko ifnot: $data.getType() === 'Integer' -->
-                                                        <td class='columnCell column_Value'>
-                                                            <!-- ko if: $data.getGraphConfigField() -->
-                                                                <input class="tableParameter inputNoArrows tableFieldStringValueInput" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}}">
-                                                            <!-- /ko -->
-                                                        </td>
-                                                    <!-- /ko -->
-                                                <!-- /ko -->
-                                                <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
-                                                    <td class='columnCell column_Value' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('value', $data) }">
-                                                        <!-- ko if: $data.getGraphConfigField() -->
-                                                            <div class="checkboxWrapper">
-                                                                <div>
-                                                                    <input class="tableParameter" tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
-                                                                </div> 
-                                                            </div>
-                                                        <!-- /ko -->
-                                                    </td>
-                                                <!-- /ko -->
-                                                <!-- ko if: $data.getHtmlInputType() === 'select' -->
+                                        <!-- /ko -->
+                                            
+                                        <!-- value fields -->
+                                        <!-- ko if: ParameterTable.getActiveColumnVisibility().value()  -->
+                                            <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
+                                                <!-- ko if: $data.getType() === 'Integer' -->    
                                                     <td class='columnCell column_Value'>
                                                         <!-- ko if: $data.getGraphConfigField() -->
-                                                            <div class="checkboxWrapper">
-                                                                <select aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.getGraphConfigField().value">
-                                                                <!-- options are added dynamically -->
-                                                                </select>
-                                                            </div>
+                                                            <input class="tableParameter" min="0" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}}" type="number">
+                                                        <!-- /ko -->
+                                                    </td>
+                                                <!-- /ko -->
+                                                <!-- ko ifnot: $data.getType() === 'Integer' -->
+                                                    <td class='columnCell column_Value'>
+                                                        <!-- ko if: $data.getGraphConfigField() -->
+                                                            <input class="tableParameter inputNoArrows tableFieldStringValueInput" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}}">
                                                         <!-- /ko -->
                                                     </td>
                                                 <!-- /ko -->
                                             <!-- /ko -->
-
-                                            <!-- default value fields -->
-                                            <!-- ko if: $data.getGraphConfigField() -->
-                                            <td class='columnCell column_Comment' onmouseenter="ParameterTable.showEditComment(this)" onmouseleave="ParameterTable.hideEditComment(this)" data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('comment', $data) }, eagleTooltip: $data.getGraphConfigField().comment">
-                                                <input class="tableParameter tableFieldCommentInput" type="string" data-bind="value: $data.getGraphConfigField().comment, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.getGraphConfigField().comment, 'comment', $data, $index())}, event:{keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().comment, 'comment', $data, $index())}}">
-                                                <button class="parameterTableCommentBtn icon-pencil" data-bind="click:function(data,event){ParameterTable.requestEditCommentInModal($data)}"></button>
-                                            </td>
-                                            <td class='columnCell column_Remove'>
-                                                <button data-bind="click: function(){ParameterTable.requestRemoveField($data)}, disabled: !Setting.findValue(Setting.ALLOW_SET_KEY_PARAMETER), eagleTooltip:'Remove Field from Graph Config', clickBubble:false">
-                                                    <i class="material-icons">remove</i>
-                                                </button>
-                                            </td>
+                                            <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
+                                                <td class='columnCell column_Value' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('value', $data) }">
+                                                    <!-- ko if: $data.getGraphConfigField() -->
+                                                        <div class="checkboxWrapper">
+                                                            <div>
+                                                                <input class="tableParameter" tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: $root.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
+                                                            </div> 
+                                                        </div>
+                                                    <!-- /ko -->
+                                                </td>
                                             <!-- /ko -->
-                                        </tr>
-                                    <!-- /ko -->
+                                            <!-- ko if: $data.getHtmlInputType() === 'select' -->
+                                                <td class='columnCell column_Value'>
+                                                    <!-- ko if: $data.getGraphConfigField() -->
+                                                        <div class="checkboxWrapper">
+                                                            <select aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: $root.getCurrentParamValueReadonly($data), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.getGraphConfigField().value">
+                                                            <!-- options are added dynamically -->
+                                                            </select>
+                                                        </div>
+                                                    <!-- /ko -->
+                                                </td>
+                                            <!-- /ko -->
+                                        <!-- /ko -->
+
+                                        <!-- default value fields -->
+                                        <!-- ko if: $data.getGraphConfigField() -->
+                                        <td class='columnCell column_Comment' onmouseenter="ParameterTable.showEditComment(this)" onmouseleave="ParameterTable.hideEditComment(this)" data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('comment', $data) }, eagleTooltip: $data.getGraphConfigField().comment">
+                                            <input class="tableParameter tableFieldCommentInput" type="string" data-bind="value: $data.getGraphConfigField().comment, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.getGraphConfigField().comment, 'comment', $data, $index())}, event:{keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().comment, 'comment', $data, $index())}}">
+                                            <button class="parameterTableCommentBtn icon-pencil" data-bind="click:function(data,event){ParameterTable.requestEditCommentInModal($data)}"></button>
+                                        </td>
+                                        <td class='columnCell column_Remove'>
+                                            <button data-bind="click: function(){ParameterTable.requestRemoveField($data)}, disabled: !Setting.findValue(Setting.ALLOW_SET_KEY_PARAMETER), eagleTooltip:'Remove Field from Graph Config', clickBubble:false">
+                                                <i class="material-icons">remove</i>
+                                            </button>
+                                        </td>
+                                        <!-- /ko -->
+                                    </tr>
                                 <!-- /ko -->
-                            </tbody>
-                        </table>
-                    </div>
-                <!-- /ko -->
+                            <!-- /ko -->
+                        </tbody>
+                    </table>
+                </div>
             <!-- /ko -->
         </div>
     </div>

--- a/templates/parameter_table.html
+++ b/templates/parameter_table.html
@@ -62,9 +62,9 @@
                     <div class="container h-100">
                         <div class="row align-items-center h-100">
                             <div class="col-md-12 text-center">
-                                <span class="fs-3">No fields</span>
+                                <span class="fs-3">No fields on Node</span>
                                 <br/>
-                                <span class="fs-6">Fields can be added from the Fields Table when a graph node is selected</span>
+                                <span class="fs-6">Fields can be added with the 'Add Parameter' button above</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Remove nodes from Graph Config when the corresponding node in the Logical Graph is removed.

I also improved the display of the "no fields" default message on the graph config. The code no longer checks that a node is selected (this doesn't matter for the graph config). And I added some text to make the status messages a bit more specific.

## Summary by Sourcery

Remove orphaned graph config fields when the corresponding Logical Graph node is deleted and enhance the display of default messages in the graph configuration.

Bug Fixes:
- Remove orphaned graph config fields when the parent Logical Graph node is removed.

Enhancements:
- Improve the display of the 'no fields' default message in the graph config.