### PR TITLE
EAGLE-1431: Stop EAGLE overwriting modelData when loading palettes

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -944,18 +944,9 @@ def open_url_file():
     if not "modelData" in graph:
         graph["modelData"] = {}
 
-    # add the repository information
-    graph["modelData"]["repo"] = ""
-    graph["modelData"]["repoBranch"] = ""
+    # overwrite some modelData information
     graph["modelData"]["repoService"] = "Url"
-    graph["modelData"]["filePath"] = ""
-
-    # add the GitLab file information
-    graph["modelData"]["commitHash"] = ""
     graph["modelData"]["downloadUrl"] = url
-    graph["modelData"]["lastModifiedName"] = ""
-    graph["modelData"]["lastModifiedEmail"] = ""
-    graph["modelData"]["lastModifiedDatetime"] = 0
 
     # for palettes, put downloadUrl in every component
     if extension == ".palette":

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3255,7 +3255,6 @@ export class Eagle {
 
             // mark the palette as modified
             destinationPalette.fileInfo().modified = true;
-            destinationPalette.sort();
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -796,7 +796,6 @@ export class Utils {
     }
 
     static preparePalette(palette: Palette, paletteListItem: {name:string, filename:string, readonly:boolean, expanded: boolean}) : void {
-        palette.fileInfo().clear();
         palette.fileInfo().name = paletteListItem.name;
         palette.fileInfo().readonly = paletteListItem.readonly;
         palette.fileInfo().builtIn = true;

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -43,7 +43,7 @@ newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Da
 newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataDescription")})
 .setWaitType(TutorialStep.Wait.Modal)
 
-newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataEagleVersion")})
+newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataGeneratorVersion")})
 .setWaitType(TutorialStep.Wait.Modal)
 
 newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})

--- a/templates/modals/model_data.html
+++ b/templates/modals/model_data.html
@@ -16,19 +16,19 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td data-bind="text: 'File Type', eagleTooltip: 'The type of content in the file. Options: ' + Utils.enumKeys(Eagle.FileType)"></td>
+                            <td data-bind="eagleTooltip: 'The type of content in the file. Options: ' + Utils.enumKeys(Eagle.FileType)">File Type</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._type"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Location', eagleTooltip: 'The location in which this file is stored'"></td>
+                            <td data-bind="eagleTooltip: 'The location in which this file is stored'">Location</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo().getText()"></td>
                             <!-- /ko -->
                         </tr>
                         <tr id="modelDataDescription">
-                            <td data-bind="text: 'Short Descripton', eagleTooltip: 'A one-line description of the purpose of this file'"></td>
+                            <td data-bind="eagleTooltip: 'A one-line description of the purpose of this file'">Short Description</td>
                             <!-- ko if: $root.currentFileInfo -->
                             <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                                 <td><input type="text" data-bind="value: $root.currentFileInfo()._shortDescription, event: {keyup: function(){$root.flagActiveFileModified();}}"></input></td>
@@ -39,7 +39,7 @@
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Detailed Descripton', eagleTooltip: 'A complete description of the purpose of this file'"></td>
+                            <td data-bind="eagleTooltip: 'A complete description of the purpose of this file'">Detailed Description</td>
                             <!-- ko if: $root.currentFileInfo -->
                             <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                                 <td><textarea data-bind="value: $root.currentFileInfo()._detailedDescription, event: {keyup: function(){$root.flagActiveFileModified();}}"></textarea></td>
@@ -50,79 +50,79 @@
                             <!-- /ko -->
                         </tr>
                         <tr id="modelDataGeneratorName">
-                            <td data-bind="text: 'Generator Name', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The name of the program or service that generated this palette'">Generator Name</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._generatorName"></td>
                             <!-- /ko -->
                         </tr>
                         <tr id="modelDataGeneratorVersion">
