### PR TITLE
EAGLE-1461: Configured values don't keep type

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -639,7 +639,7 @@ export class Field {
 
     // used to transform the value attribute of a field into a variable with the correct type
     // the value attribute is always stored as a string internally
-    static stringAsType(value: string, type: string) : any {
+    static stringAsType(value: string, type: Daliuge.DataType) : any {
         switch (type){
             case Daliuge.DataType.Boolean:
                 return Utils.asBool(value);

--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -5,8 +5,10 @@ import { Eagle } from "./Eagle";
 import { Errors } from "./Errors";
 import { Field } from "./Field";
 import { LogicalGraph } from "./LogicalGraph";
+import { Node } from "./Node";
 import { Utils } from "./Utils";
 import { EagleConfig } from "./EagleConfig";
+import { Daliuge } from "./Daliuge";
 
 export class GraphConfig {
     private id: ko.Observable<GraphConfig.Id>;
@@ -209,7 +211,7 @@ export class GraphConfig {
         return result;
     }
 
-    static toJson(graphConfig: GraphConfig) : object {
+    static toJson(graphConfig: GraphConfig, logicalGraph: LogicalGraph) : object {
         const result : any = {};
 
         // NOTE: we don't write isModified to JSON, it is run-time only
@@ -219,8 +221,8 @@ export class GraphConfig {
         // add nodes
         result.nodes = {};
         for (const node of graphConfig.nodes()){
-
-            result.nodes[node.getId()] = GraphConfigNode.toJSON(node);
+            const graphNode: Node = logicalGraph.findNodeByIdQuiet(node.getId());
+            result.nodes[node.getId()] = GraphConfigNode.toJSON(node, graphNode);
         }
 
         result.lastModifiedName = graphConfig.lastModifiedName();
@@ -230,10 +232,10 @@ export class GraphConfig {
         return result;
     }
 
-    static toJsonString(graphConfig: GraphConfig) : string {
+    static toJsonString(graphConfig: GraphConfig, logicalGraph: LogicalGraph) : string {
         let result: string = "";
 
-        const json: any = GraphConfig.toJson(graphConfig);
+        const json: any = GraphConfig.toJson(graphConfig, logicalGraph);
 
         // NOTE: manually build the JSON so that we can enforce ordering of attributes (modelData first)
         result += JSON.stringify(json, null, EagleConfig.JSON_INDENT);
@@ -351,7 +353,7 @@ export class GraphConfigNode {
         return result;
     }
 
-    static toJSON(node: GraphConfigNode) : object {
+    static toJSON(node: GraphConfigNode, graphNode: Node) : object {
         const result : any = {};
 
         // NOTE: do not add 'id' attribute, since nodes are stored in a dict keyed by id
@@ -359,7 +361,8 @@ export class GraphConfigNode {
         // add fields
         result.fields = {};
         for (const field of node.fields()){
-            result.fields[field.getId()] = GraphConfigField.toJson(field);
+            const type = graphNode.findFieldById(field.getId())?.getType();
+            result.fields[field.getId()] = GraphConfigField.toJson(field, type);
         }
 
         return result;
@@ -433,11 +436,11 @@ export class GraphConfigField {
         return result;
     }
 
-    static toJson(field: GraphConfigField): object {
+    static toJson(field: GraphConfigField, type: Daliuge.DataType): object {
         const result : any = {};
 
         // NOTE: do not add 'id' attribute, since fields are stored in a dict keyed by id
-        result.value = field.value();
+        result.value = Field.stringAsType(field.value(), type);
         result.comment = field.comment();
 
         return result;

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -123,7 +123,7 @@ export class LogicalGraph {
         // add graph configurations
         result.graphConfigurations = {};
         for (const gc of graph.graphConfigs()){
-            result.graphConfigurations[gc.getId()] = GraphConfig.toJson(gc);
+            result.graphConfigurations[gc.getId()] = GraphConfig.toJson(gc, graph);
         }
 
         // saving the id of the active graph configuration
@@ -148,7 +148,7 @@ export class LogicalGraph {
                 result += '"graphConfigurations": {},\n';
             } else {
                 const graphConfigurations: any = {};
-                graphConfigurations[graph.activeGraphConfigId().toString()] = GraphConfig.toJson(graph.getActiveGraphConfig());
+                graphConfigurations[graph.activeGraphConfigId().toString()] = GraphConfig.toJson(graph.getActiveGraphConfig(), graph);
 
                 result += '"graphConfigurations": ' + JSON.stringify(graphConfigurations, null, EagleConfig.JSON_INDENT) + ",\n";
             }


### PR DESCRIPTION
Use Node field type when writing value of GraphConfig field to JSON

## Summary by Sourcery

Bug Fixes:
- Fix loss of data type information when saving graph configuration fields to JSON, ensuring values are stored according to their defined type (e.g., boolean, number) instead of always as strings.