### PR TITLE
EAGLE-1451: Fixed bug where palette's "modified" flag was set when the Branch node selected 

### DIFF
--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -273,7 +273,7 @@
                                                         <!-- ko ifnot: !Setting.findValue(Setting.NODE_PARAMS_TABLE_DUAL_VALUE_DISPLAY) && $data.getGraphConfigField() -->
                                                             <div class="checkboxWrapper" data-bind="css: {doubleInputDisplay: $data.getGraphConfigField()}, eagleTooltip: 'Graph Value'">
                                                                 <div>
-                                                                    <select aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: ParameterTable.getCurrentParamValueReadonly($data), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.value">
+                                                                    <select aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: ParameterTable.getCurrentParamValueReadonly($data), options: $data.options, value: $data.value">
                                                                         <!-- options are added dynamically -->
                                                                     </select>
                                                                 </div>


### PR DESCRIPTION
Removed 'change' event handler function from 'default value' dropdown

This fixes the bug, but now means that nothing happens when the "default value" of a "option"-type field is changed. The graph will not be re-checked etc.

I think the fix is preferable to the bug, but not perfect.

## Summary by Sourcery

Remove change event handler from default value dropdown to prevent unintended palette modification

Bug Fixes:
- Fixed an issue where the palette's 'modified' flag was incorrectly set when selecting a Branch node's default value dropdown

Chores:
- Acknowledged that removing the change event handler means the graph will not be re-checked when default values are changed