### PR TITLE
EAGLE-1377: Remove sorting of components when loading a Palette

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2335,7 +2335,7 @@ export class Eagle {
         // close the palette menu
         this.closePaletteMenus();
 
-        const preSortCopy = palette.getNodes().slice(0);
+        const preSortCopy = palette.getNodes().slice();
 
         palette.sort();
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1248,9 +1248,6 @@ export class Eagle {
         // show errors (if found)
         this._handleLoadingErrors(errorsWarnings, Utils.getFileNameFromFullPath(fileFullPath), Repository.Service.File);
 
-        // sort the palette
-        p.sort();
-
         // add new palette to the START of the palettes array
         this.palettes.unshift(p);
 
@@ -2276,9 +2273,6 @@ export class Eagle {
         const errorsWarnings: Errors.ErrorsWarnings = {"errors":[], "warnings":[]};
         const newPalette = Palette.fromOJSJson(data, file, errorsWarnings);
 
-        // sort items in palette
-        newPalette.sort();
-
         // add to list of palettes
         this.palettes.unshift(newPalette);
 
@@ -2335,6 +2329,23 @@ export class Eagle {
             }
         }
         this.resetEditor()
+    }
+
+    sortPalette = (palette: Palette): void => {
+        // close the palette menu
+        this.closePaletteMenus();
+
+        const preSortCopy = palette.getNodes().slice(0);
+
+        palette.sort();
+
+        // check whether anything changed order, if so, mark as modified
+        for (let i = 0; i < palette.getNodes().length; i++) {
+            if (palette.getNodes()[i].getId() !== preSortCopy[i].getId()) {
+                palette.fileInfo().modified = true;
+                break;
+            }
+        }
     }
 
     getParentNameAndId = (parentId: NodeId) : string => {
@@ -3264,7 +3275,6 @@ export class Eagle {
 
                 // mark the palette as modified
                 destinationPalette.fileInfo().modified = true;
-                destinationPalette.sort();
             }
         });
     }
@@ -4141,7 +4151,6 @@ export class Eagle {
             // add to destination palette
             destinationPalette.addNode(sourceComponent, true);
             destinationPalette.fileInfo().modified = true;
-            destinationPalette.sort();
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -769,9 +769,6 @@ export class Utils {
         palette.fileInfo().downloadUrl = paletteListItem.filename;
         palette.fileInfo().type = Eagle.FileType.Palette;
         palette.fileInfo().repositoryService = Repository.Service.Url;
-
-        // sort palette and add to results
-        palette.sort();
     }
 
     static showPalettesModal(eagle: Eagle) : void {

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -39,11 +39,12 @@
             <div class="paletteCardWrapper">
                 <button type="button" class="material-icons md-18 dropdown-toggle paletteTrippleDot" data-bs-toggle="dropdown" >more_vert</button>
                 <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closePaletteMenus}">
+                    <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
-                    <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove Palette</span></a>
+                    <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove</span></a>
                     <!-- /ko -->
                     <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown -->
-                    <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}, clickBubble: false" data-html="true"><span>Reload Palette</span></a>
+                    <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}, clickBubble: false" data-html="true"><span>Reload</span></a>
                     <!-- /ko -->
                     <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                         <a href="#" data-bind="click: $root.savePaletteToDisk" data-html="true"><span>Save Locally</span></a>
@@ -53,9 +54,9 @@
                     <a href="#" data-bind="click: function(){$data.setSearchExclude(false)}"><span>Include In Search</span></a>
                     <!-- /ko -->
                     <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown && $data.fileInfo().repositoryService !== Repository.Service.File -->
-                    <a href="#" data-bind="click: $data.copyUrl"><span>Copy Palette URL</span></a>
+                    <a href="#" data-bind="click: $data.copyUrl"><span>Copy URL</span></a>
                     <!-- /ko -->
-                    <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show Palette ModelData</span></a>
+                    <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show ModelData</span></a>
                 </div>
                 <div class="accordion-item paletteWrapper" data-bind="attr: {'data-palette-index': $index}, event: { dragover: SideWindow.nodeDragOver, drop: $root.nodeDropPalette }">
                     <div class="accordion-header">


### PR DESCRIPTION
Removed automatic sorting when loading, reloading, adding to, removing from Palettes.
Added manual sort option to Palette 3-dot menu.
Simplified the names of a few items in the palette menu.

## Summary by Sourcery

Remove automatic sorting of components when loading or modifying palettes and introduce a manual sort option in the Palette menu.

New Features:
- Added a manual sort option to the Palette menu, allowing users to sort components manually.

Enhancements:
- Simplified the names of several items in the palette menu for better clarity.