### PR TITLE
EAGLE-1409: Changed EagleConfig.colors from an array to a dict

### DIFF
--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -1,117 +1,48 @@
-const colors: { name: string; color: string; }[] = [
+const colors: { [name: string]:string } = 
     {
-    //node colors
-        name: 'bodyBorder',
-        color: '#2e3192'
-    },{
-        name: 'branchBg',
-        color: '#dcdee2'
-    },{
-        name: 'constructBg',
-        color: '#05142912'
-    },{
-        name: 'embeddedApp',
-        color: '#dcdee2'
-    },{
-        name: 'constructIcon',
-        color: '#0000000f'
-    },{
-        name: 'graphText',
-        color: 'black'
-    },{
-        name: 'nodeBg',
-        color: 'white'
-    },{
-        name: 'nodeInputPort',
-        color: '#2bb673'
-    },{
-        name: 'nodeOutputPort',
-        color: '#4346ac'
-    },{
-        name: 'nodeUtilPort',
-        color: '#6fa7f1'
-    },{
-        name: 'selectBackground',
-        color: '#b4d4ff'
-    },{
-        name: 'selectConstructBackground',
-        color: '#85b9ff94'
-    },{
-        name: 'errorBackground',
-        color: '#ffdcdc'
-    },{
-        name: 'warningBackground',
-        color: '#ffeac4'
-    },{
+        bodyBorder:                  '#2e3192',
+        branchBackground:            '#dcdee2',
+        constructBackground:         '#05142912',
+        embeddedApp:                 '#dcdee2',
+        constructIcon:               '#0000000f',
+        graphText:                   'black',
+        nodeBackground:              'white',
+        nodeInputPort:               '#2bb673',
+        nodeOutputPort:              '#4346ac',
+        nodeUtilPort:                '#6fa7f1',
+        selectBackground:            '#b4d4ff',
+        selectedConstructBackground: '#85b9ff94',
+        errorBackground:             '#ffdcdc',
+        warningBackground:           '#ffeac4',
 
-    //edge colors
-        name: 'edgeDefault',
-        color: '#58595b'
-    },{
-        name: 'edgeDefaultSelected',
-        color: '#4247df'
-    },{
-        name: 'commentEdge',
-        color: '#7c7e81'
-    },{
-        name: 'edgeValid',
-        color: '#32cd32'
-    },{
-        name: 'edgeWarning',
-        color: '#ffa500'
-    },{
-        name: 'edgeFixable',
-        color: '#6dc7bd'
-    },{
-        name: 'edgeWarningSelected',
-        color: '#4247df'
-    },{
-        name: 'edgeInvalid',
-        color: '#ff0000'
-    },{
-        name: 'edgeInvalidSelected',
-        color: '#4247df'
-    },{
-        name: 'edgeEvent',
-        color: '#a6a6fe'
-    },{
-        name: 'edgeEventSelected',
-        color: '#4247df'
-    },{
-        name: 'edgeAutoCompleteSuggestion',
-        color: '#dbcfe1'
-    },{
-        name: 'edgeAutoComplete',
-        color: '#9c3bca'
-    },{
-        name: 'edgeClosesLoop',
-        color: '#58595b'
-    },{
-        name: 'edgeClosesLoopSelected',
-        color: '#4247df'
-    },{
+        // edge colors
+        edgeDefault:                 '#58595b',
+        edgeDefaultSelected:         '#4247df',
+        commentEdge:                 '#7c7e81',
+        edgeValid:                   '#32cd32',
+        edgeWarning:                 '#ffa500',
+        edgeFixable:                 '#6dc7bd',
+        edgeWarningSelected:         '#4247df',
+        edgeInvalid:                 '#ff0000',
+        edgeInvalidSelected:         '#4247df',
+        edgeEvent:                   '#a6a6fe',
+        edgeEventSelected:           '#4247df',
+        edgeAutoCompleteSuggestion:  '#dbcfe1',
+        edgeAutoComplete:            '#9c3bca',
+        edgeClosesLoop:              '#58595b',
+        edgeClosesLoopSelected:      '#4247df',
 
-    // hierarchy colors
-        name: 'hierarchyEdgeSelectedColor',
-        color: '#2F16D5'
-    },{
-        name: 'hierarchyEdgeDefaultColor',
-        color: '#000000'
-    },{
+        // hierarchy colors
+        hierarchyEdgeSelected:       '#2F16D5',
+        hierarchyEdgeDefault:        '#000000',
 
-    //graph issue colors
-        name: 'graphError',
-        color: '#ea2727'
-    },{
-        name: 'graphWarning',
-        color: '#ffa500'
-    },{
+        // graph issue colors
+        graphError:                  '#ea2727',
+        graphWarning:                '#ffa500',
         
-    //eagle colors
-        name: 'hoverHighlight',
-        color: '#feb609'
-    }
-]
+        // eagle colors
+        hoverHighlight:              '#feb609'
+    };
 
 export class EagleConfig {
 
@@ -142,16 +73,9 @@ export class EagleConfig {
     public static readonly JSON_INDENT: number = 4;
 
     static getColor(name:string) : string {
-        let result: string = null;
+        let result: string = colors[name];
 
-        for (const color of colors) {
-            if(color.name === name){
-                result = color.color
-                break;
-            }
-        }
-
-        if (result === null){
+        if (typeof result === 'undefined'){
             console.warn("EagleConfig.getColor() could not find color with name", name);
             result = 'red';
         }
@@ -162,12 +86,12 @@ export class EagleConfig {
     static initCSS(){
         //overwriting css variables using colors from EagleConfig. I am using this for simple styling to avoid excessive css data binds in the node html files
         $("#logicalGraphParent").get(0).style.setProperty("--selectedBg", EagleConfig.getColor('selectBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--selectedConstructBg", EagleConfig.getColor('selectConstructBackground'));
+        $("#logicalGraphParent").get(0).style.setProperty("--selectedConstructBackground", EagleConfig.getColor('selectedConstructBackground'));
         $("#logicalGraphParent").get(0).style.setProperty("--nodeBorder", EagleConfig.getColor('bodyBorder'));
-        $("#logicalGraphParent").get(0).style.setProperty("--nodeBg", EagleConfig.getColor('nodeBg'));
+        $("#logicalGraphParent").get(0).style.setProperty("--nodeBackground", EagleConfig.getColor('nodeBackground'));
         $("#logicalGraphParent").get(0).style.setProperty("--graphText", EagleConfig.getColor('graphText'));
-        $("#logicalGraphParent").get(0).style.setProperty("--branchBg", EagleConfig.getColor('branchBg'));
-        $("#logicalGraphParent").get(0).style.setProperty("--constructBg", EagleConfig.getColor('constructBg'));
+        $("#logicalGraphParent").get(0).style.setProperty("--branchBackground", EagleConfig.getColor('branchBackground'));
+        $("#logicalGraphParent").get(0).style.setProperty("--constructBackground", EagleConfig.getColor('constructBackground'));
         $("#logicalGraphParent").get(0).style.setProperty("--embeddedApp", EagleConfig.getColor('embeddedApp'));
         $("#logicalGraphParent").get(0).style.setProperty("--constructIcon", EagleConfig.getColor('constructIcon'));
         $("#logicalGraphParent").get(0).style.setProperty("--commentEdgeColor", EagleConfig.getColor('commentEdge'));

--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -1,4 +1,4 @@
-const colors: { [name: string]:string } = 
+const colors: {[name: string]: string} =
     {
         bodyBorder:                  '#2e3192',
         branchBackground:            '#dcdee2',

--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -1,49 +1,50 @@
-const colors: {[name: string]: string} =
-    {
-        // node colors
-        bodyBorder:                  '#2e3192',
-        branchBackground:            '#dcdee2',
-        constructBackground:         '#05142912',
-        embeddedApp:                 '#dcdee2',
-        constructIcon:               '#0000000f',
-        graphText:                   'black',
-        nodeBackground:              'white',
-        nodeInputPort:               '#2bb673',
-        nodeOutputPort:              '#4346ac',
-        nodeUtilPort:                '#6fa7f1',
-        selectBackground:            '#b4d4ff',
-        selectedConstructBackground: '#85b9ff94',
-        errorBackground:             '#ffdcdc',
-        warningBackground:           '#ffeac4',
+type ColorMap = {[name: string]: string};
 
-        // edge colors
-        edgeDefault:                 '#58595b',
-        edgeDefaultSelected:         '#4247df',
-        commentEdge:                 '#7c7e81',
-        edgeValid:                   '#32cd32',
-        edgeWarning:                 '#ffa500',
-        edgeFixable:                 '#6dc7bd',
-        edgeWarningSelected:         '#4247df',
-        edgeInvalid:                 '#ff0000',
-        edgeInvalidSelected:         '#4247df',
-        edgeEvent:                   '#a6a6fe',
-        edgeEventSelected:           '#4247df',
-        edgeAutoCompleteSuggestion:  '#dbcfe1',
-        edgeAutoComplete:            '#9c3bca',
-        edgeClosesLoop:              '#58595b',
-        edgeClosesLoopSelected:      '#4247df',
+const colors: ColorMap = {
+    // node colors
+    bodyBorder:                  '#2e3192',
+    branchBackground:            '#dcdee2',
+    constructBackground:         '#05142912',
+    embeddedApp:                 '#dcdee2',
+    constructIcon:               '#0000000f',
+    graphText:                   'black',
+    nodeBackground:              'white',
+    nodeInputPort:               '#2bb673',
+    nodeOutputPort:              '#4346ac',
+    nodeUtilPort:                '#6fa7f1',
+    selectBackground:            '#b4d4ff',
+    selectedConstructBackground: '#85b9ff94',
+    errorBackground:             '#ffdcdc',
+    warningBackground:           '#ffeac4',
 
-        // hierarchy colors
-        hierarchyEdgeSelected:       '#2F16D5',
-        hierarchyEdgeDefault:        '#000000',
+    // edge colors
+    edgeDefault:                 '#58595b',
+    edgeDefaultSelected:         '#4247df',
+    commentEdge:                 '#7c7e81',
+    edgeValid:                   '#32cd32',
+    edgeWarning:                 '#ffa500',
+    edgeFixable:                 '#6dc7bd',
+    edgeWarningSelected:         '#4247df',
+    edgeInvalid:                 '#ff0000',
+    edgeInvalidSelected:         '#4247df',
+    edgeEvent:                   '#a6a6fe',
+    edgeEventSelected:           '#4247df',
+    edgeAutoCompleteSuggestion:  '#dbcfe1',
+    edgeAutoComplete:            '#9c3bca',
+    edgeClosesLoop:              '#58595b',
+    edgeClosesLoopSelected:      '#4247df',
 
-        // graph issue colors
-        graphError:                  '#ea2727',
-        graphWarning:                '#ffa500',
-        
-        // eagle colors
-        hoverHighlight:              '#feb609'
-    };
+    // hierarchy colors
+    hierarchyEdgeSelected:       '#2F16D5',
+    hierarchyEdgeDefault:        '#000000',
+
+    // graph issue colors
+    graphError:                  '#ea2727',
+    graphWarning:                '#ffa500',
+    
+    // eagle colors
+    hoverHighlight:              '#feb609'
+};
 
 export class EagleConfig {
 
@@ -85,20 +86,22 @@ export class EagleConfig {
     }
 
     static initCSS(){
+        const style: CSSStyleDeclaration = $("#logicalGraphParent").get(0).style;
+
         //overwriting css variables using colors from EagleConfig. I am using this for simple styling to avoid excessive css data binds in the node html files
-        $("#logicalGraphParent").get(0).style.setProperty("--selectedBg", EagleConfig.getColor('selectBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--selectedConstructBackground", EagleConfig.getColor('selectedConstructBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--nodeBorder", EagleConfig.getColor('bodyBorder'));
-        $("#logicalGraphParent").get(0).style.setProperty("--nodeBackground", EagleConfig.getColor('nodeBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--graphText", EagleConfig.getColor('graphText'));
-        $("#logicalGraphParent").get(0).style.setProperty("--branchBackground", EagleConfig.getColor('branchBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--constructBackground", EagleConfig.getColor('constructBackground'));
-        $("#logicalGraphParent").get(0).style.setProperty("--embeddedApp", EagleConfig.getColor('embeddedApp'));
-        $("#logicalGraphParent").get(0).style.setProperty("--constructIcon", EagleConfig.getColor('constructIcon'));
-        $("#logicalGraphParent").get(0).style.setProperty("--commentEdgeColor", EagleConfig.getColor('commentEdge'));
-        $("#logicalGraphParent").get(0).style.setProperty("--matchingEdgeColor", EagleConfig.getColor('edgeAutoComplete'));
-        $("#logicalGraphParent").get(0).style.setProperty("--nodeOutputColor", EagleConfig.getColor('nodeOutputPort'));
-        $("#logicalGraphParent").get(0).style.setProperty("--nodeInputColor", EagleConfig.getColor('nodeInputPort'));
+        style.setProperty("--selectedBg", EagleConfig.getColor('selectBackground'));
+        style.setProperty("--selectedConstructBackground", EagleConfig.getColor('selectedConstructBackground'));
+        style.setProperty("--nodeBorder", EagleConfig.getColor('bodyBorder'));
+        style.setProperty("--nodeBackground", EagleConfig.getColor('nodeBackground'));
+        style.setProperty("--graphText", EagleConfig.getColor('graphText'));
+        style.setProperty("--branchBackground", EagleConfig.getColor('branchBackground'));
+        style.setProperty("--constructBackground", EagleConfig.getColor('constructBackground'));
+        style.setProperty("--embeddedApp", EagleConfig.getColor('embeddedApp'));
+        style.setProperty("--constructIcon", EagleConfig.getColor('constructIcon'));
+        style.setProperty("--commentEdgeColor", EagleConfig.getColor('commentEdge'));
+        style.setProperty("--matchingEdgeColor", EagleConfig.getColor('edgeAutoComplete'));
+        style.setProperty("--nodeOutputColor", EagleConfig.getColor('nodeOutputPort'));
+        style.setProperty("--nodeInputColor", EagleConfig.getColor('nodeInputPort'));
         $("html").get(0).style.setProperty("--hoverHighlight", EagleConfig.getColor('hoverHighlight'));
     }
 }

--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -1,5 +1,6 @@
 const colors: {[name: string]: string} =
     {
+        // node colors
         bodyBorder:                  '#2e3192',
         branchBackground:            '#dcdee2',
         constructBackground:         '#05142912',

--- a/src/Hierarchy.ts
+++ b/src/Hierarchy.ts
@@ -177,7 +177,7 @@ export class Hierarchy {
         const parentScrollOffset = $(".rightWindowDisplay.hierarchy").scrollTop()
 
         // determine colour of edge
-        const colour: string = edgeSelected ? EagleConfig.getColor('hierarchyEdgeSelectedColor') : EagleConfig.getColor('hierarchyEdgeDefaultColor');
+        const colour: string = edgeSelected ? EagleConfig.getColor('hierarchyEdgeSelected') : EagleConfig.getColor('hierarchyEdgeDefault');
 
         let p1x, p1y, p2x, p2y, arrowX, mpx;
         if(use==="input"){

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1182,7 +1182,7 @@ export class Node {
             if(eagle.objectIsSelectedById(this.id())){
                 return EagleConfig.getColor('selectBackground')
             }else{
-                return EagleConfig.getColor('nodeBg');
+                return EagleConfig.getColor('nodeBackground');
             }
         }else{
             return '' //returning nothing lets the means we are not over writing the default css behaviour

--- a/static/graph.css
+++ b/static/graph.css
@@ -1,12 +1,12 @@
 #logicalGraphParent{
     /* declaring custom variables used in css set via ts later from the graph config variables */
     --selectedBg : red;
-    --selectedConstructBg:red;
+    --selectedConstructBackground:red;
     --nodeBorder : red;
-    --nodeBg:red;
+    --nodeBackground:red;
     --graphText:red;
-    --branchBg:red;
-    --constructBg:red;
+    --branchBackground:red;
+    --constructBackground:red;
     --embeddedApp:red;
     --constructIcon:red;
     --edgeColor:red;
@@ -189,7 +189,7 @@
 
 .node .body {
     position: relative;
-    background-color: var(--nodeBg);
+    background-color: var(--nodeBackground);
     border-radius: 50%;
     border: 1.5px solid var(--nodeBorder);
     width: 100%;
@@ -203,7 +203,7 @@
 }
 
 .node .innerRing {
-    background-color: var(--nodeBg);
+    background-color: var(--nodeBackground);
     border-radius: 50%;
     border: 1.5px solid var(--nodeBorder);
     position: absolute;
@@ -215,7 +215,7 @@
     border-radius: 50%;
     border: 1.5px solid var(--nodeBorder);
     position: absolute;
-    background-color: var(--branchBg);
+    background-color: var(--branchBackground);
     inset: -7px -7px -7px -7px;
     box-shadow: -2px 5px 5px -4px #555555;
 }
@@ -234,7 +234,7 @@
 }
 
 .node .construct_node .body {
-    background-color: var(--constructBg);
+    background-color: var(--constructBackground);
 }
 
 .node .construct_node .basic_node .body {
@@ -346,7 +346,7 @@
 }
 
 .node .construct_node .container.selected .body {
-    background-color: var(--selectedConstructBg);
+    background-color: var(--selectedConstructBackground);
 }
 
 .node .construct_node .basic_node .container.selected .body {


### PR DESCRIPTION
Updated supporting functions.
Removed 'bg' abbreviation in some color names, use 'background' instead.

## Summary by Sourcery

Refactor EagleConfig colors from an array of objects to a dictionary for improved readability and access

Bug Fixes:
- Updated color name references to use more descriptive and consistent naming (e.g., 'branchBg' to 'branchBackground')

Enhancements:
- Converted color configuration from an array of objects with 'name' and 'color' properties to a dictionary with color names as keys and color values as values

Chores:
- Simplified color retrieval method by using direct dictionary lookup instead of array iteration