### PR TITLE
EAGLE-1392: Better text for App-to-App edge errors

### DIFF
--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -325,7 +325,7 @@ export class Edge {
 
         // check that we are not connecting an Application component to an Application component, that is not supported
         if (sourceNode.getCategoryType() === Category.Type.Application && destinationNode.getCategoryType() === Category.Type.Application){
-            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Fixable, Errors.ShowFix("Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixAppToAppEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Fixable, Errors.ShowFix("Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixAppToAppEdge(eagle, edgeId);}, "Add intermediate Data node between edge's source and destination app nodes"), showNotification, showConsole, errorsWarnings);
         }
 
         // if source node or destination node is a construct, then something is wrong, constructs should not have ports

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -325,7 +325,7 @@ export class Edge {
 
         // check that we are not connecting an Application component to an Application component, that is not supported
         if (sourceNode.getCategoryType() === Category.Type.Application && destinationNode.getCategoryType() === Category.Type.Application){
-            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Fixable, Errors.Show("Inserted Data node as Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
+            Edge.isValidLog(edge, draggingPortMode, Errors.Validity.Fixable, Errors.ShowFix("Application nodes may not be connected directly to other Application nodes", function(){Utils.showEdge(eagle, edgeId);}, function(){Utils.fixAppToAppEdge(eagle, edgeId);}), showNotification, showConsole, errorsWarnings);
         }
 
         // if source node or destination node is a construct, then something is wrong, constructs should not have ports
@@ -523,6 +523,10 @@ export class Edge {
             case Errors.Validity.Error:
                 title = "Edge Invalid";
                 type = "danger";
+                break;
+            case Errors.Validity.Fixable:
+                title = "Edge Fixed";
+                type = "info";
                 break;
         }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2058,6 +2058,17 @@ export class Utils {
         field.setParameterType(newType);
     }
 
+    static fixAppToAppEdge(eagle: Eagle, edgeId: EdgeId){
+        const edge: Edge = eagle.logicalGraph().findEdgeById(edgeId);
+        const srcNode: Node = eagle.logicalGraph().findNodeByIdQuiet(edge.getSrcNodeId());
+        const destNode: Node = eagle.logicalGraph().findNodeByIdQuiet(edge.getDestNodeId());
+        const srcPort: Field = srcNode.findFieldById(edge.getSrcPortId());
+        const destPort: Field = destNode.findFieldById(edge.getDestPortId());
+
+        eagle.logicalGraph().removeEdgeById(edge.getId());
+        eagle.addEdge(srcNode, srcPort, destNode, destPort, edge.isLoopAware(), edge.isClosesLoop())
+    }
+
     static addMissingRequiredField(eagle: Eagle, node: Node, requiredField: Field){
         // if requiredField is "dropclass", and node already contains an "appclass" field, then just rename it
         if (requiredField.getDisplayText() === Daliuge.FieldName.DROP_CLASS){


### PR DESCRIPTION
Changed the error message to be more similar to the wording of similar errors.
Better display of Errors.Validity.Fixable errors in notifications
Added a fix function and description  for app-to-app edges

## Summary by Sourcery

Improve error handling and messaging for app-to-app edges in the logical graph

New Features:
- Implement a function to automatically add an intermediate data node between application nodes

Bug Fixes:
- Improve display of fixable edge errors in notifications

Enhancements:
- Enhance error messaging for app-to-app edge connections
- Add a fix mechanism for app-to-app edge validation errors