### PR TITLE
Eagle 1364

### DIFF
--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -431,7 +431,7 @@ export class ParameterTable {
             return;
         }
         
-        //check that the user has sufficient persmissions to change the field's description
+        //check that the user has sufficient permissions to change the field's description
         if(ParameterTable.getNodeLockedState(field)){
             Utils.showNotification("Insufficient Permissions", "Editing permissions are required to be able to edit a field's description.", "warning");
             return

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -430,6 +430,12 @@ export class ParameterTable {
             Utils.showNotification("Warning", message, "warning");
             return;
         }
+        
+        //check that the user has sufficient persmissions to change the field's description
+        if(ParameterTable.getNodeLockedState(field)){
+            Utils.showNotification("Insufficient Permissions", "Editing permissions are required to be able to edit a field's description.", "warning");
+            return
+        }
 
         Utils.requestUserText(
             "Edit Field Description",

--- a/templates/parameter_table.html
+++ b/templates/parameter_table.html
@@ -276,7 +276,9 @@
                                                 <!-- ko if: ParameterTable.getActiveColumnVisibility().description() -->
                                                 <td class='columnCell column_Description' onmouseenter="ParameterTable.showEditDescription(this)" onmouseleave="ParameterTable.hideEditDescription(this)" data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('description', $data) }, eagleTooltip:description">
                                                     <input class="tableParameter" type="string" data-bind="value: description, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.description(), 'description', $data, $index())}, event:{keyup: function(event, data){ParameterTable.select($data.description(), 'description', $data, $index())}}">
-                                                    <button class="parameterTableDescriptionBtn icon-pencil" data-bind="click:function(data,event){ParameterTable.requestEditDescriptionInModal($data)}"></button>
+                                                    <!-- ko ifnot: ParameterTable.getNodeLockedState($data) -->
+                                                        <button class="parameterTableDescriptionBtn icon-pencil" data-bind="click:function(data,event){ParameterTable.requestEditDescriptionInModal($data)}"></button>
+                                                    <!-- /ko -->
                                                 </td>
                                                 <!-- /ko -->
                                             <!-- /ko -->


### PR DESCRIPTION
hiding the open description modal button if the user doesnt have sufficient permissions
also added a backup check the function that opens the modal.

## Summary by Sourcery

Implement permission checks to ensure users without sufficient permissions cannot open the description modal or see the button to do so.

Bug Fixes:
- Hide the open description modal button if the user lacks sufficient permissions.

Enhancements:
- Add a backup permission check in the function that opens the description modal.