### PR TITLE
EAGLE-1445: "Display X as JSON" modal should have readonly textarea

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1415,13 +1415,13 @@ export class Eagle {
                 return;
         }
 
-        Utils.requestUserText("Display " + fileType + " as JSON", "", jsonString);
+        Utils.requestUserText("Display " + fileType + " as JSON", "", jsonString, true);
     }
 
     displayNodeAsJson = (node: Node) : void => {
         const jsonString: string = JSON.stringify(Node.toOJSGraphJson(node), null, EagleConfig.JSON_INDENT);
 
-        Utils.requestUserText("Display Node as JSON", "", jsonString);
+        Utils.requestUserText("Display Node as JSON", "", jsonString, true);
     }
 
     /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -505,12 +505,13 @@ export class Utils {
         });
     }
 
-    static requestUserText(title : string, message : string, defaultText: string) : Promise<string> {
+    static requestUserText(title : string, message : string, defaultText: string, readonly: boolean = false) : Promise<string> {
         return new Promise(async(resolve, reject) => {
             $('#inputTextModalTitle').text(title);
             $('#inputTextModalMessage').html(message);
 
             $('#inputTextModalInput').val(defaultText);
+            $('#inputTextModalInput').prop('readonly', readonly);
 
             // store the callback, result on the modal HTML element
             // so that the info is available to event handlers


### PR DESCRIPTION
Added parameter 'readonly' to Utils.requestUserText(). Set param true when displaying JSON for graph/palette/node.

## Summary by Sourcery

Add readonly option to text input modal for JSON display

Bug Fixes:
- Ensure JSON display modals have a read-only textarea to prevent accidental modifications

Enhancements:
- Modify Utils.requestUserText() to support an optional readonly parameter for the input textarea