### PR TITLE
EAGLE-1437: Change of Application Arguments to shorter versions

### DIFF
--- a/e2e/parameterTableAndKeyboardShortcuts.spec.ts
+++ b/e2e/parameterTableAndKeyboardShortcuts.spec.ts
@@ -50,8 +50,8 @@ test('Parameter Tables and keyboard Shortcuts', async ({ page }) => {
   await expect(page.getByRole('row').last().locator('.typesInput')).toHaveValue('Integer')
 
   //change parameter type then check that the value has been changed accordingly
-  await page.getByRole('row').last().locator('.column_ParamType').getByRole('combobox').selectOption('ApplicationArgument');
-  await expect(page.getByRole('row').last().locator('.column_ParamType').getByRole('combobox')).toHaveValue('ApplicationArgument')
+  await page.getByRole('row').last().locator('.column_ParamType').getByRole('combobox').selectOption('Application');
+  await expect(page.getByRole('row').last().locator('.column_ParamType').getByRole('combobox')).toHaveValue('Application')
   
   //change use as and then make sure that the value has been changed accordingly
   await page.getByRole('row').last().locator('.column_Usage').getByRole('combobox').selectOption('OutputPort');

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -38,6 +38,22 @@ export class Daliuge {
     static isPythonInitialiser(node: Node): boolean {
         return node.getCategory() === Category.PythonMemberFunction && (node.getName().includes("__init__") || node.getName().includes("__class__"));
     }
+
+    static DLGFieldTypeToFieldType(dft: Daliuge.DLGFieldType): Daliuge.FieldType {
+        if (dft === Daliuge.DLGFieldType.ApplicationArgument) return Daliuge.FieldType.Application;
+        if (dft === Daliuge.DLGFieldType.ComponentParameter) return Daliuge.FieldType.Component;
+        if (dft === Daliuge.DLGFieldType.ConstraintParameter) return Daliuge.FieldType.Constraint;
+        if (dft === Daliuge.DLGFieldType.ConstructParameter) return Daliuge.FieldType.Construct;
+        return Daliuge.FieldType.Unknown;
+    }
+
+    static FieldTypeToDLGFieldType(df: Daliuge.FieldType): Daliuge.DLGFieldType {
+        if (df === Daliuge.FieldType.Application) return Daliuge.DLGFieldType.ApplicationArgument;
+        if (df === Daliuge.FieldType.Component) return Daliuge.DLGFieldType.ComponentParameter;
+        if (df === Daliuge.FieldType.Constraint) return Daliuge.DLGFieldType.ConstraintParameter;
+        if (df === Daliuge.FieldType.Construct) return Daliuge.DLGFieldType.ConstructParameter;
+        return Daliuge.DLGFieldType.Unknown;
+    }
 }
 
 export namespace Daliuge {
@@ -112,6 +128,14 @@ export namespace Daliuge {
     }
 
     export enum FieldType {
+        Application = "Application",
+        Component = "Component",
+        Constraint = "Constraint",
+        Construct = "Construct",
+        Unknown = "Unknown"
+    }
+
+    export enum DLGFieldType {
         ApplicationArgument = "ApplicationArgument",
         ComponentParameter = "ComponentParameter",
         ConstraintParameter = "ConstraintParameter",
@@ -140,28 +164,28 @@ export namespace Daliuge {
     }
 
     // These are the canonical example definition of each field
-    export const groupStartField = new Field(null, FieldName.GROUP_START, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.ComponentParameter, FieldUsage.NoPort);
-    export const groupEndField = new Field(null, FieldName.GROUP_END, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.ComponentParameter, FieldUsage.NoPort);
+    export const groupStartField = new Field(null, FieldName.GROUP_START, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
+    export const groupEndField = new Field(null, FieldName.GROUP_END, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
 
-    export const branchYesField = new Field(null, FieldName.TRUE, "", "", "The affirmative output from a branch node", false, DataType.Object, false, [], false, FieldType.ComponentParameter, FieldUsage.OutputPort);
-    export const branchNoField  = new Field(null, FieldName.FALSE,  "", "", "he negative output from a branch node", false, DataType.Object, false, [], false, FieldType.ComponentParameter, FieldUsage.OutputPort);
+    export const branchYesField = new Field(null, FieldName.TRUE, "", "", "The affirmative output from a branch node", false, DataType.Object, false, [], false, FieldType.Component, FieldUsage.OutputPort);
+    export const branchNoField  = new Field(null, FieldName.FALSE,  "", "", "he negative output from a branch node", false, DataType.Object, false, [], false, FieldType.Component, FieldUsage.OutputPort);
 
-    export const dropClassField = new Field(null, FieldName.DROP_CLASS, "", "", "", false, DataType.String, false, [], false, FieldType.ComponentParameter, FieldUsage.NoPort);
+    export const dropClassField = new Field(null, FieldName.DROP_CLASS, "", "", "", false, DataType.String, false, [], false, FieldType.Component, FieldUsage.NoPort);
 
-    export const executionTimeField = new Field(null, FieldName.EXECUTION_TIME, "5", "5", "", false, DataType.Float, false, [], false, FieldType.ConstraintParameter, FieldUsage.NoPort);
-    export const numCpusField = new Field(null, FieldName.NUM_OF_CPUS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.ConstraintParameter, FieldUsage.NoPort);
-    export const dataVolumeField = new Field(null, FieldName.DATA_VOLUME, "5", "5", "", false, DataType.Float, false, [], false, FieldType.ConstraintParameter, FieldUsage.NoPort);
+    export const executionTimeField = new Field(null, FieldName.EXECUTION_TIME, "5", "5", "", false, DataType.Float, false, [], false, FieldType.Constraint, FieldUsage.NoPort);
+    export const numCpusField = new Field(null, FieldName.NUM_OF_CPUS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.Constraint, FieldUsage.NoPort);
+    export const dataVolumeField = new Field(null, FieldName.DATA_VOLUME, "5", "5", "", false, DataType.Float, false, [], false, FieldType.Constraint, FieldUsage.NoPort);
 
-    export const kField = new Field(null, FieldName.K, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.ConstructParameter, FieldUsage.NoPort);
-    export const numCopiesField = new Field(null, FieldName.NUM_OF_COPIES, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.ConstructParameter, FieldUsage.NoPort);
-    export const numInputsField = new Field(null, FieldName.NUM_OF_INPUTS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.ConstructParameter, FieldUsage.NoPort);
-    export const numIterationsField = new Field(null, FieldName.NUM_OF_ITERATIONS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.ConstructParameter, FieldUsage.NoPort);
+    export const kField = new Field(null, FieldName.K, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.Construct, FieldUsage.NoPort);
+    export const numCopiesField = new Field(null, FieldName.NUM_OF_COPIES, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.Construct, FieldUsage.NoPort);
+    export const numInputsField = new Field(null, FieldName.NUM_OF_INPUTS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.Construct, FieldUsage.NoPort);
+    export const numIterationsField = new Field(null, FieldName.NUM_OF_ITERATIONS, "1", "1", "", false, DataType.Integer, false, [], false, FieldType.Construct, FieldUsage.NoPort);
 
-    export const baseNameField = new Field(null, FieldName.BASE_NAME, "", "", "The base name of the class of this Member function", false, DataType.String, false, [], false, FieldType.ComponentParameter, FieldUsage.NoPort);
-    export const selfField = new Field(null, FieldName.SELF, "", "", "", false, DataType.Object, false, [], false, FieldType.ComponentParameter, FieldUsage.InputOutput);
+    export const baseNameField = new Field(null, FieldName.BASE_NAME, "", "", "The base name of the class of this Member function", false, DataType.String, false, [], false, FieldType.Component, FieldUsage.NoPort);
+    export const selfField = new Field(null, FieldName.SELF, "", "", "", false, DataType.Object, false, [], false, FieldType.Component, FieldUsage.InputOutput);
 
-    export const funcCodeField = new Field(null, FieldName.FUNC_CODE, "", "def func_name(args): return args", "Python function code", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.ComponentParameter, FieldUsage.NoPort);
-    export const funcNameField = new Field(null, FieldName.FUNC_NAME, "", "func_name", "Python function name", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.ComponentParameter, FieldUsage.NoPort);
+    export const funcCodeField = new Field(null, FieldName.FUNC_CODE, "", "def func_name(args): return args", "Python function code", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.Component, FieldUsage.NoPort);
+    export const funcNameField = new Field(null, FieldName.FUNC_NAME, "", "func_name", "Python function name", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.Component, FieldUsage.NoPort);
 
     // This list defines the fields required for ALL nodes belonging to a given Category.Type
     // NOTE: ids are empty string here, we should generate a new id whenever we clone the fields

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -38,22 +38,6 @@ export class Daliuge {
     static isPythonInitialiser(node: Node): boolean {
         return node.getCategory() === Category.PythonMemberFunction && (node.getName().includes("__init__") || node.getName().includes("__class__"));
     }
-
-    static DLGFieldTypeToFieldType(dft: Daliuge.DLGFieldType): Daliuge.FieldType {
-        if (dft === Daliuge.DLGFieldType.ApplicationArgument) return Daliuge.FieldType.Application;
-        if (dft === Daliuge.DLGFieldType.ComponentParameter) return Daliuge.FieldType.Component;
-        if (dft === Daliuge.DLGFieldType.ConstraintParameter) return Daliuge.FieldType.Constraint;
-        if (dft === Daliuge.DLGFieldType.ConstructParameter) return Daliuge.FieldType.Construct;
-        return Daliuge.FieldType.Unknown;
-    }
-
-    static FieldTypeToDLGFieldType(df: Daliuge.FieldType): Daliuge.DLGFieldType {
-        if (df === Daliuge.FieldType.Application) return Daliuge.DLGFieldType.ApplicationArgument;
-        if (df === Daliuge.FieldType.Component) return Daliuge.DLGFieldType.ComponentParameter;
-        if (df === Daliuge.FieldType.Constraint) return Daliuge.DLGFieldType.ConstraintParameter;
-        if (df === Daliuge.FieldType.Construct) return Daliuge.DLGFieldType.ConstructParameter;
-        return Daliuge.DLGFieldType.Unknown;
-    }
 }
 
 export namespace Daliuge {
@@ -135,12 +119,33 @@ export namespace Daliuge {
         Unknown = "Unknown"
     }
 
+    // NOTE: this second 'field type' enum is required because DALiuGE will (in the short term)
+    //       continue to use longer names for the field types. Eventually, DALiuGE will move to
+    //       the shorter names. At that point we can remove this.
     export enum DLGFieldType {
         ApplicationArgument = "ApplicationArgument",
         ComponentParameter = "ComponentParameter",
         ConstraintParameter = "ConstraintParameter",
         ConstructParameter = "ConstructParameter",
         Unknown = "Unknown"
+    }
+
+    // NOTE: these two maps translate between the EAGLE field types and the Daliuge field types
+    //       once DALiuGE is updated, we can also remove these
+    export const dlgToFieldTypeMap: { [key in Daliuge.DLGFieldType]: Daliuge.FieldType } = {
+        [Daliuge.DLGFieldType.ApplicationArgument]: Daliuge.FieldType.Application,
+        [Daliuge.DLGFieldType.ComponentParameter]: Daliuge.FieldType.Component,
+        [Daliuge.DLGFieldType.ConstraintParameter]: Daliuge.FieldType.Constraint,
+        [Daliuge.DLGFieldType.ConstructParameter]: Daliuge.FieldType.Construct,
+        [Daliuge.DLGFieldType.Unknown]: Daliuge.FieldType.Unknown,
+    }
+    
+    export const fieldTypeToDlgMap: { [key in Daliuge.FieldType]: Daliuge.DLGFieldType } = {
+        [Daliuge.FieldType.Application]: Daliuge.DLGFieldType.ApplicationArgument,
+        [Daliuge.FieldType.Component]: Daliuge.DLGFieldType.ComponentParameter,
+        [Daliuge.FieldType.Constraint]: Daliuge.DLGFieldType.ConstraintParameter,
+        [Daliuge.FieldType.Construct]: Daliuge.DLGFieldType.ConstructParameter,
+        [Daliuge.FieldType.Unknown]: Daliuge.DLGFieldType.Unknown,
     }
 
     export enum FieldUsage {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3633,7 +3633,7 @@ export class Eagle {
                 }
 
                 // create a new input/output "object" port on the PythonObject
-                const inputOutputPort = new Field(Utils.generateFieldId(), Daliuge.FieldName.SELF, "", "", "", true, sourcePort.getType(), false, null, false, Daliuge.FieldType.ComponentParameter, Daliuge.FieldUsage.InputOutput);
+                const inputOutputPort = new Field(Utils.generateFieldId(), Daliuge.FieldName.SELF, "", "", "", true, sourcePort.getType(), false, null, false, Daliuge.FieldType.Component, Daliuge.FieldUsage.InputOutput);
                 pythonObjectNode.addField(inputOutputPort);
 
                 // add edge to Logical Graph (connecting the PythonMemberFunction and the automatically-generated PythonObject)
@@ -4314,7 +4314,7 @@ export class Eagle {
             newNode.removeAllOutputPorts();
 
             // add InputOutput port for dataType
-            const newInputOutputPort = new Field(Utils.generateFieldId(), srcPort.getDisplayText(), "", "", "", false, srcPort.getType(), false, [], false, Daliuge.FieldType.ApplicationArgument, Daliuge.FieldUsage.InputOutput);
+            const newInputOutputPort = new Field(Utils.generateFieldId(), srcPort.getDisplayText(), "", "", "", false, srcPort.getType(), false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.InputOutput);
             newNode.addField(newInputOutputPort);
 
             // set the parent of the new node

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -581,9 +581,9 @@ export class Field {
     static getHtmlTitleText(parameterType: Daliuge.FieldType, usage: Daliuge.FieldUsage) : string {
         if (usage === Daliuge.FieldUsage.NoPort){
             switch(parameterType){
-                case Daliuge.FieldType.ApplicationArgument:
+                case Daliuge.FieldType.Application:
                 return "Application Argument";
-                case Daliuge.FieldType.ComponentParameter:
+                case Daliuge.FieldType.Component:
                 return "Component Parameter";
             }
         } else {
@@ -665,7 +665,7 @@ export class Field {
             positional:field.positional(),
             encoding:field.encoding(),
             id: field.id(),
-            parameterType: field.parameterType(),
+            parameterType: Daliuge.FieldTypeToDLGFieldType(field.parameterType()),
             usage: field.usage(),
         }
 
@@ -731,28 +731,28 @@ export class Field {
         // handle legacy fieldType
         if (typeof data.fieldType !== 'undefined'){
             switch (data.fieldType){
-                case "ApplicationArgument":
-                    parameterType = Daliuge.FieldType.ApplicationArgument;
+                case Daliuge.DLGFieldType.ApplicationArgument:
+                    parameterType = Daliuge.FieldType.Application;
                     usage = Daliuge.FieldUsage.NoPort;
                     break;
-                case "ComponentParameter":
-                    parameterType = Daliuge.FieldType.ComponentParameter;
+                case Daliuge.DLGFieldType.ComponentParameter:
+                    parameterType = Daliuge.FieldType.Component;
                     usage = Daliuge.FieldUsage.NoPort;
                     break;
-                case "ConstraintParameter":
-                    parameterType = Daliuge.FieldType.ConstraintParameter;
+                case Daliuge.DLGFieldType.ConstraintParameter:
+                    parameterType = Daliuge.FieldType.Constraint;
                     usage = Daliuge.FieldUsage.NoPort;
                     break;
-                case "ConstructParameter":
-                    parameterType = Daliuge.FieldType.ConstructParameter;
+                case Daliuge.DLGFieldType.ConstructParameter:
+                    parameterType = Daliuge.FieldType.Construct;
                     usage = Daliuge.FieldUsage.NoPort;
                     break;
-                case "InputPort":
-                    parameterType = Daliuge.FieldType.ApplicationArgument;
+                case Daliuge.FieldUsage.InputPort:
+                    parameterType = Daliuge.FieldType.Application;
                     usage = Daliuge.FieldUsage.InputPort;
                     break;
-                case "OutputPort":
-                    parameterType = Daliuge.FieldType.ApplicationArgument;
+                case Daliuge.FieldUsage.OutputPort:
+                    parameterType = Daliuge.FieldType.Application;
                     usage = Daliuge.FieldUsage.OutputPort;
                     break;
                 default:
@@ -761,7 +761,7 @@ export class Field {
         }
 
         if (typeof data.parameterType !== 'undefined')
-            parameterType = data.parameterType;
+            parameterType = Daliuge.DLGFieldTypeToFieldType(data.parameterType);
         if (typeof data.usage !== 'undefined')
             usage = data.usage;
         if (typeof data.event !== 'undefined')
@@ -918,24 +918,24 @@ export class Field {
 
         // check that fields have parameter types that are suitable for this node
         // skip the 'drop class' component parameter, those are always suitable for every node
-        if (field.getDisplayText() != Daliuge.FieldName.DROP_CLASS && field.getParameterType() != Daliuge.FieldType.ComponentParameter){
+        if (field.getDisplayText() != Daliuge.FieldName.DROP_CLASS && field.getParameterType() != Daliuge.FieldType.Component){
             if (
-                (field.getParameterType() === Daliuge.FieldType.ComponentParameter) && !CategoryData.getCategoryData(node.getCategory()).canHaveComponentParameters ||
-                (field.getParameterType() === Daliuge.FieldType.ApplicationArgument) && !CategoryData.getCategoryData(node.getCategory()).canHaveApplicationArguments ||
-                (field.getParameterType() === Daliuge.FieldType.ConstructParameter) && !CategoryData.getCategoryData(node.getCategory()).canHaveConstructParameters
+                (field.getParameterType() === Daliuge.FieldType.Component) && !CategoryData.getCategoryData(node.getCategory()).canHaveComponentParameters ||
+                (field.getParameterType() === Daliuge.FieldType.Application) && !CategoryData.getCategoryData(node.getCategory()).canHaveApplicationArguments ||
+                (field.getParameterType() === Daliuge.FieldType.Construct) && !CategoryData.getCategoryData(node.getCategory()).canHaveConstructParameters
             ){
                 // determine a suitable type
                 let suitableType: Daliuge.FieldType = Daliuge.FieldType.Unknown;
                 const categoryData: Category.CategoryData = CategoryData.getCategoryData(node.getCategory());
 
                 if (categoryData.canHaveComponentParameters){
-                    suitableType = Daliuge.FieldType.ComponentParameter;
+                    suitableType = Daliuge.FieldType.Component;
                 } else {
                     if (categoryData.canHaveApplicationArguments){
-                        suitableType = Daliuge.FieldType.ApplicationArgument;
+                        suitableType = Daliuge.FieldType.Application;
                     } else {
                         if (categoryData.canHaveConstructParameters){
-                            suitableType = Daliuge.FieldType.ConstructParameter;
+                            suitableType = Daliuge.FieldType.Construct;
                         }
                     }
                 }

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -665,7 +665,7 @@ export class Field {
             positional:field.positional(),
             encoding:field.encoding(),
             id: field.id(),
-            parameterType: Daliuge.FieldTypeToDLGFieldType(field.parameterType()),
+            parameterType: Daliuge.fieldTypeToDlgMap[field.parameterType()] || Daliuge.DLGFieldType.Unknown,
             usage: field.usage(),
         }
 
@@ -761,7 +761,7 @@ export class Field {
         }
 
         if (typeof data.parameterType !== 'undefined')
-            parameterType = Daliuge.DLGFieldTypeToFieldType(data.parameterType);
+            parameterType = Daliuge.dlgToFieldTypeMap[<Daliuge.DLGFieldType>data.parameterType] || Daliuge.FieldType.Unknown;
         if (typeof data.usage !== 'undefined')
             usage = data.usage;
         if (typeof data.event !== 'undefined')

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -257,7 +257,7 @@ export class Node {
     }
 
     isStreaming = () : boolean => {
-        const streamingField = this.findFieldByDisplayText(Daliuge.FieldName.STREAMING, Daliuge.FieldType.ComponentParameter);
+        const streamingField = this.findFieldByDisplayText(Daliuge.FieldName.STREAMING, Daliuge.FieldType.Component);
 
         if (streamingField !== null){
             return streamingField.valIsTrue(streamingField.getValue());
@@ -267,7 +267,7 @@ export class Node {
     }
 
     isPersist = () : boolean => {
-        const persistField = this.findFieldByDisplayText(Daliuge.FieldName.PERSIST, Daliuge.FieldType.ComponentParameter);
+        const persistField = this.findFieldByDisplayText(Daliuge.FieldName.PERSIST, Daliuge.FieldType.Component);
 
         if (persistField !== null){
             return persistField.valIsTrue(persistField.getValue());
@@ -442,7 +442,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ComponentParameter){
+            if (field.getParameterType() === Daliuge.FieldType.Component){
                 result.push(field);
             }
         }
@@ -454,7 +454,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ComponentParameter && field.getUsage() === Daliuge.FieldUsage.NoPort){
+            if (field.getParameterType() === Daliuge.FieldType.Component && field.getUsage() === Daliuge.FieldUsage.NoPort){
                 result.push(field);
             }
         }
@@ -466,7 +466,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ApplicationArgument){
+            if (field.getParameterType() === Daliuge.FieldType.Application){
                 result.push(field);
             }
         }
@@ -478,7 +478,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ApplicationArgument && field.getUsage() === Daliuge.FieldUsage.NoPort){
+            if (field.getParameterType() === Daliuge.FieldType.Application && field.getUsage() === Daliuge.FieldUsage.NoPort){
                 result.push(field);
             }
         }
@@ -490,7 +490,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ConstructParameter){
+            if (field.getParameterType() === Daliuge.FieldType.Construct){
                 result.push(field);
             }
         }
@@ -502,7 +502,7 @@ export class Node {
         const result: Field[] = [];
 
         for (const field of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.ConstructParameter && field.getUsage() === Daliuge.FieldUsage.NoPort){
+            if (field.getParameterType() === Daliuge.FieldType.Construct && field.getUsage() === Daliuge.FieldUsage.NoPort){
                 result.push(field);
             }
         }
@@ -646,10 +646,10 @@ export class Node {
     }
 
     canHaveType = (parameterType: Daliuge.FieldType) : boolean => {
-        if (parameterType === Daliuge.FieldType.ComponentParameter){
+        if (parameterType === Daliuge.FieldType.Component){
             return this.canHaveComponentParameters()
         }
-        if (parameterType === Daliuge.FieldType.ApplicationArgument){
+        if (parameterType === Daliuge.FieldType.Application){
             return this.canHaveApplicationArguments();
         }
 
@@ -976,7 +976,7 @@ export class Node {
                 false,
                 [],
                 false,
-                Daliuge.FieldType.ComponentParameter,
+                Daliuge.FieldType.Component,
                 Daliuge.FieldUsage.NoPort));
         } else {
             this.getFieldByDisplayText(Daliuge.FieldName.GROUP_START).setValue(value.toString());
@@ -996,7 +996,7 @@ export class Node {
                 false,
                 [],
                 false,
-                Daliuge.FieldType.ComponentParameter,
+                Daliuge.FieldType.Component,
                 Daliuge.FieldUsage.NoPort));
         } else {
             this.getFieldByDisplayText(Daliuge.FieldName.GROUP_END).setValue(value.toString());
@@ -1024,7 +1024,7 @@ export class Node {
 
     removeAllComponentParameters = () : void => {
         for (let i = this.fields().length - 1 ; i >= 0 ; i--){
-            if (this.fields()[i].getParameterType() === Daliuge.FieldType.ComponentParameter){
+            if (this.fields()[i].getParameterType() === Daliuge.FieldType.Component){
                 this.fields.splice(i, 1);
             }
         }
@@ -1032,7 +1032,7 @@ export class Node {
 
     removeAllApplicationArguments = () : void => {
         for (let i = this.fields().length - 1 ; i >= 0 ; i--){
-            if (this.fields()[i].getParameterType() === Daliuge.FieldType.ApplicationArgument){
+            if (this.fields()[i].getParameterType() === Daliuge.FieldType.Application){
                 this.fields.splice(i, 1);
             }
         }
@@ -1253,7 +1253,7 @@ export class Node {
     }
 
     addEmptyField = (index:number) :void => {
-        const newField = new Field(Utils.generateFieldId(), "New Parameter", "", "", "", false, Daliuge.DataType.String, false, [], false, Daliuge.FieldType.ComponentParameter, Daliuge.FieldUsage.NoPort);
+        const newField = new Field(Utils.generateFieldId(), "New Parameter", "", "", "", false, Daliuge.DataType.String, false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.NoPort);
 
         if(index === -1){
             this.addField(newField);
@@ -1547,7 +1547,7 @@ export class Node {
                 false,
                 [],
                 false,
-                Daliuge.FieldType.ComponentParameter,
+                Daliuge.FieldType.Component,
                 Daliuge.FieldUsage.NoPort);
             node.addField(preciousField);
         }
@@ -1565,7 +1565,7 @@ export class Node {
                 false,
                 [],
                 false,
-                Daliuge.FieldType.ComponentParameter,
+                Daliuge.FieldType.Component,
                 Daliuge.FieldUsage.NoPort);
             node.addField(streamingField);
         }
@@ -1584,7 +1584,7 @@ export class Node {
 
                 // if the parameter type is not specified, assume it is a ComponentParameter
                 if (field.getParameterType() === Daliuge.FieldType.Unknown){
-                    field.setParameterType(Daliuge.FieldType.ComponentParameter);
+                    field.setParameterType(Daliuge.FieldType.Component);
                 }
 
                 node.addField(field);
@@ -1595,7 +1595,7 @@ export class Node {
         if (typeof nodeData.applicationArgs !== 'undefined'){
             for (const paramData of nodeData.applicationArgs){
                 const field = Field.fromOJSJson(paramData);
-                field.setParameterType(Daliuge.FieldType.ApplicationArgument);
+                field.setParameterType(Daliuge.FieldType.Application);
                 node.addField(field);
             }
         }
@@ -1628,7 +1628,7 @@ export class Node {
         if (typeof nodeData.inputPorts !== 'undefined'){
             for (const inputPort of nodeData.inputPorts){
                 const port = Field.fromOJSJsonPort(inputPort);
-                port.setParameterType(Daliuge.FieldType.ApplicationArgument);
+                port.setParameterType(Daliuge.FieldType.Application);
                 port.setUsage(Daliuge.FieldUsage.InputPort);
 
                 if (node.canHaveInputs()){
@@ -1647,7 +1647,7 @@ export class Node {
         if (typeof nodeData.outputPorts !== 'undefined'){
             for (const outputPort of nodeData.outputPorts){
                 const port = Field.fromOJSJsonPort(outputPort);
-                port.setParameterType(Daliuge.FieldType.ApplicationArgument);
+                port.setParameterType(Daliuge.FieldType.Application);
                 port.setUsage(Daliuge.FieldUsage.OutputPort);
 
                 if (node.canHaveOutputs()){
@@ -1667,7 +1667,7 @@ export class Node {
             for (const inputLocalPort of nodeData.inputLocalPorts){
                 if (node.hasInputApplication()){
                     const port = Field.fromOJSJsonPort(inputLocalPort);
-                    port.setParameterType(Daliuge.FieldType.ApplicationArgument);
+                    port.setParameterType(Daliuge.FieldType.Application);
                     port.setUsage(Daliuge.FieldUsage.OutputPort);
 
                     node.inputApplication().addField(port);
@@ -1681,7 +1681,7 @@ export class Node {
         if (typeof nodeData.outputLocalPorts !== 'undefined'){
             for (const outputLocalPort of nodeData.outputLocalPorts){
                 const port = Field.fromOJSJsonPort(outputLocalPort);
-                port.setParameterType(Daliuge.FieldType.ApplicationArgument);
+                port.setParameterType(Daliuge.FieldType.Application);
                 port.setUsage(Daliuge.FieldUsage.InputPort);
 
                 if (node.hasOutputApplication()){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2091,7 +2091,7 @@ export class Utils {
         const srcPortType = destPort.getType() === undefined ? Daliuge.DataType.Object : destPort.getType();
 
         // create new source port
-        const srcPort = new Field(edge.getSrcPortId(), destPort.getDisplayText(), "", "", "", false, srcPortType, false, [], false, Daliuge.FieldType.ApplicationArgument, Daliuge.FieldUsage.OutputPort);
+        const srcPort = new Field(edge.getSrcPortId(), destPort.getDisplayText(), "", "", "", false, srcPortType, false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.OutputPort);
 
         // add port to source node
         srcNode.addField(srcPort);
@@ -2112,7 +2112,7 @@ export class Utils {
         const destPortType = srcPort.getType() === undefined ? Daliuge.DataType.Object : srcPort.getType();
 
         // create new destination port
-        const destPort = new Field(edge.getDestPortId(), srcPort.getDisplayText(), "", "", "", false, destPortType, false, [], false, Daliuge.FieldType.ApplicationArgument, Daliuge.FieldUsage.OutputPort);
+        const destPort = new Field(edge.getDestPortId(), srcPort.getDisplayText(), "", "", "", false, destPortType, false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.OutputPort);
 
         // add port to destination node
         destNode.addField(destPort);

--- a/static/tables.css
+++ b/static/tables.css
@@ -95,7 +95,7 @@
 }
 
 .parameter_table_parameter_type{
-    width: 171px;
+    width: 149px;
 }
 
 .parameter_table_type{


### PR DESCRIPTION
Switched to shorter fieldType names:

- ApplicationArgument -> Application
- ComponentParameter -> Component
- ConstraintParameter -> Constraint
- ConstructParameter -> Construct

Use originals when loading and saving ONLY, otherwise within EAGLE we use the new versions.

Eventually DALiuGE will be updated with the new names.

Decrease width of "Parameter Type" column in Parameter Table.
Newly added parameters are 'Application'-type instead of 'Component'-type

## Summary by Sourcery

Refactor field type names to use shorter, more concise versions while maintaining compatibility with existing data loading and saving mechanisms

New Features:
- Added methods to convert between legacy and new field type enumerations

Enhancements:
- Introduced conversion methods between old and new field type enums to ensure backward compatibility
- Reduced width of 'Parameter Type' column in parameter table

Chores:
- Replaced verbose field type names with shorter equivalents
- Updated all references to field types across multiple files