### PR TITLE
Eagle 1395

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -591,9 +591,11 @@ export class Eagle {
      * It resets all fields in the editor menu.
      */
     resetEditor = () : void => {
-        console.log('resetting the editor')
-        this.selectedObjects([]);
-        Eagle.selectedLocation(Eagle.FileType.Unknown);
+        setTimeout(() => {
+            console.log('resetting the editor')
+            this.selectedObjects([]);
+            Eagle.selectedLocation(Eagle.FileType.Unknown);
+        }, 100);
     }
 
     // if selectedObjects contains nothing but one node, return the node, else null
@@ -629,6 +631,7 @@ export class Eagle {
     setSelection = (selection : Node | Edge, selectedLocation: Eagle.FileType) : void => {
         Eagle.selectedLocation(selectedLocation);
         GraphRenderer.clearPortPeek()
+        console.log('setting selection')
 
         if (selection === null){
             this.selectedObjects([]);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -592,7 +592,6 @@ export class Eagle {
      */
     resetEditor = () : void => {
         setTimeout(() => {
-            console.log('resetting the editor')
             this.selectedObjects([]);
             Eagle.selectedLocation(Eagle.FileType.Unknown);
         }, 100);
@@ -631,7 +630,6 @@ export class Eagle {
     setSelection = (selection : Node | Edge, selectedLocation: Eagle.FileType) : void => {
         Eagle.selectedLocation(selectedLocation);
         GraphRenderer.clearPortPeek()
-        console.log('setting selection')
 
         if (selection === null){
             this.selectedObjects([]);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4302,9 +4302,18 @@ export class Eagle {
                 maxY = maxY + 300
             }
 
-            // choose random position within minimums and maximums determined above
-            const randomX = Math.floor(Math.random() * (maxX - minX + 1) + minX);
-            const randomY = Math.floor(Math.random() * (maxY - minY + 1) + minY);
+            let randomX
+            let randomY
+
+            if (this.logicalGraph().getNumNodes() === 0){
+                //if there are no nodes in the graph we will put the new node in the center of the canvas
+                randomX = minX + (maxX - minX)/2
+                randomY = minY + (maxY - minY)/2
+            }else{
+                // choose random position within minimums and maximums determined above
+                randomX = Math.floor(Math.random() * (maxX - minX + 1) + minX);
+                randomY = Math.floor(Math.random() * (maxY - minY + 1) + minY);
+            }
 
             x = randomX;
             y = randomY;

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4306,8 +4306,8 @@ export class Eagle {
             let randomY
 
             if (this.logicalGraph().getNumNodes() === 0){
-                //if there are no nodes in the graph we will put the new node in the center of the canvas
-                randomX = minX + (maxX - minX)/2
+                //if there are no nodes in the graph we will put the new node to the left of the center of the canvas
+                randomX = minX + (maxX - minX)/4
                 randomY = minY + (maxY - minY)/2
             }else{
                 // choose random position within minimums and maximums determined above

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -591,6 +591,7 @@ export class Eagle {
      * It resets all fields in the editor menu.
      */
     resetEditor = () : void => {
+        console.log('resetting the editor')
         this.selectedObjects([]);
         Eagle.selectedLocation(Eagle.FileType.Unknown);
     }

--- a/src/SideWindow.ts
+++ b/src/SideWindow.ts
@@ -5,6 +5,7 @@ import { Utils } from './Utils';
 import { Setting } from "./Setting";
 import { UiModeSystem } from "./UiModes";
 import { GraphRenderer } from "./GraphRenderer";
+import { Tutorial, TutorialSystem } from "./Tutorial";
 
 export class SideWindow {
     // The width remains on the sidewindow, this is because when we are dragging the width of a side window, there are frequent changes to the width. 
@@ -18,6 +19,11 @@ export class SideWindow {
     }
 
     static toggleShown = (window:string): void => {
+        if(TutorialSystem.activeTut){
+            //if a tutorial is active, the arrow keys are used for navigating through steps
+            return
+        }
+        
         SideWindow.toggleTransition()
 
         if(window === 'left'){

--- a/src/Tutorial.ts
+++ b/src/Tutorial.ts
@@ -111,6 +111,21 @@ export class TutorialSystem {
             return false
         }
     }
+
+    static findInPalettes(target:string) : void {
+        //expand all palettes
+        const paletteElements = $('#paletteList .accordion .paletteCardWrapper')
+        paletteElements.each(function(){
+            if(!$(this).find('.accordion-collapse').hasClass('show')){
+                $(this).find('.accordion-button')[0].click()
+            }
+        })
+
+        //find and scroll to the vertical location of the target node in the palette list
+        $('#paletteList').animate({
+            scrollTop: $(target).offset().top
+        },10);
+    }
 }
 
 export class Tutorial {

--- a/src/Tutorial.ts
+++ b/src/Tutorial.ts
@@ -122,8 +122,9 @@ export class TutorialSystem {
         })
 
         //find and scroll to the vertical location of the target node in the palette list
+        const newScrollPos = $(target).position().top - 100; //the position of the target node in the palette list minus an offset 
         $('#paletteList').animate({
-            scrollTop: $(target).offset().top
+            scrollTop: newScrollPos
         },10);
     }
 }

--- a/src/Tutorial.ts
+++ b/src/Tutorial.ts
@@ -122,10 +122,12 @@ export class TutorialSystem {
         })
 
         //find and scroll to the vertical location of the target node in the palette list
-        const newScrollPos = $(target).position().top - 100; //the position of the target node in the palette list minus an offset 
-        $('#paletteList').animate({
-            scrollTop: newScrollPos
-        },10);
+        setTimeout(() => {
+            const newScrollPos = $(target).position().top - 100; //the position of the target node in the palette list minus an offset 
+            $('#paletteList').animate({
+                scrollTop: newScrollPos
+            },10);
+        }, 100);
     }
 }
 

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -6,52 +6,52 @@ import { Setting } from '../Setting';
 
 const newTut = TutorialSystem.newTutorial('Graph Building', 'An introduction to graph building.')
 
-newTut.newTutStep("Welcome to the Graph Building tutorial!", "You can quit this tutorial anytime using the 'exit' button or ESC key. Please refer to the main <a target='_blank' href='https://eagle-dlg.readthedocs.io'>documentation</a> for in-depth information.", function(){return $("#logicalGraphParent")})
+// newTut.newTutStep("Welcome to the Graph Building tutorial!", "You can quit this tutorial anytime using the 'exit' button or ESC key. Please refer to the main <a target='_blank' href='https://eagle-dlg.readthedocs.io'>documentation</a> for in-depth information.", function(){return $("#logicalGraphParent")})
 
-newTut.newTutStep("Creating a New Graph", "First we are going to create a new graph. Options for creating, loading and saving graphs can be found here. <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
-.setType(TutorialStep.Type.Press)
-.setBackPreFunction(function(){$('.forceShow').removeClass('forceShow');$('.modal').modal("hide");}) //allowing the graph navbar dropdown to hide
+// newTut.newTutStep("Creating a New Graph", "First we are going to create a new graph. Options for creating, loading and saving graphs can be found here. <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
+// .setType(TutorialStep.Type.Press)
+// .setBackPreFunction(function(){$('.forceShow').removeClass('forceShow');$('.modal').modal("hide");}) //allowing the graph navbar dropdown to hide
 
-newTut.newTutStep("Creating a New Graph", "<em>Click on 'New'.</em>", function(){return $("#navbarDropdownGraph").parent().find('.dropdown-item').first()})
-.setType(TutorialStep.Type.Press)
-.setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')}) //keeping the navbar graph dropdown open
-.setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('#createNewGraph').removeClass('forceShow')})//allowing the 'new' drop drop down section to close
-.setBackSkip(true)
+// newTut.newTutStep("Creating a New Graph", "<em>Click on 'New'.</em>", function(){return $("#navbarDropdownGraph").parent().find('.dropdown-item').first()})
+// .setType(TutorialStep.Type.Press)
+// .setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')}) //keeping the navbar graph dropdown open
+// .setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('#createNewGraph').removeClass('forceShow')})//allowing the 'new' drop drop down section to close
+// .setBackSkip(true)
 
-newTut.newTutStep("Creating a New Graph", "<em>Click on 'Create new graph'</em>", function(){return $("#navbarDropdownGraph").parent().find('#createNewGraph')})
-.setType(TutorialStep.Type.Press)
-.setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//keeping the 'new' drop drop down section open as well
-.setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('.dropdown-item').first().parent().addClass('forceShow');TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//force showing both of the navbar graph drop downs
-.setBackSkip(true)
+// newTut.newTutStep("Creating a New Graph", "<em>Click on 'Create new graph'</em>", function(){return $("#navbarDropdownGraph").parent().find('#createNewGraph')})
+// .setType(TutorialStep.Type.Press)
+// .setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//keeping the 'new' drop drop down section open as well
+// .setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('.dropdown-item').first().parent().addClass('forceShow');TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//force showing both of the navbar graph drop downs
+// .setBackSkip(true)
 
-newTut.newTutStep("Creating a new graph", "Then just <em>give it a name and press enter</em>", function(){return $("#inputModalInput")})
-.setWaitType(TutorialStep.Wait.Modal)
-.setType(TutorialStep.Type.Input)
-.setPreFunction(function(){$('.forceShow').removeClass('forceShow')}) //allowing the graph navbar dropdown to hide
-.setBackSkip(true)
+// newTut.newTutStep("Creating a new graph", "Then just <em>give it a name and press enter</em>", function(){return $("#inputModalInput")})
+// .setWaitType(TutorialStep.Wait.Modal)
+// .setType(TutorialStep.Type.Input)
+// .setPreFunction(function(){$('.forceShow').removeClass('forceShow')}) //allowing the graph navbar dropdown to hide
+// .setBackSkip(true)
 
-newTut.newTutStep("Creating a new graph", "<em>And 'Ok' to save!</em>", function(){return $("#inputModal .affirmativeBtn")})
-.setWaitType(TutorialStep.Wait.Modal)
-.setType(TutorialStep.Type.Press)
-.setBackSkip(true)
+// newTut.newTutStep("Creating a new graph", "<em>And 'Ok' to save!</em>", function(){return $("#inputModal .affirmativeBtn")})
+// .setWaitType(TutorialStep.Wait.Modal)
+// .setType(TutorialStep.Type.Press)
+// .setBackSkip(true)
 
-newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Data' which allows you to add a description for your graph. <em>Try clicking it now to try it out</em>", function(){return $("#openGraphModelDataModal")})
-.setType(TutorialStep.Type.Press)
-.setBackPreFunction(function(){$('.modal').modal("hide");}) //hiding open modals
+// newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Data' which allows you to add a description for your graph. <em>Try clicking it now to try it out</em>", function(){return $("#openGraphModelDataModal")})
+// .setType(TutorialStep.Type.Press)
+// .setBackPreFunction(function(){$('.modal').modal("hide");}) //hiding open modals
 
-newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataDescription")})
-.setWaitType(TutorialStep.Wait.Modal)
+// newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataDescription")})
+// .setWaitType(TutorialStep.Wait.Modal)
 
-newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataEagleVersion")})
-.setWaitType(TutorialStep.Wait.Modal)
+// newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataEagleVersion")})
+// .setWaitType(TutorialStep.Wait.Modal)
 
-newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})
-.setWaitType(TutorialStep.Wait.Modal)
-.setType(TutorialStep.Type.Press)
-.setBackPreFunction(function(){$('#modelDataModal').modal('show')})
+// newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})
+// .setWaitType(TutorialStep.Wait.Modal)
+// .setType(TutorialStep.Type.Press)
+// .setBackPreFunction(function(){$('#modelDataModal').modal('show')})
 
 newTut.newTutStep("Palette Components", "Each of these components in a palette performs a function that can be used in your graph", function(){return $("#palette_0_HelloWorldApp")})
-.setPreFunction(function(){SideWindow.setShown('left', true)})
+.setPreFunction(function(){SideWindow.setShown('left', true); TutorialSystem.findInPalettes('#palette_0_HelloWorldApp');})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(450)
 

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -53,7 +53,7 @@ const newTut = TutorialSystem.newTutorial('Graph Building', 'An introduction to 
 newTut.newTutStep("Palette Components", "Each of these components in a palette performs a function that can be used in your graph", function(){return $("#palette_0_HelloWorldApp")})
 .setPreFunction(function(){SideWindow.setShown('left', true); TutorialSystem.findInPalettes('#palette_0_HelloWorldApp');})
 .setWaitType(TutorialStep.Wait.Delay)
-.setDelayAmount(450)
+.setDelayAmount(500)
 
 newTut.newTutStep("Adding base components into the graph", "To add one into the graph, simply click on the icon or drag the component into the graph.<em> Click on the icon to continue.</em>", function(){return $("#addPaletteNodeHelloWorldApp")})
 .setType(TutorialStep.Type.Press)

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -6,49 +6,49 @@ import { Setting } from '../Setting';
 
 const newTut = TutorialSystem.newTutorial('Graph Building', 'An introduction to graph building.')
 
-// newTut.newTutStep("Welcome to the Graph Building tutorial!", "You can quit this tutorial anytime using the 'exit' button or ESC key. Please refer to the main <a target='_blank' href='https://eagle-dlg.readthedocs.io'>documentation</a> for in-depth information.", function(){return $("#logicalGraphParent")})
+newTut.newTutStep("Welcome to the Graph Building tutorial!", "You can quit this tutorial anytime using the 'exit' button or ESC key. Please refer to the main <a target='_blank' href='https://eagle-dlg.readthedocs.io'>documentation</a> for in-depth information.", function(){return $("#logicalGraphParent")})
 
-// newTut.newTutStep("Creating a New Graph", "First we are going to create a new graph. Options for creating, loading and saving graphs can be found here. <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
-// .setType(TutorialStep.Type.Press)
-// .setBackPreFunction(function(){$('.forceShow').removeClass('forceShow');$('.modal').modal("hide");}) //allowing the graph navbar dropdown to hide
+newTut.newTutStep("Creating a New Graph", "First we are going to create a new graph. Options for creating, loading and saving graphs can be found here. <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
+.setType(TutorialStep.Type.Press)
+.setBackPreFunction(function(){$('.forceShow').removeClass('forceShow');$('.modal').modal("hide");}) //allowing the graph navbar dropdown to hide
 
-// newTut.newTutStep("Creating a New Graph", "<em>Click on 'New'.</em>", function(){return $("#navbarDropdownGraph").parent().find('.dropdown-item').first()})
-// .setType(TutorialStep.Type.Press)
-// .setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')}) //keeping the navbar graph dropdown open
-// .setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('#createNewGraph').removeClass('forceShow')})//allowing the 'new' drop drop down section to close
-// .setBackSkip(true)
+newTut.newTutStep("Creating a New Graph", "<em>Click on 'New'.</em>", function(){return $("#navbarDropdownGraph").parent().find('.dropdown-item').first()})
+.setType(TutorialStep.Type.Press)
+.setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')}) //keeping the navbar graph dropdown open
+.setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('#createNewGraph').removeClass('forceShow')})//allowing the 'new' drop drop down section to close
+.setBackSkip(true)
 
-// newTut.newTutStep("Creating a New Graph", "<em>Click on 'Create new graph'</em>", function(){return $("#navbarDropdownGraph").parent().find('#createNewGraph')})
-// .setType(TutorialStep.Type.Press)
-// .setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//keeping the 'new' drop drop down section open as well
-// .setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('.dropdown-item').first().parent().addClass('forceShow');TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//force showing both of the navbar graph drop downs
-// .setBackSkip(true)
+newTut.newTutStep("Creating a New Graph", "<em>Click on 'Create new graph'</em>", function(){return $("#navbarDropdownGraph").parent().find('#createNewGraph')})
+.setType(TutorialStep.Type.Press)
+.setPreFunction(function(){TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//keeping the 'new' drop drop down section open as well
+.setBackPreFunction(function(){$("#navbarDropdownGraph").parent().find('.dropdown-item').first().parent().addClass('forceShow');TutorialSystem.activeTutCurrentStep.getTargetFunc()().parent().addClass('forceShow')})//force showing both of the navbar graph drop downs
+.setBackSkip(true)
 
-// newTut.newTutStep("Creating a new graph", "Then just <em>give it a name and press enter</em>", function(){return $("#inputModalInput")})
-// .setWaitType(TutorialStep.Wait.Modal)
-// .setType(TutorialStep.Type.Input)
-// .setPreFunction(function(){$('.forceShow').removeClass('forceShow')}) //allowing the graph navbar dropdown to hide
-// .setBackSkip(true)
+newTut.newTutStep("Creating a new graph", "Then just <em>give it a name and press enter</em>", function(){return $("#inputModalInput")})
+.setWaitType(TutorialStep.Wait.Modal)
+.setType(TutorialStep.Type.Input)
+.setPreFunction(function(){$('.forceShow').removeClass('forceShow')}) //allowing the graph navbar dropdown to hide
+.setBackSkip(true)
 
-// newTut.newTutStep("Creating a new graph", "<em>And 'Ok' to save!</em>", function(){return $("#inputModal .affirmativeBtn")})
-// .setWaitType(TutorialStep.Wait.Modal)
-// .setType(TutorialStep.Type.Press)
-// .setBackSkip(true)
+newTut.newTutStep("Creating a new graph", "<em>And 'Ok' to save!</em>", function(){return $("#inputModal .affirmativeBtn")})
+.setWaitType(TutorialStep.Wait.Modal)
+.setType(TutorialStep.Type.Press)
+.setBackSkip(true)
 
-// newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Data' which allows you to add a description for your graph. <em>Try clicking it now to try it out</em>", function(){return $("#openGraphModelDataModal")})
-// .setType(TutorialStep.Type.Press)
-// .setBackPreFunction(function(){$('.modal').modal("hide");}) //hiding open modals
+newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Data' which allows you to add a description for your graph. <em>Try clicking it now to try it out</em>", function(){return $("#openGraphModelDataModal")})
+.setType(TutorialStep.Type.Press)
+.setBackPreFunction(function(){$('.modal').modal("hide");}) //hiding open modals
 
-// newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataDescription")})
-// .setWaitType(TutorialStep.Wait.Modal)
+newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataDescription")})
+.setWaitType(TutorialStep.Wait.Modal)
 
-// newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataEagleVersion")})
-// .setWaitType(TutorialStep.Wait.Modal)
+newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataEagleVersion")})
+.setWaitType(TutorialStep.Wait.Modal)
 
-// newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})
-// .setWaitType(TutorialStep.Wait.Modal)
-// .setType(TutorialStep.Type.Press)
-// .setBackPreFunction(function(){$('#modelDataModal').modal('show')})
+newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})
+.setWaitType(TutorialStep.Wait.Modal)
+.setType(TutorialStep.Type.Press)
+.setBackPreFunction(function(){$('#modelDataModal').modal('show')})
 
 newTut.newTutStep("Palette Components", "Each of these components in a palette performs a function that can be used in your graph", function(){return $("#palette_0_HelloWorldApp")})
 .setPreFunction(function(){SideWindow.setShown('left', true); TutorialSystem.findInPalettes('#palette_0_HelloWorldApp');})


### PR DESCRIPTION
there are a few fixes for the tutorial here

the left and right arrow key shortcuts for toggling the left and right window have been suppressed while in the tutorial as these are used for navigating through the tutorial steps

i have created a new function to find a node in the palette. this will open all the palettes and scroll the palette list to find the node we are requesting in the tutorial step.

there was an additional issue with the step requesting the selection of the newly added 'helloWorldApp' node in the graph. that should also be working as intended again.

adjusted the random placement function for nodes, it will now place the first node to the left of the center of the canvas

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the 'helloWorldApp' node was not being correctly selected in the graph during the tutorial.