### PR TITLE
EAGLE-1454: "git key not set" error message auto-dismisses when clicking on repository

### DIFF
--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -95,6 +95,7 @@ export class GitHub {
             if (token === null || token === "") {
                 Utils.showUserMessage("Access Token", "The GitHub access token is not set! To access GitHub repository, set the token via settings.");
                 reject("The GitHub access token is not set! To access GitHub repository, set the token via settings.");
+                return;
             }
 
             // get location

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -67,6 +67,7 @@ export class GitLab {
             if (token === null || token === "") {
                 Utils.showUserMessage("Access Token", "The GitLab access token is not set! To access GitLab repository, set the token via settings.");
                 reject("The GitLab access token is not set! To access GitLab repository, set the token via settings.");
+                return;
             }
 
             // get location


### PR DESCRIPTION
Fixed bug where 'reject' statement in Promise was not followed by a return, so execution proceeded anyway, and opened a second modal, which dismissed the first.

## Summary by Sourcery

Bug Fixes:
- Resolve issue where Promise rejection did not halt execution, causing multiple modals to be opened when access token is not set