### PR TITLE
EAGLE-1374: New 'developer' class of notifications

### DIFF
--- a/src/ComponentUpdater.ts
+++ b/src/ComponentUpdater.ts
@@ -11,7 +11,6 @@ export class ComponentUpdater {
 
         // check if any nodes to update
         if (graph.getNodes().length === 0){
-            // TODO: don't showNotification here! instead add a warning to the errorsWarnings and callback()
             errorsWarnings.errors.push(Errors.Message("Graph contains no components to update"));
             callback(errorsWarnings, updatedNodes);
             return;

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2231,7 +2231,6 @@ export class Eagle {
             // display error if one occurred
             if (error != null){
                 Utils.showNotification("Error deleting file", error, "danger");
-                console.error(error);
                 return;
             }
 
@@ -3308,14 +3307,12 @@ export class Eagle {
 
         // if no objects selected, warn user
         if (data.length === 0){
-            console.warn("Unable to delete selection: Nothing selected");
             Utils.showNotification("Warning", "Unable to delete selection: Nothing selected", "warning");
             return;
         }
 
         // if in "hide data nodes" mode, then recommend the user delete edges in "show data nodes" mode instead
         if (!this.showDataNodes()){
-            console.warn("Unable to delete selection: Editor is in 'hide data nodes' mode, and the current selection may be ambiguous. Please use 'show data nodes' mode before deleting.");
             Utils.showNotification("Warning", "Unable to delete selection: Editor is in 'hide data nodes' mode, and the current selection may be ambiguous. Please use 'show data nodes' mode before deleting.", "warning");
             return;
         }

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -255,7 +255,6 @@ export class Field {
     removeOption = (index:number) : void => {
         if(this.options().length <= 1){
             Utils.showNotification("Cannot Remove","There must be at least one option in the select!",'danger');
-
             return
         }
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -425,9 +425,7 @@ export class ParameterTable {
 
         // check that we can actually find the node that this field belongs to
         if (node === null){
-            const message = "Could not find node containing this field";
-            console.warn(message);
-            Utils.showNotification("Warning", message, "warning");
+            Utils.showNotification("Warning", "Could not find node containing this field", "warning");
             return;
         }
         

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -281,6 +281,7 @@ export class Setting {
     static readonly CONFIRM_DELETE_FILES : string = "ConfirmDeleteFiles";
     static readonly CONFIRM_DELETE_OBJECTS : string = "ConfirmDeleteObjects";
 
+    static readonly SHOW_DEVELOPER_NOTIFICATIONS: string = "ShowDeveloperNotifications";
     static readonly SHOW_FILE_LOADING_ERRORS : string = "ShowFileLoadingErrors";
 
     static readonly ALLOW_INVALID_EDGES : string = "AllowInvalidEdges";
@@ -436,6 +437,7 @@ const settings : SettingsGroup[] = [
         "Developer",
         () => {return false;},
         [
+            new Setting(true, "Show Developer Notifications", Setting.SHOW_DEVELOPER_NOTIFICATIONS, "EAGLE generates a number of messages intended to alert developers to unusual occurrences or issues. Enabling this setting displays those messages.", false, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Show File Loading Warnings", Setting.SHOW_FILE_LOADING_ERRORS, "Display list of issues with files encountered during loading.", false, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Open Translator In Current Tab", Setting.OPEN_TRANSLATOR_IN_CURRENT_TAB, "When translating a graph, display the output of the translator in the current tab", false, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Create Applications for Construct Ports", Setting.CREATE_APPLICATIONS_FOR_CONSTRUCT_PORTS, "When loading old graph files with ports on construct nodes, move the port to an embedded application", false, Setting.Type.Boolean, true, true, true, true, true),

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -110,7 +110,6 @@ export class Undo {
 
     prevSnapshot = (eagle: Eagle) : void => {
         if (this.rear() === this.current()){
-            console.log("Undo.prevSnapshot() : no previous snapshot, abort!");
             Utils.showNotification("Unable to Undo", "No further history available", "warning");
             return;
         }
@@ -136,7 +135,6 @@ export class Undo {
 
     nextSnapshot = (eagle: Eagle) : void => {
         if (this.front() === this.current()){
-            console.log("Undo.nextSnapshot() : no next snapshot, abort!");
             Utils.showNotification("Unable to Redo", "No further history available", "warning");
             return;
         }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -467,6 +467,13 @@ export class Utils {
         $('#issuesDisplay').modal("show");
     }
 
+    /**
+     * Show a temporary notification message to the user at the bottom of the graph display area
+     * @param title The title of the notification
+     * @param message The body of the notification
+     * @param type The type of the notification. This changes the color of the notification
+     * @param developer If true, this notification is intended for developers-only. Regular users are unlikely to be able to do anything useful with the information. Users enable/disable display of developer-only notifications via a setting on the Developer tab of the Settings modal.
+     */
     static showNotification(title : string, message : string, type : "success" | "info" | "warning" | "danger", developer: boolean = false) : void {
         // display in console
         switch(type){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -467,7 +467,22 @@ export class Utils {
         $('#issuesDisplay').modal("show");
     }
 
-    static showNotification(title : string, message : string, type : "success" | "info" | "warning" | "danger") : void {
+    static showNotification(title : string, message : string, type : "success" | "info" | "warning" | "danger", developer: boolean = false) : void {
+        // display in console
+        switch(type){
+            case "danger":
+                console.error(title, message);
+                break;
+            case "warning":
+                console.warn(title, message);
+                break;
+        }
+
+        // if this is a message intended for developers, check whether display of those messages is enabled
+        if (developer && !Setting.findValue(Setting.SHOW_DEVELOPER_NOTIFICATIONS)){
+            return;
+        }
+
         $.notify({
             title:title + ":",
             message:message
@@ -1545,9 +1560,7 @@ export class Utils {
         const jsonObject = JSON.parse(jsonString);
         const validatorResult : {valid: boolean, errors: string} = Utils._validateJSON(jsonObject, Daliuge.SchemaVersion.OJS, fileType);
         if (!validatorResult.valid){
-            const message = "JSON Output failed validation against internal JSON schema, saving anyway";
-            console.error(message, validatorResult.errors);
-            Utils.showNotification("Error",  message + "<br/>" + validatorResult.errors, "danger");
+            Utils.showNotification("Error",  "JSON Output failed validation against internal JSON schema, saving anyway" + "<br/>" + validatorResult.errors, "danger", true);
         }
     }
 


### PR DESCRIPTION
Added new setting 'Show developer notifications'.

Update Utils.showNotification with new param that specifies whether message is intended for developers.

Removed duplicate console.error/console.warn calls from same spots in code where showNotification() was called. Instead just have showNotification() also call console.error/console.warn within it.

Made the "JSON schema validation failure" notification a developer-only message.

## Summary by Sourcery

Add a new 'developer' class of notifications with a corresponding setting to toggle their visibility. Refactor the showNotification function to include developer-specific messages and consolidate logging calls.

New Features:
- Introduce a new 'developer' class of notifications that can be toggled via a setting.

Enhancements:
- Consolidate console.error and console.warn calls within the showNotification function to streamline error and warning logging.