### PR TITLE
EAGLE-1443: Added button on inspector to display node as Json

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1404,35 +1404,24 @@ export class Eagle {
     }
 
     displayObjectAsJson = (fileType: Eagle.FileType) : void => {
-        let clone: LogicalGraph | Palette;
+        let jsonString: string;
         
         switch(fileType){
             case Eagle.FileType.Graph:
-                clone = this.logicalGraph().clone();
+                jsonString = LogicalGraph.toOJSJsonString(this.logicalGraph(), false);
                 break;
             default:
                 console.error("displayObjectAsJson(): Un-handled fileType", fileType);
                 return;
         }
-        
-        // zero-out some info that isn't useful for comparison
-        clone.fileInfo().repositoryUrl = "";
-        clone.fileInfo().commitHash = "";
-        clone.fileInfo().downloadUrl = "";
-        clone.fileInfo().signature = "";
-        clone.fileInfo().lastModifiedName = "";
-        clone.fileInfo().lastModifiedEmail = "";
-        clone.fileInfo().lastModifiedDatetime = 0;
 
-        let jsonString: string;
-        
-        switch(fileType){
-            case Eagle.FileType.Graph:
-                jsonString = LogicalGraph.toOJSJsonString(clone as LogicalGraph, false);
-                break;
-        }
+        Utils.requestUserText("Display " + fileType + " as JSON", "", jsonString);
+    }
 
-        Utils.requestUserText("Export " + fileType + " to JSON", "", jsonString);
+    displayNodeAsJson = (node: Node) : void => {
+        const jsonString: string = JSON.stringify(Node.toOJSGraphJson(node), null, EagleConfig.JSON_INDENT);
+
+        Utils.requestUserText("Display Node as JSON", "", jsonString);
     }
 
     /**

--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -6,6 +6,7 @@ import { Errors } from "./Errors";
 import { Field } from "./Field";
 import { LogicalGraph } from "./LogicalGraph";
 import { Utils } from "./Utils";
+import { EagleConfig } from "./EagleConfig";
 
 export class GraphConfig {
     private id: ko.Observable<GraphConfig.Id>;
@@ -235,7 +236,7 @@ export class GraphConfig {
         const json: any = GraphConfig.toJson(graphConfig);
 
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
-        result += JSON.stringify(json, null, 4);
+        result += JSON.stringify(json, null, EagleConfig.JSON_INDENT);
 
         return result;
     }

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -23,7 +23,6 @@
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $data.getGitHTML()" data-bs-toggle="tooltip" data-html="true">link</i>
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'Id: '+$data.getId()" data-bs-toggle="tooltip" data-html="true">fingerprint</i>
                                     <i class="material-icons interactive clickable iconHoverEffect" onclick=eagle.editNodeDescription() data-bs-placement="right" data-bind="eagleTooltip: $data.getDescriptionHTML()" data-bs-toggle="tooltip" data-html="true">library_books</i>
-                                
                                     <!-- ko if: $data.getAllErrorsWarnings().errors.length > 0 || $data.getAllErrorsWarnings().warnings.length > 0 -->
                                         <i class="material-icons interactive clickable iconHoverEffect" onclick=eagle.showGraphErrors() data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}" data-bs-toggle="tooltip" data-html="true">error</i>
                                     <!-- /ko -->
@@ -42,6 +41,9 @@
                                     <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                                         <button type="button" id="duplicateSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.duplicateSelection('normal')}, clickBubble: false, eagleTooltip: 'Duplicate Selection ' + KeyboardShortcut.idToText('duplicate_selection', true)" data-bs-placement="left">
                                             <i class="material-icons md-20 clickable iconHoverEffect">content_copy</i>
+                                        </button>
+                                        <button type="button" id="displaySelectedNodeAsJson" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.displayNodeAsJson($data)}, clickBubble: false, eagleTooltip: 'Display Node as JSON'" data-bs-placement="left">
+                                            <i class="material-icons md-20 clickable iconHoverEffect">open_in_new</i>
                                         </button>
                                     <!-- /ko -->
                                     <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -43,7 +43,7 @@
                                             <i class="material-icons md-20 clickable iconHoverEffect">content_copy</i>
                                         </button>
                                         <button type="button" id="displaySelectedNodeAsJson" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.displayNodeAsJson($data)}, clickBubble: false, eagleTooltip: 'Display Node as JSON'" data-bs-placement="left">
-                                            <i class="material-icons md-20 clickable iconHoverEffect">open_in_new</i>
+                                            <i class="material-icons md-20 clickable iconHoverEffect">data_object</i>
                                         </button>
                                     <!-- /ko -->
                                     <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->


### PR DESCRIPTION
Also removed some code from displayObjectAsJson() that cleared several attributes from modelData. I'm not sure why it would do that.

The icon is "open in new window" which is not perfect, but I couldn't find any "json"-related icons

## Summary by Sourcery

Add functionality to display a selected node as JSON in the inspector interface

New Features:
- Added a new button in the inspector to display the selected node's JSON representation

Enhancements:
- Simplified the displayObjectAsJson() method by removing unnecessary attribute clearing
- Updated JSON serialization to use a consistent indentation from EagleConfig