### PR TITLE
Eagle 1278

### DIFF
--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -155,7 +155,7 @@
                                             </td>
                                             <!-- /ko -->
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
-                                                <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description, click: function(){Utils.showField($root, nodeId(), $data)}">
+                                                <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description">
                                                     <input class="tableParameter selectionTargets tableFieldDisplayName" placeholder="New Parameter" type="string" data-bind="value: displayText, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')} ,keyup: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}}">
                                                     <!-- ko if: Eagle.selectedLocation() === Eagle.FileType.Graph -->
                                                         <!-- ko ifnot: $root.logicalGraph().getActiveGraphConfig()?.hasField($data) -->


### PR DESCRIPTION
bugfix for selection of field name cells in the parameter table

## Summary by Sourcery

Bug Fixes:
- Prevent accidental edits of field names when clicking on them in the parameter table.