### PR TITLE
EAGLE-1363: Fixed bug when editing description of field on Node in palette

### DIFF
--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -419,18 +419,26 @@ export class ParameterTable {
         ParameterTable.openTable(Eagle.BottomWindowMode.GraphConfigAttributesTable, ParameterTable.SelectType.Normal);
     }
 
-    static requestEditDescriptionInModal(currentField:Field) : void {
+    static requestEditDescriptionInModal(field: Field) : void {
         const eagle: Eagle = Eagle.getInstance();
-        const currentNode: Node = eagle.logicalGraph().findNodeByIdQuiet(currentField.getNodeId());
+        const node: Node = eagle.selectedNode();
+
+        // check that we can actually find the node that this field belongs to
+        if (node === null){
+            const message = "Could not find node containing this field";
+            console.warn(message);
+            Utils.showNotification("Warning", message, "warning");
+            return;
+        }
 
         Utils.requestUserText(
             "Edit Field Description",
-            "Please edit the description for: " + currentNode.getName() + ' - ' + currentField.getDisplayText(),
-            currentField.getDescription(),
+            "Please edit the description for: " + node.getName() + ' - ' + field.getDisplayText(),
+            field.getDescription(),
             (completed, userText) => {
                 // if completed successfully, set the description on the field
                 if (completed){
-                    currentField.setDescription(userText);
+                    field.setDescription(userText);
                 }
             }
         )


### PR DESCRIPTION
Fixed an issue where a field description was not editable if the containing node was from a palette.

This used to cause an issue:
1. Select a node in a palette
2. View the parameters table
3. Click the 'edit' icon on the description of a field
4. Observe a javascript console error

The error was caused by the previous code always looking for the field's node within the logicalGraph. If the node was in a palette, then it was not found, and the null value caused issues.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where editing the description of a field on a node from a palette caused a JavaScript console error.