### PR TITLE
EAGLE-1290: Check for matching func_name and func_code fields in PyFuncApp

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -159,6 +159,9 @@ export namespace Daliuge {
     export const baseNameField = new Field(null, FieldName.BASE_NAME, "", "", "The base name of the class of this Member function", false, DataType.String, false, [], false, FieldType.ComponentParameter, FieldUsage.NoPort);
     export const selfField = new Field(null, FieldName.SELF, "", "", "", false, DataType.Object, false, [], false, FieldType.ComponentParameter, FieldUsage.InputOutput);
 
+    export const funcCodeField = new Field(null, FieldName.FUNC_CODE, "", "def func_name(args): return args", "Python function code", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.ComponentParameter, FieldUsage.NoPort);
+    export const funcNameField = new Field(null, FieldName.FUNC_NAME, "", "func_name", "Python function name", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.ComponentParameter, FieldUsage.NoPort);
+
     // This list defines the fields required for ALL nodes belonging to a given Category.Type
     // NOTE: ids are empty string here, we should generate a new id whenever we clone the fields
     export const categoryTypeFieldsRequired = [
@@ -243,6 +246,15 @@ export namespace Daliuge {
             fields: [
                 Daliuge.baseNameField,
                 Daliuge.selfField
+            ]
+        },
+        {
+            categories: [
+                Category.PythonApp
+            ],
+            fields: [
+                Daliuge.funcCodeField,
+                Daliuge.funcNameField
             ]
         }
     ];

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -250,7 +250,8 @@ export namespace Daliuge {
         },
         {
             categories: [
-                Category.PythonApp
+                Category.PythonApp,
+                Category.PythonMemberFunction
             ],
             fields: [
                 Daliuge.funcCodeField,


### PR DESCRIPTION
Adds requirements for PyFuncApp and PythonMemberFunction components to contain "func_name", "func_code" fields.

Also add check (for PyFuncApp ONLY) that the value specified in "func_name" is found within "func_code". I didn't add this check for PythonMemberFunction, since the default func_name is "__init__" which would be found in the originating source code, rather than within func_code.

NOTE: This change does not fix the existing issue where the graph is NOT checked after a field value change. To trigger the graph to be rechecked, a larger change is required (add/remove node, add/remove field etc)

## Summary by Sourcery

Adds validation to PyFuncApp and PythonMemberFunction components to ensure they contain 'func_name' and 'func_code' fields. For PyFuncApp components, it also validates that the 'func_name' value is present within the 'func_code' field.