### PR TITLE
EAGLE-1365: New "Collapse All Palettes" item in Palette 3-dot menu

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -25,6 +25,7 @@
 "use strict";
 
 import * as ko from "knockout";
+import * as bootstrap from 'bootstrap';
 
 import { Category } from './Category';
 import { ComponentUpdater } from './ComponentUpdater';
@@ -4633,6 +4634,13 @@ export class Eagle {
         }
 
         return null;
+    }
+
+    collapseAllPalettes = (): void => {
+        for (let i = 0 ; i < this.palettes().length; i++){
+            const element = document.querySelector('#collapse'+i);
+            bootstrap.Collapse.getOrCreateInstance(element).hide();
+        }
     }
 }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4636,10 +4636,24 @@ export class Eagle {
         return null;
     }
 
-    collapseAllPalettes = (): void => {
+    toggleAllPalettes = (): void => {
+        // first check the state of the palette accordion items
+        let anyExpanded: boolean = false;
         for (let i = 0 ; i < this.palettes().length; i++){
             const element = document.querySelector('#collapse'+i);
-            bootstrap.Collapse.getOrCreateInstance(element).hide();
+            if ($(element).hasClass('show')){
+                anyExpanded = true;
+                break;
+            }
+        }
+
+        for (let i = 0 ; i < this.palettes().length; i++){
+            const element = document.querySelector('#collapse'+i);
+            if (anyExpanded){
+                bootstrap.Collapse.getOrCreateInstance(element).hide();
+            } else {
+                bootstrap.Collapse.getOrCreateInstance(element).show();
+            }
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,7 +253,7 @@ $(function(){
 
     
     //initiating all the eagle ui when the graph is ready
-    eagle.eagleIsReady = ko.observable(true)
+    eagle.eagleIsReady(true);
 
     //applying html ko bindings
     ko.applyBindings(eagle, document.getElementById("tabTitle"));
@@ -261,6 +261,11 @@ $(function(){
     
     //changing errors mode from loading to graph as eagle is now ready and finished loading
     eagle.errorsMode(Errors.Mode.Graph);
+
+    // collapse all the palettes once they have loaded
+    setTimeout(function(){
+        Eagle.getInstance().collapseAllPalettes();
+    }, 100)
 });
 
 async function loadRepos() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,11 +261,6 @@ $(function(){
     
     //changing errors mode from loading to graph as eagle is now ready and finished loading
     eagle.errorsMode(Errors.Mode.Graph);
-
-    // collapse all the palettes once they have loaded
-    setTimeout(function(){
-        Eagle.getInstance().collapseAllPalettes();
-    }, 100)
 });
 
 async function loadRepos() {

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -21,6 +21,7 @@
                 <a class="dropdown-item" id="loadPalette" href="#" data-bind="click: getPaletteFileToLoad">Load Local Palette
                     <span data-bind="text: KeyboardShortcut.idToText('open_palette_from_local_disk', true)"></span>
                 </a>
+                <a class="dropdown-item" id="collapseAllPalettes" href="#" data-bind="click: collapseAllPalettes">Collapse All Palettes</a>
             </div>
         </span>
         <div class="searchBarContainer">

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -21,7 +21,7 @@
                 <a class="dropdown-item" id="loadPalette" href="#" data-bind="click: getPaletteFileToLoad">Load Local Palette
                     <span data-bind="text: KeyboardShortcut.idToText('open_palette_from_local_disk', true)"></span>
                 </a>
-                <a class="dropdown-item" id="collapseAllPalettes" href="#" data-bind="click: collapseAllPalettes">Collapse All Palettes</a>
+                <a class="dropdown-item" id="toggleAllPalettes" href="#" data-bind="click: toggleAllPalettes">Toggle All Palettes</a>
             </div>
         </span>
         <div class="searchBarContainer">


### PR DESCRIPTION
Also, collapse all palettes by default when EAGLE loads. Uses hacky method for this, setTimeout of 100ms. If you have a better idea of how to do this, let me know.

Also, when attempting to use eagleIsReady as a trigger to collapseAllPalettes, I found that the eagleIsReady observable was being overwritten, which would cause all data bindings to the old observable to be lost. Now the code just updates the value of the existing observable.

## Summary by Sourcery

Introduce a new 'Collapse All Palettes' option in the Palette menu and implement automatic collapsing of all palettes upon EAGLE loading. Modify the initialization of the eagleIsReady observable to prevent overwriting and ensure data bindings are maintained.

New Features:
- Add a 'Collapse All Palettes' option in the Palette 3-dot menu.

Enhancements:
- Collapse all palettes by default when EAGLE loads using a setTimeout method.