### PR TITLE
improved modals and fixed a navbar issue on small screens

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1081,6 +1081,13 @@ select.form-control{
     filter: drop-shadow(2px 7px 10px #000);
 }
 
+@media only screen and (max-width: 1920px) {
+    .modal-content {
+        height:80vh;
+        width:80vw;
+    }
+}
+
 .modal-body{
     height: calc(100% - 103px) !important ;
     top: 50px;
@@ -2050,6 +2057,12 @@ ul.nav.navbar-nav .dropdown-item:hover{
     position: absolute;
     left: 50%;
     transform: translatex(-50%) !important;
+}
+
+@media only screen and (max-width: 1380px) {
+    .navbar-nav.navbar-center {
+        left: 40%;
+    }
 }
 
 .template-title {

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -30,10 +30,13 @@
                 <button id="copyGraphUrl" class="btn btn-outline-secondary navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: copyGraphUrl, eagleTooltip: 'Copy Graph Url'" >
                     <i class="material-icons md-18">content_copy</i>
                 </button>
+                <button id="centerGraph" class="btn btn-outline-secondary navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: centerGraph, eagleTooltip: 'Center Graph ' + KeyboardShortcut.idToText('center_graph', true)" >
+                    <i class="material-icons md-18">filter_center_focus</i>
+                </button>
             </div>
 
             <!-- navbar category -->
-            <div class="btn-group ms-4 navbarGroup" role="group" aria-label="Basic example">
+            <!-- <div class="btn-group ms-4 navbarGroup" role="group" aria-label="Basic example">
                 <button id="centerGraph" class="btn btn-outline-secondary navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: centerGraph, eagleTooltip: 'Center Graph ' + KeyboardShortcut.idToText('center_graph', true)" >
                     <i class="material-icons md-18">filter_center_focus</i>
                 </button>
@@ -41,7 +44,7 @@
                     <i class="material-icons md-18">photo_camera</i>
                 </button>
                 <span class="navBarToolBarTitle">View</span>
-            </div>
+            </div> -->
 
             <!-- navbar category -->
             <div class="btn-group ms-4 navbarGroup" role="group" aria-label="Basic example">
@@ -132,6 +135,7 @@
                         </span>
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item" id="displayGraphAsJson" href="#" data-bind="click: function(){displayObjectAsJson(Eagle.FileType.Graph);}">Display As Json</a>
+                        <a class="dropdown-item" id="screenshotGraph" href="#" data-bind="click: saveGraphScreenshot">Screenshot</a>
                     <!-- /ko -->
                     <!-- ko ifnot: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <a class="dropdown-item" id="saveGraph" href="#" data-bind="click: function(){saveFileToLocal(Eagle.FileType.Graph)}">Save</a>


### PR DESCRIPTION
## Summary by Sourcery

Improves the styling of modals on larger screens and fixes an issue where the navbar was not properly centered on smaller screens. Also, adds a screenshot option to the graph menu.

Enhancements:
- Improves the styling of modals on larger screens to occupy 80% of the viewport height and width.
- Adjusts the navbar centering on smaller screens (max-width: 1380px) by setting the left position to 40% to maintain proper alignment.
- Adds a 'Screenshot' option to the graph menu, allowing users to save a screenshot of the graph.