-                            <td data-bind="text: 'Generator Version', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The version of the program or service that generated this palette'">Generator Version</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._generatorVersion"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Generator Commit Hash', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The commit hash of the program or service that generated this palette'">Generator Commit Hash</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._generatorCommitHash"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Schema Version', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The name of the schema to which this palette file complies'">Schema Version</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._schemaVersion"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Readonly', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'True, if this palette is not intended to be modified by users'">Readonly</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._readonly"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Repository URL', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The URL of the repository from which this palette was generated'">Repository URL</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._repositoryUrl"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Commit Hash', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The commit hash of the repository from which this palette was generated'">Commit Hash</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._commitHash"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Download URL', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'The URL from which this palette was downloaded'">Download URL</td>
                             <!-- ko if: $root.currentFileInfo -->
-                                <td data-bind="text: $root.currentFileInfo()._downloadURL"></td>
+                                <td data-bind="text: $root.currentFileInfo()._downloadUrl"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Signature', eagleTooltip: ''"></td>
+                            <td data-bind="eagleTooltip: 'A hash encoding the unique contents of this palette'">Signature</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._signature"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Last Modified Name', eagleTooltip: 'Name of the user who last modified this file'"></td>
+                            <td data-bind="eagleTooltip: 'Name of the user who last modified this file'">Last Modified Name</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._lastModifiedName"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Last Modified Email', eagleTooltip: 'Email of the user who last modified this file'"></td>
+                            <td data-bind="eagleTooltip: 'Email of the user who last modified this file'">Last Modified Email</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._lastModifiedEmail"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Last Modified Datetime', eagleTooltip: 'Date and time when this file was last modified'"></td>
+                            <td data-bind="eagleTooltip: 'Date and time when this file was last modified'">Last Modified Datetime</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo().lastModifiedDatetimeText()"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Num Nodes', eagleTooltip: 'Number of nodes within this file'"></td>
+                            <td data-bind="eagleTooltip: 'Number of nodes within this file'">Num Nodes</td>
                             <!-- ko if: $root.currentFileInfo -->
                                 <td data-bind="text: $root.currentFileInfo()._numLGNodes"></td>
                             <!-- /ko -->

--- a/templates/modals/model_data.html
+++ b/templates/modals/model_data.html
@@ -49,16 +49,22 @@
                             <!-- /ko -->
                             <!-- /ko -->
                         </tr>
-                        <tr id="modelDataEagleVersion">
-                            <td data-bind="text: 'Eagle Version', eagleTooltip: ''"></td>
+                        <tr id="modelDataGeneratorName">
+                            <td data-bind="text: 'Generator Name', eagleTooltip: ''"></td>
                             <!-- ko if: $root.currentFileInfo -->
-                                <td data-bind="text: $root.currentFileInfo()._eagleVersion"></td>
+                                <td data-bind="text: $root.currentFileInfo()._generatorName"></td>
+                            <!-- /ko -->
+                        </tr>
+                        <tr id="modelDataGeneratorVersion">
+                            <td data-bind="text: 'Generator Version', eagleTooltip: ''"></td>
+                            <!-- ko if: $root.currentFileInfo -->
+                                <td data-bind="text: $root.currentFileInfo()._generatorVersion"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>
-                            <td data-bind="text: 'Eagle Commit Hash', eagleTooltip: ''"></td>
+                            <td data-bind="text: 'Generator Commit Hash', eagleTooltip: ''"></td>
                             <!-- ko if: $root.currentFileInfo -->
-                                <td data-bind="text: $root.currentFileInfo()._eagleCommitHash"></td>
+                                <td data-bind="text: $root.currentFileInfo()._generatorCommitHash"></td>
                             <!-- /ko -->
                         </tr>
                         <tr>


### PR DESCRIPTION
Also stop EAGLE re-sorting the nodes in a palette after adding nodes from a graph.

Re-named fields in modelData modal from eagleVersion to generatorVersion, add generatorName.

Fixed bug where modelData.downloadUrl was not displayed.

## Summary by Sourcery

Improve model data handling and display in EAGLE by updating metadata fields, preventing unintended overwrites, and fixing display issues

Bug Fixes:
- Fixed an issue where modelData.downloadUrl was not being displayed correctly
- Stopped EAGLE from overwriting modelData when loading palettes

Enhancements:
- Renamed metadata fields from Eagle-specific terms to more generic generator-related terms
- Improved tooltips for model data modal to provide clearer descriptions

Chores:
- Removed automatic re-sorting of nodes in a palette after adding nodes from a graph