### PR TITLE
fixed the tooltip spacing issue on node headers when zooming the graph

### DIFF
--- a/templates/basic_node.html
+++ b/templates/basic_node.html
@@ -1,7 +1,7 @@
 <div class="nodeContent basic_node">
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)},attr:{id:$data.getId()}">
-        <div class="header" data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, css:{'graphDataNode':$data.isData()}">
-            <div data-bind="style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
+        <div class="header" data-bind=" css:{'graphDataNode':$data.isData()}">
+            <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
                 <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">
             </div>

--- a/templates/branch_node.html
+++ b/templates/branch_node.html
@@ -1,7 +1,7 @@
 <div class="nodeContent branch_node">
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)}">
-        <div class="header" data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}">
-            <div data-bind="style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
+        <div class="header">
+            <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
                 <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
             </div>

--- a/templates/construct_node.html
+++ b/templates/construct_node.html
@@ -1,7 +1,7 @@
 <div class="nodeContent construct_node">
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)}">
-        <div class="header" data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}">
-            <div data-bind="style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
+        <div class="header">
+            <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
                 <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
             </div>


### PR DESCRIPTION
fixed the space between the node header in the graph and the tooltip. the issue was because the node headers scale depending on zoom level, but the tooltip was not applied to the scaled element cause a desync. 