### PR TITLE
EAGLE-1410: func_code and func_name checking

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -164,7 +164,6 @@ export namespace Daliuge {
     export const funcNameField = new Field(null, FieldName.FUNC_NAME, "", "func_name", "Python function name", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.ComponentParameter, FieldUsage.NoPort);
 
     // This list defines the fields required for ALL nodes belonging to a given Category.Type
-    // NOTE: ids are empty string here, we should generate a new id whenever we clone the fields
     export const categoryTypeFieldsRequired = [
         {
             categoryTypes: [
@@ -195,7 +194,6 @@ export namespace Daliuge {
     ];
 
     // This list defines the fields required for ALL nodes belonging to a given Category
-    // NOTE: ids are empty string here, remember to generate a new id whenever cloning the fields
     export const categoryFieldsRequired = [
         {
             categories: [
@@ -260,14 +258,6 @@ export namespace Daliuge {
         {
             categories: [
                 Category.PythonMemberFunction
-            ],
-            fields: [
-                Daliuge.funcNameField
-            ]
-        },
-        {
-            categories: [
-                Category.DALiuGEApp
             ],
             fields: [
                 Daliuge.funcNameField


### PR DESCRIPTION
Removed requirement for func_name field in DaliugeApp components

## Summary by Sourcery

Chores:
- Remove outdated comments related to field cloning.