### PR TITLE
EAGLE-1439: Don't overwrite unrecognised node categories when loading 

### DIFF
--- a/src/CategoryData.ts
+++ b/src/CategoryData.ts
@@ -68,7 +68,7 @@ export class CategoryData {
                 canHaveComponentParameters: false,
                 canHaveApplicationArguments: false,
                 canHaveConstructParameters: false,
-                icon: "error",
+                icon: "icon-none",
                 color: "pink",
                 sortOrder: Number.MAX_SAFE_INTEGER,
             };

--- a/src/CategoryData.ts
+++ b/src/CategoryData.ts
@@ -56,10 +56,8 @@ export class CategoryData {
         const c = CategoryData.cData[category];
 
         if (typeof c === 'undefined'){
-            console.error("Could not fetch category data for category", category);
             return {
                 categoryType: Category.Type.Unknown,
-               
                 isGroup: false,
                 minInputs: 0,
                 maxInputs: 0,

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -28,6 +28,7 @@ import * as ko from "knockout";
 import * as bootstrap from 'bootstrap';
 
 import { Category } from './Category';
+import { CategoryData } from "./CategoryData";
 import { ComponentUpdater } from './ComponentUpdater';
 import { Daliuge } from './Daliuge';
 import { DockerHubBrowser } from "./DockerHubBrowser";
@@ -4377,7 +4378,11 @@ export class Eagle {
             categoryType = this.selectedNode().getCategoryType();
         }
 
-        // if selectedNode is not set, return the list of all categories, even though it won't be rendered (I guess)
+        // if selectedNode categoryType is Unknown, return list of all categories
+        if (categoryType === Category.Type.Unknown){
+            return Utils.buildComponentList((cData: CategoryData) => {return true});
+        }
+
         // if selectedNode is set, return a list of categories within the same category type
         return Utils.getCategoriesWithInputsAndOutputs(categoryType);
     }, this)

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4417,16 +4417,22 @@ export class Eagle {
             Utils.showNotification(Palette.BUILTIN_PALETTE_NAME + " palette not found", "Unable to transform node according to a template. Instead just changing category.", "warning");
         } else {
             // find node with new type in builtinPalette
-            const oldCategoryTemplate: Node = builtinPalette.findNodeByNameAndCategory(oldNode.getCategory());
+            let oldCategoryTemplate: Node = builtinPalette.findNodeByNameAndCategory(oldNode.getCategory());
             const newCategoryTemplate: Node = builtinPalette.findNodeByNameAndCategory(newNodeCategory);
 
-            // check that prototypes were found for old category and new category
-            if (oldCategoryTemplate === null || newCategoryTemplate === null){
-                console.warn("Prototypes for old and/or new categories could not be found in palettes", oldNode.getCategory(), newNodeCategory);
+            // check that new category prototype was found, if not, skip transform node
+            if (newCategoryTemplate === null){
+                console.warn("Prototype for new category (" + newNodeCategory + ") could not be found in palettes. Can't intelligently transform old node into new node, will just set new category.");
                 return;
-            }
+            } else {
+                // check that old category prototype was found, if not, use 'Unknown' as a placeholder for transform node
+                if (oldCategoryTemplate === null){
+                    console.warn("Prototype for old category (" + oldNode.getCategory() + ") could not be found in palettes. Using existing node as template to transform into new node.");
+                    oldCategoryTemplate = oldNode;
+                }
 
-            Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate);
+                Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate);
+            }
         }
 
         oldNode.setCategory(newNodeCategory);

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1944,6 +1944,12 @@ export class Node {
             Field.isValid(node,field,selectedLocation,i)
         }
 
+        if(!Utils.isKnownCategory(node.getCategory())){
+            const message: string = "Node (" + node.getName() + ") has unrecognised category " + node.getCategory();
+            const issue: Errors.Issue = Errors.Show(message, function(){Utils.showNode(eagle, node.getId())});
+            node.issues().push({issue:issue,validity:Errors.Validity.Warning});
+        }
+
         if(node.isConstruct()){
             //checking the input application if one is present
             if(node.hasInputApplication()){

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1343,12 +1343,11 @@ export class Node {
         }
 
         // translate categories if required
-        let category: Category = nodeData.category;
+        const category: Category = nodeData.category;
 
         // if category is not known, then add error
         if (!Utils.isKnownCategory(category)){
             errorsWarnings.errors.push(Errors.Message("Node with name " + name + " has unknown category: " + category));
-            category = Category.Unknown;
         }
 
         const node : Node = new Node(name, "", category);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2694,6 +2694,11 @@ export class Utils {
         if (node.getDescription() === sourceTemplate.getDescription()){
             node.setDescription(destinationTemplate.getDescription());
         }
+
+        // set some other rendering attributes of the node, to ensure they match the destinationTemplate
+        node.setCategoryType(destinationTemplate.getCategoryType());
+        node.setRadius(destinationTemplate.getRadius());
+        node.setColor(destinationTemplate.getColor());
     }
 
     static findOldRepositoriesInLocalStorage(): Repository[] {

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -81,10 +81,10 @@
                                     <h5>Category:</h5>
                                 </div>
                                 <div class="col-8 col contentObjectValue">
-                                    <!-- ko if: $data.getCategoryType() === Category.Type.Data -->
+                                    <!-- ko if: $data.getCategoryType() === Category.Type.Data || $data.getCategoryType() === Category.Type.Unknown -->
                                         <select id="objectInspectorCategorySelect" data-bind="value: $data.getCategory(), options:$root.getEligibleNodeCategories(), event:{change:function(data,event){$root.inspectorChangeNodeCategoryRequest(event)}}, valueAllowUnset: true, disabled: $data.isLocked(), eagleTooltip:'NOTE: changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category'"></select>
                                     <!-- /ko -->
-                                    <!-- ko if: $data.getCategoryType() !== Category.Type.Data -->
+                                    <!-- ko if: $data.getCategoryType() !== Category.Type.Data && $data.getCategoryType() !== Category.Type.Unknown -->
                                         <span data-bind="text:$data.getCategory()"></span>
                                     <!-- /ko -->
                                 </div>  


### PR DESCRIPTION
Previously, if EAGLE didn't recognise the category of a node, it would replace the category with "Unknown". This resulted in the loss of some information.

It seems better to just warn the user of the issue, and allow them to solve the problem as they see fit.

Changes:
- Don't overwrite a node category if unrecognised
- Use "icon-none" to display nodes with unrecognised categories
- Add a rule to Node.isValid() to check if the category is unrecognised, if so, warn user
- Allow unrecognised categories to be changed in the inspector UI (and put all known categories in the list of categories it can be changed to)

Testing:
I added a test graph, with an unrecognised category, to the EAGLE-1439 JIRA ticket. The node with the unrecognised category is called "array", it is second from the left. If you select it, you can update the category in the inspector. For example, try change it to a Memory, or File node.

Currently not passing CI, but that seems to be due to the broken "HelloWorldApp" issue. Once that is fixed it should pass.

## Summary by Sourcery

Improve handling of unrecognised node categories in EAGLE by preventing automatic overwriting and providing better user guidance

New Features:
- Enable users to manually update nodes with unrecognised categories

Bug Fixes:
- Prevent automatic overwriting of unrecognised node categories with 'Unknown'

Enhancements:
- Add support for displaying nodes with unrecognised categories
- Implement warning mechanism for unrecognised node categories
- Allow changing unrecognised categories in the inspector UI