### PR TITLE
EAGLE-1421: Added undefined check for EagleStorage.db

### DIFF
--- a/src/EagleStorage.ts
+++ b/src/EagleStorage.ts
@@ -55,6 +55,11 @@ export class EagleStorage {
         return new Promise(async(resolve, reject) => {
             const customRepositories: Repository[] = [];
 
+            if (typeof EagleStorage.db === "undefined"){
+                reject("EagleStorage DB is undefined!")
+                return;
+            }
+
             // query IndexedDB
             const repositoriesObjectStore = EagleStorage.db.transaction(EagleStorage.TRANSACTION_NAME).objectStore(EagleStorage.OBJECT_STORE_NAME);
 


### PR DESCRIPTION
If EagleStorage.db is not defined, reject() within listCustomRepositories

## Summary by Sourcery

Bug Fixes:
- Prevent potential runtime errors by adding an undefined check for EagleStorage.db before attempting to access its transaction