### PR TITLE
EAGLE-1446: Removed requirement for PyFuncApp to have a func_code field

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -254,7 +254,6 @@ export namespace Daliuge {
                 Category.PyFuncApp
             ],
             fields: [
-                Daliuge.funcCodeField,
                 Daliuge.funcNameField
             ]
         },


### PR DESCRIPTION
Since PyFuncApps generated directly from code (by dlg_paletteGen) do not contain this field.

## Summary by Sourcery

Remove the requirement for func_code field in PyFuncApp category

Bug Fixes:
- Fixed compatibility issue for PyFuncApps generated directly from code without a func_code field

Enhancements:
- Simplified PyFuncApp definition by removing unnecessary func_code field requirement