### PR TITLE
EAGLE-1369: Relax warnings on fields with no default value and unknown type

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -846,14 +846,6 @@ export class Field {
                 field.issues().push({issue:issue,validity:Errors.Validity.Error})
         }
 
-        /*
-        // check that the field has a default value
-        if (field.getDefaultValue() === "" && !field.isType(Daliuge.DataType.String) && !field.isType(Daliuge.DataType.Password) && !field.isType(Daliuge.DataType.Object) && !field.isType(Daliuge.DataType.Unknown)) {
-            const issue: Errors.Issue = Errors.ShowFix("Node (" + node.getName() + ") has a component parameter (" + field.getDisplayText() + ") whose default value is not specified", function(){Utils.showField(eagle, node.getId(),field)}, function(){Utils.fixFieldDefaultValue(eagle, field)}, "Generate default value for parameter");
-                field.issues().push({issue:issue,validity:Errors.Validity.Warning})
-        }
-        */
-
         // check that the field has a known type
         if (!Utils.validateType(field.getType())) {
             const issue: Errors.Issue = Errors.ShowFix("Node (" + node.getName() + ") has a component parameter (" + field.getDisplayText() + ") whose type (" + field.getType() + ") is unknown", function(){Utils.showField(eagle, node.getId(),field)}, function(){Utils.fixFieldType(eagle, field)}, "Prepend existing type (" + field.getType() + ") with 'Object.'");

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -846,11 +846,13 @@ export class Field {
                 field.issues().push({issue:issue,validity:Errors.Validity.Error})
         }
 
+        /*
         // check that the field has a default value
         if (field.getDefaultValue() === "" && !field.isType(Daliuge.DataType.String) && !field.isType(Daliuge.DataType.Password) && !field.isType(Daliuge.DataType.Object) && !field.isType(Daliuge.DataType.Unknown)) {
             const issue: Errors.Issue = Errors.ShowFix("Node (" + node.getName() + ") has a component parameter (" + field.getDisplayText() + ") whose default value is not specified", function(){Utils.showField(eagle, node.getId(),field)}, function(){Utils.fixFieldDefaultValue(eagle, field)}, "Generate default value for parameter");
                 field.issues().push({issue:issue,validity:Errors.Validity.Warning})
         }
+        */
 
         // check that the field has a known type
         if (!Utils.validateType(field.getType())) {

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -267,6 +267,13 @@ export class Modals {
             $('#editFieldModalAffirmativeButton').trigger("focus");
         });
 
+        $('#editFieldModal').on('hidden.bs.modal', function(){
+            // TODO: this is a bit of a hack to make sure the graph is re-checked after using the editFieldModal.
+            //       it will not catch errors introduced when a user just edits fields within the ParameterTable
+            //       so eventually we'll need a better system here
+            Eagle.getInstance().checkGraph();
+        });
+
         // #editEdgeModal - requestUserEditEdge()
         $('#editEdgeModalAffirmativeButton').on('click', function(){
             $('#editEdgeModal').data('completed', true);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1603,15 +1603,15 @@ export class Utils {
     }
 
     static validateType(type: string) : boolean {
-        const typePrefix = Utils.dataTypePrefix(type);
-
-        for (const dt of Utils.enumKeys(Daliuge.DataType)){
-            if (dt === typePrefix){
-                return true;
-            }
+        if (typeof(type) === "undefined"){
+            return false;
         }
 
-        return false;
+        if (type.trim() === ""){
+            return false;
+        }
+
+        return true;
     }
 
     static downloadFile(error : string, data : string, fileName : string) : void {


### PR DESCRIPTION
Removed check for fields with no default value specified.
Check for known field type now allows anything except undefined or empty string.

## Summary by Sourcery

Relax validation rules by removing the check for fields with no default value and allowing any non-empty, defined field type.

Bug Fixes:
- Fix validation to allow any non-empty, defined field type.

Enhancements:
- Remove the check for fields with no default value, relaxing the validation criteria.