### PR TITLE
EAGLE-1326: Auto-save graphs if modified when user requests a translation

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -317,6 +317,16 @@ export class Eagle {
             await this.translator().genPGT(defaultTranslatorAlgorithmMethod, false, Daliuge.SchemaVersion.Unknown);
         } catch (error){
             console.error("deployDefaultTranslationAlgorithm()", error);
+            Utils.showNotification("Error", error, "danger");
+        }
+    }
+
+    deployTranslationAlgorithm = async (algorithm: string, test: boolean) => {
+        try {
+            await this.translator().genPGT(algorithm, test, Daliuge.SchemaVersion.Unknown);
+        } catch (error){
+            console.error("deployDefaultTranslationAlgorithm()", error);
+            Utils.showNotification("Error", error, "danger");
         }
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2003,13 +2003,13 @@ export class Eagle {
                     token = Setting.findValue(Setting.GITLAB_ACCESS_TOKEN_KEY);
                     break;
                 default:
-                    Utils.showUserMessage("Error", "Unknown repository service. Not GitHub or GitLab!");
+                    reject("Unknown repository service. Not GitHub or GitLab!");
                     return;
             }
 
             // check that access token is defined
             if (token === null || token === "") {
-                Utils.showUserMessage("Error", "The GitHub access token is not set! To save files on GitHub, set the access token.");
+                reject("The GitHub access token is not set! To save files on GitHub, set the access token.");
                 return;
             }
 

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -132,9 +132,8 @@ export class Translator {
 
         // check if the graph is committed before translation
         if (this._checkGraphModified(eagle)){
-            // use the async function here
-            // TODO: switch back from TEST func here!
-            await eagle.saveGraphTest();
+            // use the async function here, so that we can check isModified after saving
+            await eagle.saveGraph();
             
             // check again if graph is modified
             if (this._checkGraphModified(eagle)){

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -133,6 +133,7 @@ export class Translator {
         // check if the graph is committed before translation
         if (this._checkGraphModified(eagle)){
             // TODO: use the async function here
+            Utils.showNotification("Saving graph", "Automatically saving modified graph prior to translation", "info");
             eagle.saveGraph();
             
             // check again if graph is modified

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -120,18 +120,18 @@ export class Translator {
 
         // check if the graph has at least one node
         if (eagle.logicalGraph().getNumNodes() === 0) {
-            Utils.showUserMessage("Error", "Unable to translate. Logical graph has no nodes!");
-            return;
+            throw new Error("Unable to translate. Logical graph has no nodes!");
         }
 
         // check if the graph has a name
         if (eagle.logicalGraph().fileInfo().name === ""){
-            Utils.showUserMessage("Error", "Unable to translate. Logical graph does not have a name! Please save the graph first.");
-            return;
+            throw new Error("Unable to translate. Logical graph does not have a name! Please save the graph first.");
         }
 
         // check if the graph is committed before translation
         if (this._checkGraphModified(eagle)){
+            Utils.showNotification("Saving graph", "Automatically saving modified graph prior to translation", "info");
+
             // use the async function here, so that we can check isModified after saving
             await eagle.saveGraph();
             
@@ -139,8 +139,6 @@ export class Translator {
             if (this._checkGraphModified(eagle)){
                 Utils.showNotification("Unable to Translate", "Please save/commit the graph before attempting translation", "danger");
                 return;
-            } else {
-                Utils.showNotification("Saved graph", "Automatically saved modified graph prior to translation", "info");
             }
         }
 

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -134,6 +134,10 @@ export class Translator {
 
             // use the async function here, so that we can check isModified after saving
             await eagle.saveGraph();
+
+            // short wait after saving, just to indicate to the user that saving is performed by EAGLE
+            // and that the translation is a separate step
+            await new Promise( resolve => setTimeout(resolve, 2000) );
             
             // check again if graph is modified
             if (this._checkGraphModified(eagle)){

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -133,7 +133,8 @@ export class Translator {
         // check if the graph is committed before translation
         if (this._checkGraphModified(eagle)){
             // use the async function here
-            await eagle.saveGraph();
+            // TODO: switch back from TEST func here!
+            await eagle.saveGraphTest();
             
             // check again if graph is modified
             if (this._checkGraphModified(eagle)){

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -115,7 +115,7 @@ export class Translator {
      * @param testingMode
      * @param format
      */
-     genPGT = (algorithmName : string, testingMode: boolean, format: Daliuge.SchemaVersion) : void => {
+     genPGT = async (algorithmName : string, testingMode: boolean, format: Daliuge.SchemaVersion) : Promise<void> => {
         const eagle: Eagle = Eagle.getInstance();
 
         // check if the graph has at least one node
@@ -132,14 +132,15 @@ export class Translator {
 
         // check if the graph is committed before translation
         if (this._checkGraphModified(eagle)){
-            // TODO: use the async function here
-            Utils.showNotification("Saving graph", "Automatically saving modified graph prior to translation", "info");
-            eagle.saveGraph();
+            // use the async function here
+            await eagle.saveGraph();
             
             // check again if graph is modified
             if (this._checkGraphModified(eagle)){
                 Utils.showNotification("Unable to Translate", "Please save/commit the graph before attempting translation", "danger");
                 return;
+            } else {
+                Utils.showNotification("Saved graph", "Automatically saved modified graph prior to translation", "info");
             }
         }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -317,14 +317,14 @@ export class Utils {
     }
     
     // , successCallback : (data : string) => void, errorCallback : (error : string) => void) : void {
-    static async httpGet(url : string): Promise<string> {
+    static async httpGet(url: string): Promise<string> {
         return new Promise(async(resolve, reject) => {
             $.ajax({
                 url: url,
-                success: function (data : string) {
+                success: function(data: string) {
                     resolve(data);
                 },
-                error: function(xhr, status, error : string){
+                error: function(xhr, status, error: string){
                     reject(error);
                 }
             });
@@ -332,49 +332,91 @@ export class Utils {
     }
 
     static async httpGetJSON(url: string, json: object): Promise<object> {
-        return $.ajax({
-            url : url,
-            type : 'GET',
-            data : JSON.stringify(json),
-            contentType : 'application/json'
+        return new Promise(async(resolve, reject) => {
+            $.ajax({
+                url : url,
+                type : 'GET',
+                data : JSON.stringify(json),
+                contentType : 'application/json',
+                success : function(obj: object){
+                    resolve(obj);
+                },
+                error: function(xhr, status, error: string){
+                    reject(error);
+                }
+            });
         });
     }
 
     static async httpPost(url : string, data : string): Promise<string> {
-        return $.ajax({
-            url : url,
-            type : 'POST',
-            data : data,
-            processData: false,  // tell jQuery not to process the data
-            contentType: false   // tell jQuery not to set contentType
+        return new Promise(async(resolve, reject) => {
+            $.ajax({
+                url : url,
+                type : 'POST',
+                data : data,
+                processData: false,  // tell jQuery not to process the data
+                contentType: false,  // tell jQuery not to set contentType
+                success: function(data: string){
+                    resolve(data);
+                },
+                error: function(xhr, status, error: string){
+                    reject(error);
+                }
+            });
         });
     }
 
     static async httpPostJSON(url : string, json : object): Promise<string> {
-        return $.ajax({
-            url : url,
-            type : 'POST',
-            data : JSON.stringify(json),
-            contentType : 'application/json'
+        return new Promise(async(resolve, reject) => {
+            $.ajax({
+                url : url,
+                type : 'POST',
+                data : JSON.stringify(json),
+                contentType : 'application/json',
+                success : function(data : string){
+                    resolve(data);
+                },
+                error : function(xhr, status, error: string){
+                    reject(error);
+                }
+            });
         });
     }
 
     static async httpPostJSONString(url : string, jsonString : string): Promise<string> {
-        return $.ajax({
-            url : url,
-            type : 'POST',
-            data : jsonString,
-            contentType : 'application/json'
+        return new Promise(async(resolve, reject) => {
+            console.log("httpPostJSONString(", url, ")")
+            $.ajax({
+                url : url,
+                type : 'POST',
+                data : jsonString,
+                contentType : 'application/json',
+                success : function(data : string){
+                    console.log("resolve httpPostJSONString");
+                    resolve(data);
+                },
+                error : function(xhr, status, error: string){
+                    reject(error);
+                }
+            });
         });
     }
 
     static async httpPostForm(url : string, formData : FormData): Promise<string> {
-        return $.ajax({
-            url : url,
-            type : 'POST',
-            data : formData,
-            processData: false,  // tell jQuery not to process the data
-            contentType: false,  // tell jQuery not to set contentType
+        return new Promise(async(resolve, reject) => {
+            return $.ajax({
+                url : url,
+                type : 'POST',
+                data : formData,
+                processData: false,  // tell jQuery not to process the data
+                contentType: false,  // tell jQuery not to set contentType
+                success : function(data : string){
+                    resolve(data);
+                },
+                error : function(xhr, status, error: string){
+                    reject(error);
+                }
+            });
         });
     }
 
@@ -1654,20 +1696,20 @@ export class Utils {
         return true;
     }
 
-    static downloadFile(error : string, data : string, fileName : string) : void {
-        if (error != null){
-            Utils.showUserMessage("Error", "Error saving the file!");
-            console.error(error);
-            return;
-        }
-
-        // NOTE: this stuff is a hacky way of saving a file locally
-        const blob = new Blob([data]);
-        const link = document.createElement('a');
-        link.href = window.URL.createObjectURL(blob);
-        link.download = fileName;
-        document.body.appendChild(link);
-        link.click();
+    static async downloadFile(data : string, fileName : string) : Promise<void> {
+        return new Promise(async(resolve) => {
+            // NOTE: this stuff is a hacky way of saving a file locally
+            const blob = new Blob([data]);
+            const link = document.createElement('a');
+            link.href = window.URL.createObjectURL(blob);
+            link.download = fileName;
+            link.onclick = function(){
+                document.body.removeChild(link);
+                resolve();
+            };
+            document.body.appendChild(link);
+            link.click();
+        });
     }
 
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1728,7 +1728,7 @@ export class Utils {
             // request commit message from the user
             let userString;
             try {
-                userString = Utils.requestUserString("Commit Message", modalMessage, "", false);
+                userString = Utils.requestUserString("Saving to git", modalMessage, "", false);
             } catch (error){
                 reject(error);
                 return;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -318,106 +318,56 @@ export class Utils {
     
     // , successCallback : (data : string) => void, errorCallback : (error : string) => void) : void {
     static async httpGet(url: string): Promise<string> {
-        return new Promise(async(resolve, reject) => {
-            $.ajax({
-                url: url,
-                success: function(data: string) {
-                    resolve(data);
-                },
-                error: function(xhr, status, error: string){
-                    reject(error);
-                }
-            });
+        return $.ajax({
+            url: url
         });
     }
 
     static async httpGetJSON(url: string, json: object): Promise<object> {
-        return new Promise(async(resolve, reject) => {
-            $.ajax({
-                url : url,
-                type : 'GET',
-                data : JSON.stringify(json),
-                contentType : 'application/json',
-                success : function(obj: object){
-                    resolve(obj);
-                },
-                error: function(xhr, status, error: string){
-                    reject(error);
-                }
-            });
+        return $.ajax({
+            url : url,
+            type : 'GET',
+            data : JSON.stringify(json),
+            contentType : 'application/json'
         });
     }
 
     static async httpPost(url : string, data : string): Promise<string> {
-        return new Promise(async(resolve, reject) => {
-            $.ajax({
-                url : url,
-                type : 'POST',
-                data : data,
-                processData: false,  // tell jQuery not to process the data
-                contentType: false,  // tell jQuery not to set contentType
-                success: function(data: string){
-                    resolve(data);
-                },
-                error: function(xhr, status, error: string){
-                    reject(error);
-                }
-            });
+        return $.ajax({
+            url : url,
+            type : 'POST',
+            data : data,
+            processData: false,  // tell jQuery not to process the data
+            contentType: false   // tell jQuery not to set contentType
         });
     }
 
     static async httpPostJSON(url : string, json : object): Promise<string> {
-        return new Promise(async(resolve, reject) => {
-            $.ajax({
-                url : url,
-                type : 'POST',
-                data : JSON.stringify(json),
-                contentType : 'application/json',
-                success : function(data : string){
-                    resolve(data);
-                },
-                error : function(xhr, status, error: string){
-                    reject(error);
-                }
-            });
+        return $.ajax({
+            url : url,
+            type : 'POST',
+            data : JSON.stringify(json),
+            contentType : 'application/json'
         });
     }
 
     static async httpPostJSONString(url : string, jsonString : string): Promise<string> {
-        return new Promise(async(resolve, reject) => {
-            console.log("httpPostJSONString(", url, ")")
-            $.ajax({
-                url : url,
-                type : 'POST',
-                data : jsonString,
-                contentType : 'application/json',
-                success : function(data : string){
-                    console.log("resolve httpPostJSONString");
-                    resolve(data);
-                },
-                error : function(xhr, status, error: string){
-                    reject(error);
-                }
-            });
+        return $.ajax({
+            url : url,
+            type : 'POST',
+            data : jsonString,
+            contentType : 'application/json'
         });
     }
 
     static async httpPostForm(url : string, formData : FormData): Promise<string> {
-        return new Promise(async(resolve, reject) => {
-            return $.ajax({
+        return $.ajax({
                 url : url,
                 type : 'POST',
                 data : formData,
                 processData: false,  // tell jQuery not to process the data
-                contentType: false,  // tell jQuery not to set contentType
-                success : function(data : string){
-                    resolve(data);
-                },
-                error : function(xhr, status, error: string){
-                    reject(error);
-                }
+                contentType: false   // tell jQuery not to set contentType
             });
-        });
     }
 
     static fieldTextToFieldName(text : string) : string {

--- a/templates/translation_menu.html
+++ b/templates/translation_menu.html
@@ -44,8 +44,8 @@
                         </div>
 
                         <p class="card-text"></p>
-                        <button id="alg1PGT" class="btn btn-primary btn_wide generatePgt" value="metis" data-bind="click: function(){eagle.translator().genPGT('metis', false, Daliuge.SchemaVersion.Unknown);}">Generate PGT</button>
-                        <button id="test1PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.translator().genPGT('metis', true, Daliuge.SchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
+                        <button id="alg1PGT" class="btn btn-primary btn_wide generatePgt" value="metis" data-bind="click: function(){eagle.deployTranslationAlgorithm('metis', false);}">Generate PGT</button>
+                        <button id="test1PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.deployTranslationAlgorithm('metis', true);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                     </div>
                 </div>
             </div>
@@ -89,8 +89,8 @@
                         </div>
 
                         <p class="card-text"></p>
-                        <button id="alg2PGT" class="btn btn-primary btn_wide generatePgt" value="mysarkar" data-bind="click: function(){eagle.translator().genPGT('mysarkar', false, Daliuge.SchemaVersion.Unknown);}">Generate PGT</button>
-                        <button id="test2PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.translator().genPGT('mysarkar', true, Daliuge.SchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
+                        <button id="alg2PGT" class="btn btn-primary btn_wide generatePgt" value="mysarkar" data-bind="click: function(){eagle.deployTranslationAlgorithm('mysarkar', false);}">Generate PGT</button>
+                        <button id="test2PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.deployTranslationAlgorithm('mysarkar', true);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                     </div>
                 </div>
             </div>
@@ -152,8 +152,8 @@
                         </div>
 
                         <p class="card-text"></p>
-                        <button id="alg3PGT" class="btn btn-primary btn_wide generatePgt" value="min_num_parts" data-bind="click: function(){eagle.translator().genPGT('min_num_parts', false, Daliuge.SchemaVersion.Unknown);}">Generate PGT</button>
-                        <button id="test3PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.translator().genPGT('min_num_parts', true, Daliuge.SchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
+                        <button id="alg3PGT" class="btn btn-primary btn_wide generatePgt" value="min_num_parts" data-bind="click: function(){eagle.deployTranslationAlgorithm('min_num_parts', false);}">Generate PGT</button>
+                        <button id="test3PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.deployTranslationAlgorithm('min_num_parts', true);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                     </div>
                 </div>
             </div>
@@ -218,8 +218,8 @@
                         </div>
 
                         <p class="card-text"></p>
-                        <button id="alg4PGT" class="btn btn-primary btn_wide generatePgt" value="pso" data-bind="click: function(){eagle.translator().genPGT('pso', false, Daliuge.SchemaVersion.Unknown);}">Generate PGT</button>
-                        <button id="test4PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.translator().genPGT('pso', true, Daliuge.SchemaVersion.Unknown);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
+                        <button id="alg4PGT" class="btn btn-primary btn_wide generatePgt" value="pso" data-bind="click: function(){eagle.deployTranslationAlgorithm('pso', false);}">Generate PGT</button>
+                        <button id="test4PGT" class="btn btn-secondary btn_wide" data-bind="click: function(){eagle.deployTranslationAlgorithm('pso', true);}, eagleTooltip: 'Submit to translator in test mode. All apps will be replaced with placeholders. Useful for debugging.'">Test PGT</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Triggered when a user requests the current graph to be translated.

If the current graph is modified, then the "save" function will be automatically called. The behaviour of the save function depends on the source of the current file. If the file is from git, then the graph will be auto-saved to git. Similarly, if the file is local, then the graph will be saved locally. Some user interaction may be necessary. For example, specifying a commit message if saving to git. The behaviour is exactly the same as the "save graph" quick action.

Once the graph is saved, the graph's modified flag is re-checked. It should be false. If it is false, then the translation will proceed as requested. If it is true for some reason (the file could not be auto-saved) then the translation does not occur and the user is shown an error message.

## Summary by Sourcery

This pull request introduces a change that automatically saves the graph before translation if it has been modified. It also refactors the save functions to use promises.