### PR TITLE
Eagle 1375

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -385,6 +385,14 @@ export class Eagle {
         return fileInfo.getText();
     }, this);
 
+    activeConfigText : ko.PureComputed<string> = ko.pureComputed(() => {
+        if (this.logicalGraph().getActiveGraphConfig() === null){
+            return "";
+        }
+
+        return  "<strong>Config:</strong> " +this.logicalGraph().getActiveGraphConfig().getName()
+    }, this);
+
     toggleWindows = () : void  => {
         const setOpen = !Setting.findValue(Setting.LEFT_WINDOW_VISIBLE) || !Setting.findValue(Setting.RIGHT_WINDOW_VISIBLE) || !Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE)
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -382,10 +382,10 @@ export class Eagle {
             return "";
         }
 
-        return fileInfo.getText();
+        return fileInfo.getHtml();
     }, this);
 
-    activeConfigText : ko.PureComputed<string> = ko.pureComputed(() => {
+    activeConfigHtml : ko.PureComputed<string> = ko.pureComputed(() => {
         if (this.logicalGraph().getActiveGraphConfig() === null){
             return "";
         }

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -371,6 +371,18 @@ export class FileInfo {
     getText = () : string => {
         if (this.repositoryName !== ""){
             if (this.path === ""){
+                return this.repositoryService + ": " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.name;
+            } else {
+                return this.repositoryService + ": " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.path + "/" + this.name;
+            }
+        } else {
+            return this.name;
+        }
+    }
+
+    getHtml = () : string => {
+        if (this.repositoryName !== ""){
+            if (this.path === ""){
                 return "<strong>" + this.repositoryService + "</strong>: " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.name;
             } else {
                 return "<strong>" + this.repositoryService + "</strong>: " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.path + "/" + this.name;

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -371,9 +371,9 @@ export class FileInfo {
     getText = () : string => {
         if (this.repositoryName !== ""){
             if (this.path === ""){
-                return this.repositoryService + ": " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.name;
+                return "<strong>" + this.repositoryService + "</strong>: " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.name;
             } else {
-                return this.repositoryService + ": " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.path + "/" + this.name;
+                return "<strong>" + this.repositoryService + "</strong>: " + this.repositoryName + " (" + this.repositoryBranch + "): " + this.path + "/" + this.name;
             }
         } else {
             return this.name;

--- a/static/base.css
+++ b/static/base.css
@@ -2057,6 +2057,10 @@ ul.nav.navbar-nav .dropdown-item:hover{
     transform: translateY(-50%);
 }
 
+#activeConfig{
+    margin-left:5px;
+}
+
 .navbar-light .navbar-nav .nav-link {
     color: rgba(255, 255, 255, 0.55);
 }

--- a/static/tables.css
+++ b/static/tables.css
@@ -178,6 +178,7 @@ td:first-child input {
 
 #graphConfigurationsTableWrapper thead{
     top: 0px;
+    border-top: 1px white solid;
 }
 
 .eagleTableWrapper th{

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -271,17 +271,18 @@
                     <div class="headerButtons inspectorHeaderButtons" id="objectInspectorHeaderIconRow">
                         <div class="row">
                             <div class="col col-6">
+                                <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.File -->
+                                <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Local Graph File'" data-bs-toggle="tooltip" data-html="true">folder_open</i>
+                                <!-- /ko -->
+                                <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitHub || $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitLab -->
+                                    <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Graph File from GitHub or GitLab'" data-bs-toggle="tooltip" data-html="true">account_tree</i>
+                                <!-- /ko -->
                                 <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().fullPath()" data-bs-toggle="tooltip" data-html="true">link</i>
                                 <i class="material-icons interactive clickable" data-bs-placement="right" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().shortDescription, click: function(){Utils.showModelDataModal('Graph Info', $root.logicalGraph().fileInfo());}" data-bs-toggle="tooltip" data-html="true">sticky_note_2</i>
                                 <i class="material-icons interactive clickable" data-bs-placement="right" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().detailedDescription, click: function(){Utils.showModelDataModal('Graph Info', $root.logicalGraph().fileInfo());}" data-bs-toggle="tooltip" data-html="true">menu_book</i>
                             </div>
                             <div class="col-6 col text-right">
-                                <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.File -->
-                                    <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Local Graph File'" data-bs-toggle="tooltip" data-html="true">folder_open</i>
-                                <!-- /ko -->
-                                <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitHub || $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitLab -->
-                                    <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Graph File from GitHub or GitLab'" data-bs-toggle="tooltip" data-html="true">account_tree</i>
-                                <!-- /ko -->
+                                <i class="material-icons interactive clickable" data-bs-placement="right" data-bind="eagleTooltip: 'View graph configurations table', click: GraphConfigurationsTable.openTable" data-bs-toggle="tooltip" data-html="true">dns</i>
                             </div>
                         </div>
                     </div>
@@ -308,6 +309,22 @@
                             </div>  
                             <div class="col-6 col contentObjectValue">
                                 <span data-bind="text:$root.logicalGraph().fileInfo().lastModifiedName, eagleTooltip:$root.logicalGraph().fileInfo().lastModifiedName"></span>
+                            </div>
+                        </div>
+                        <div class="row inspectorEdgeSrcNodeId contentObject">
+                            <div class="col-6 col contentObjectTitle">
+                                <h5>Active Config: </h5>
+                            </div>  
+                            <div class="col-6 col contentObjectValue">
+                                <span data-bind="text:$root.logicalGraph().getActiveGraphConfig()?.getName(), eagleTooltip:$root.logicalGraph().getActiveGraphConfig()?.getDescription()"></span>
+                            </div>
+                        </div>
+                        <div class="row inspectorEdgeSrcNodeId contentObject">
+                            <div class="col-6 col contentObjectTitle">
+                                <h5>Config Length: </h5>
+                            </div>  
+                            <div class="col-6 col contentObjectValue">
+                                <span data-bind="text:$root.logicalGraph().getActiveGraphConfig()?.numFields(), eagleTooltip:'Number of fields overwritten by the active config.'"></span>
                             </div>
                         </div>
                     </div>

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -321,7 +321,7 @@
                         </div>
                         <div class="row inspectorEdgeSrcNodeId contentObject">
                             <div class="col-6 col contentObjectTitle">
-                                <h5>Config Length: </h5>
+                                <h5>Config Fields: </h5>
                             </div>  
                             <div class="col-6 col contentObjectValue">
                                 <span data-bind="text:$root.logicalGraph().getActiveGraphConfig()?.numFields(), eagleTooltip:'Number of fields overwritten by the active config.'"></span>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -226,6 +226,7 @@
     </div>
 </nav>
 <div id="graphNameWrapper" data-bind="style: { 'visibility':eagle.getEagleIsReady()}">
-    <span id="filename" data-bind="text: repositoryFileName"></span>
+    <span id="filename" data-bind="html: repositoryFileName"></span>
+    <span id="activeConfig" data-bind="html: activeConfigText, eagleTooltip:'Name of the active graph configuration'"></span>
     <span id="fileIsModified" class="material-icons md-18" data-bind="visible: eagle.logicalGraph().fileInfo().modified">draw</span>
 </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -227,6 +227,6 @@
 </nav>
 <div id="graphNameWrapper" data-bind="style: { 'visibility':eagle.getEagleIsReady()}">
     <span id="filename" data-bind="html: repositoryFileName"></span>
-    <span id="activeConfig" data-bind="html: activeConfigText, eagleTooltip:'Name of the active graph configuration'"></span>
+    <span id="activeConfig" data-bind="html: activeConfigHtml, eagleTooltip:'Name of the active graph configuration'"></span>
     <span id="fileIsModified" class="material-icons md-18" data-bind="visible: eagle.logicalGraph().fileInfo().modified">draw</span>
 </div>


### PR DESCRIPTION
displaying active graph config in the graph name wrapper and in the graph inspector

## Summary by Sourcery

Display the active graph configuration details in the graph inspector and graph name wrapper, enhancing the user interface with better organization and additional functionality.

New Features:
- Display the active graph configuration name and description in the graph inspector and graph name wrapper.

Enhancements:
- Reorder icons in the graph inspector for better organization and user experience.
- Add a new icon in the graph inspector to view the graph configurations table.