### PR TITLE
EAGLE-1429: Fields on Construct component should not be ports

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -298,6 +298,14 @@ export class Node {
         }
     }, this);
 
+    usageOptions : ko.PureComputed<Daliuge.FieldUsage[]> = ko.pureComputed(() => {
+        // fields on construct nodes cannot be ports
+        if (this.categoryType() === Category.Type.Construct){
+            return [Daliuge.FieldUsage.NoPort];
+        }
+        return Object.values(Daliuge.FieldUsage)
+    }, this);
+
     getInputPorts = () : Field[] => {
         const result: Field[] = []
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -317,6 +317,9 @@ export class ParameterTable {
         if (edgesToRemove.length > 0){
             Utils.showNotification("Removed edges", "Removed " + edgesToRemove.length + " edge(s) made invalid by the change in port usage", "info");
         }
+
+        // trigger graph check, since changing the usage of a field may break some rules
+        eagle.checkGraph();
     }
 
     // when a field value is modified in the parameter table, we need to flag the containing palette or logical graph as modified

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -41,7 +41,9 @@
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleType()}"><span>Type</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().type()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFlags()}"><span>Flags</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().flags()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleParameterType()}"><span>Parameter Type</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().parameterType()"></div>
-                <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleUsage()}"><span>Use As</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().usage()"></div>
+                <!-- ko ifnot: selectedNode()?.isConstruct() -->
+                    <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleUsage()}"><span>Use As</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().usage()"></div>
+                <!-- /ko -->
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleEncoding()}"><span>Encoding</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().encoding()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleActions()}"><span>Actions</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().actions()"></div>
             </div>
@@ -147,13 +149,13 @@
                                             Parameter Type
                                         </th>
                                     <!-- /ko -->                                        
-                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
+                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() && !eagle.selectedNode()?.isConstruct() -->
                                         <th class="parameter_table_usage" data-bind="click: function(){ParameterTable.sortTableBy('usage')}, eagleTooltip:'InputPorts and OutputPorts are used to specify named inputs and outputs from this Component.'" data-bs-placement="top">
                                             <i id="tableSort_usage" class="md-18 tableSortIcon icon-tableSortNone"></i>
                                             Use As
                                         </th>
                                     <!-- /ko -->
-                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode().isApplication() -->
+                                    <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode()?.isApplication() -->
                                         <th class="parameter_table_encoding" data-bind="click: function(){ParameterTable.sortTableBy('encoding')}, eagleTooltip:'The way data is encoded when passing through this port.'" data-bs-placement="top">
                                             <i id="tableSort_encoding" class="md-18 tableSortIcon icon-tableSortNone"></i>
                                             Encoding
@@ -434,7 +436,7 @@
                                                 </td>
                                             <!-- /ko -->
                                             
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
+                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() && !eagle.selectedNode()?.isConstruct() -->
                                                 <td class='columnCell column_Usage'>
                                                     <div class="checkboxWrapper">
                                                         <select class="tableFieldUseAs" data-bind="options: eagle.selectedNode().usageOptions, value: usage, disabled: ParameterTable.getParamsTableEditState() , event: {change: ParameterTable.fieldUsageChanged}">
@@ -444,7 +446,7 @@
                                                 </td>
                                             <!-- /ko -->
 
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode().isApplication() -->
+                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().encoding() && eagle.selectedNode()?.isApplication() -->
                                                 <td class='columnCell column_Encoding'>
                                                     <!-- ko if: $data.usage() === Daliuge.FieldUsage.NoPort-->
                                                         <span class="faded">N/A</span>

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -437,7 +437,7 @@
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().usage() -->
                                                 <td class='columnCell column_Usage'>
                                                     <div class="checkboxWrapper">
-                                                        <select class="tbaleFieldUseAs" data-bind="options: Object.values(Daliuge.FieldUsage), value: usage, disabled: ParameterTable.getParamsTableEditState() , event: {change: ParameterTable.fieldUsageChanged}">
+                                                        <select class="tableFieldUseAs" data-bind="options: eagle.selectedNode().usageOptions, value: usage, disabled: ParameterTable.getParamsTableEditState() , event: {change: ParameterTable.fieldUsageChanged}">
                                                             <!-- options are added dynamically -->
                                                         </select>
                                                     </div>
@@ -451,7 +451,7 @@
                                                     <!-- /ko -->
                                                     <!-- ko ifnot: $data.usage() === Daliuge.FieldUsage.NoPort-->
                                                         <div class="checkboxWrapper">
-                                                            <select class="tbaleFieldEncoding" data-bind="options: Object.values(Daliuge.Encoding), value: encoding, disabled: ParameterTable.getParamsTableEditState()">
+                                                            <select class="tableFieldEncoding" data-bind="options: Object.values(Daliuge.Encoding), value: encoding, disabled: ParameterTable.getParamsTableEditState()">
                                                                 <!-- options are added dynamically -->
                                                             </select>
                                                         </div>

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -44,7 +44,9 @@
                 <!-- ko ifnot: selectedNode()?.isConstruct() -->
                     <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleUsage()}"><span>Use As</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().usage()"></div>
                 <!-- /ko -->
-                <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleEncoding()}"><span>Encoding</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().encoding()"></div>
+                <!-- ko if: selectedNode() === null || selectedNode().isApplication() -->
+                    <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleEncoding()}"><span>Encoding</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().encoding()"></div>
+                <!-- /ko -->
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleActions()}"><span>Actions</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().actions()"></div>
             </div>
         </div>

--- a/tests/page-model.js
+++ b/tests/page-model.js
@@ -191,8 +191,8 @@ class Page {
       .click(Selector('#paramsTableWrapper').find('tr').nth(-1).find('.tableFieldParamTypeSelect').find('option').withText(parameterType))
 
       //setting the requested use as 
-      .click(Selector('#paramsTableWrapper').find('tr').nth(-1).find('.tbaleFieldUseAs'))
-      .click(Selector('#paramsTableWrapper').find('tr').nth(-1).find('.tbaleFieldUseAs').find('option').withText(useAs))
+      .click(Selector('#paramsTableWrapper').find('tr').nth(-1).find('.tableFieldUseAs'))
+      .click(Selector('#paramsTableWrapper').find('tr').nth(-1).find('.tableFieldUseAs').find('option').withText(useAs))
     
     if(value != ''){
       await t


### PR DESCRIPTION
checkGraph() function already picked up this issue. Construct nodes have a maximum of zero ports. But the issue was only detected when the graph was re-checked, which wasn't happening.

So I added a call to eagle.checkGraph() inside the existing fieldUsageChanged() event handler to re-check graph after change to field usage.

Also update the options data-bind in the UI for the "usage" column in the ParameterTable. If the node is a construct, then only the "NoPort" option appears in the usage drop-down.

## Summary by Sourcery

Modify field usage handling for Construct nodes to prevent port creation and ensure graph consistency

Bug Fixes:
- Prevent fields on Construct nodes from being set as ports by restricting usage options
- Automatically re-check graph integrity when field usage changes

Enhancements:
- Add dynamic usage options computation for nodes based on their category type
- Improve field usage change handling to maintain graph validity

Tests:
- Update page model test selectors to match new class names for field usage dropdown