### PR TITLE
EAGLE-1449: Remove requirement to save 'local' files before translation

### DIFF
--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -30,6 +30,7 @@ import { GraphConfig } from "./GraphConfig";
 import { LogicalGraph } from './LogicalGraph';
 import { Setting } from './Setting';
 import { Utils } from './Utils';
+import { Repository } from "./Repository";
 
 export class Translator {
     numberOfIslands : ko.Observable<number>;
@@ -128,8 +129,11 @@ export class Translator {
             throw new Error("Unable to translate. Logical graph does not have a name! Please save the graph first.");
         }
 
+        // is the graph a local file?
+        const isLocalFile: boolean = eagle.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
+
         // check if the graph is committed before translation
-        if (this._checkGraphModified(eagle)){
+        if (!isLocalFile && this._checkGraphModified(eagle)){
             Utils.showNotification("Saving graph", "Automatically saving modified graph prior to translation", "info");
 
             // use the async function here, so that we can check isModified after saving


### PR DESCRIPTION
If the file is 'local', the translate button will continue with the translation without saving.

## Summary by Sourcery

Modify translation workflow to skip saving for local files

Bug Fixes:
- Remove the requirement to save local files before translation, allowing immediate translation of local files

Enhancements:
- Add a check to determine if the file is local before requiring a save operation