### PR TITLE
Eagle 1450

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -635,7 +635,9 @@ export class Eagle {
 
     
     getTranslatorColor : ko.PureComputed<string> = ko.pureComputed(() : string => {
-        if (this.logicalGraph().fileInfo().modified){
+        if(Setting.findValue(Setting.TEST_TRANSLATE_MODE)){
+            return 'orange'
+        }else if (this.logicalGraph().fileInfo().modified){
             return 'red'
         }else{
             return 'green'

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -624,13 +624,21 @@ export class Eagle {
         if (this.selectedObjects().length !== 1){
             return null;
         }
-
         const object = this.selectedObjects()[0];
 
         if (object instanceof Edge){
             return object;
         } else {
             return null;
+        }
+    }, this);
+
+    
+    getTranslatorColor : ko.PureComputed<string> = ko.pureComputed(() : string => {
+        if (this.logicalGraph().fileInfo().modified){
+            return 'red'
+        }else{
+            return 'green'
         }
     }, this);
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -635,7 +635,9 @@ export class Eagle {
 
     
     getTranslatorColor : ko.PureComputed<string> = ko.pureComputed(() : string => {
-        if(Setting.findValue(Setting.TEST_TRANSLATE_MODE)){
+        const isLocalFile: boolean = this.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
+
+        if(Setting.findValue(Setting.TEST_TRANSLATE_MODE) || isLocalFile){
             return 'orange'
         }else if (this.logicalGraph().fileInfo().modified){
             return 'red'

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -637,7 +637,10 @@ export class Eagle {
     getTranslatorColor : ko.PureComputed<string> = ko.pureComputed(() : string => {
         const isLocalFile: boolean = this.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
 
-        if(Setting.findValue(Setting.TEST_TRANSLATE_MODE) || isLocalFile){
+        if(isLocalFile){
+            return 'dodgerblue'
+
+        }else if(Setting.findValue(Setting.TEST_TRANSLATE_MODE)){
             return 'orange'
         }else if (this.logicalGraph().fileInfo().modified){
             return 'red'

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -312,6 +312,7 @@ export class Setting {
     static readonly CONFIRM_RELOAD_PALETTES : string = "ConfirmReloadPalettes";
     static readonly CONFIRM_DELETE_FILES : string = "ConfirmDeleteFiles";
     static readonly CONFIRM_DELETE_OBJECTS : string = "ConfirmDeleteObjects";
+    static readonly TEST_TRANSLATE_MODE : string = "TestTranslateMode";
 
     static readonly SHOW_DEVELOPER_NOTIFICATIONS: string = "ShowDeveloperNotifications";
     static readonly SHOW_FILE_LOADING_ERRORS : string = "ShowFileLoadingErrors";
@@ -407,6 +408,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Open " + Palette.TEMPLATE_PALETTE_NAME + " Palette on Startup", Setting.OPEN_TEMPLATE_PALETTE, "Open the '" + Palette.TEMPLATE_PALETTE_NAME + "' palette on startup.", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Disable JSON Validation", Setting.DISABLE_JSON_VALIDATION, "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", false, Setting.Type.Boolean, false,false,false,false,false),
             new Setting(true, "Overwrite Existing Translator Tab", Setting.OVERWRITE_TRANSLATION_TAB, "When translating a graph, overwrite an existing translator tab", false, Setting.Type.Boolean, true,true,true,true,true),
+            new Setting(false, "Test Translate Mode", Setting.TEST_TRANSLATE_MODE, "Remove the necessity to save when translating.", false, Setting.Type.Boolean, false,false,false,false,false),
         ]
     ),
     new SettingsGroup(

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -133,7 +133,7 @@ export class Translator {
         const isLocalFile: boolean = eagle.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
 
         // check if the graph is committed before translation
-        if (!isLocalFile && this._checkGraphModified(eagle)){
+        if (!Setting.findValue(Setting.TEST_TRANSLATE_MODE) && !isLocalFile && this._checkGraphModified(eagle)){
             Utils.showNotification("Saving graph", "Automatically saving modified graph prior to translation", "info");
 
             // use the async function here, so that we can check isModified after saving

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2506,26 +2506,26 @@ export class Utils {
 
     static getRmodeTooltip() : string {
         let html = '**General**: Sets the standard for provenance tracking throughout graph translation and execution. Used to determine scientifically (high-level) changes to workflow behaviour. Signature files are stored alongside log files. Refer to the documentation for further explanation.<br>'
-        html = html+'**Documentation link** <a href="https://daliuge.readthedocs.io/en/latest/architecture/reproducibility/reproducibility.html" target="_blank">daliuge.readthedocs</a><br>'
-        html = html+'**NOTHING**: No provenance data is tracked at any stage.<br>'
-        html = html+'**ALL**: Data for all subsequent levels is generated and stored together.<br>'
-        html = html+'**RERUN**: Stores general about all logical graph components<br>'
-        html = html+'**REPEAT**: Stores specific information about logical and physical graph components<br>'
-        html = html+'**RECOMPUTE**: Stores maximum information about logical and physical graph components and at runtime.<br>'
-        html = html+'**REPRODUCE**: Stores information about terminal data drops at logical, physical and runtime layers.<br>'
-        html = html+'**REPLICATE SCI**: Essentially RERUN + REPRODUCE<br>'
-        html = html+'**REPLICATE COMP**: Essentially RECOMPUTE + REPRODUCE<br>'
-        html = html+'**REPLICATE TOTALLY**: Essentially REPEAT + REPRODUCE<br>'
+        html += '**Documentation link** <a href="https://daliuge.readthedocs.io/en/latest/architecture/reproducibility/reproducibility.html" target="_blank">daliuge.readthedocs</a><br>'
+        html += '**NOTHING**: No provenance data is tracked at any stage.<br>'
+        html += '**ALL**: Data for all subsequent levels is generated and stored together.<br>'
+        html += '**RERUN**: Stores general about all logical graph components<br>'
+        html += '**REPEAT**: Stores specific information about logical and physical graph components<br>'
+        html += '**RECOMPUTE**: Stores maximum information about logical and physical graph components and at runtime.<br>'
+        html += '**REPRODUCE**: Stores information about terminal data drops at logical, physical and runtime layers.<br>'
+        html += '**REPLICATE SCI**: Essentially RERUN + REPRODUCE<br>'
+        html += '**REPLICATE COMP**: Essentially RECOMPUTE + REPRODUCE<br>'
+        html += '**REPLICATE TOTALLY**: Essentially REPEAT + REPRODUCE<br>'
 
         return html
     }
 
     static getTranslateBtnColorTooltip() : string {
         let html = '**Reproducibility Status**<br><br>'
-        html = html+'**Green:** Graph is saved and ready for translation.<br>'
-        html = html+'**Red:** Graph is not saved, Save before translation.<br>'
-        html = html+'**Orange:** In test translation mode, do not use for workflow execution.<br>'
-        html = html+'**Blue:** Using a local graph, up to the user to keep a copy of the logical graph if you wish to keep full reproducibility of the workflow.'
+        html += '**Green:** Graph is saved and ready for translation.<br>'
+        html += '**Red:** Graph is not saved, Save before translation.<br>'
+        html += '**Orange:** In test translation mode, do not use for workflow execution.<br>'
+        html += '**Blue:** Using a local graph, up to the user to keep a copy of the logical graph if you wish to keep full reproducibility of the workflow.'
 
         return html
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2525,7 +2525,7 @@ export class Utils {
         html += '**Green:** Graph is saved and ready for translation.<br>'
         html += '**Red:** Graph is not saved, Save before translation.<br>'
         html += '**Orange:** In test translation mode, do not use for workflow execution.<br>'
-        html += '**Blue:** Using a local graph, up to the user to keep a copy of the logical graph if you wish to keep full reproducibility of the workflow.'
+        html += "**Blue:** Graph is a local file, it is the user's responsibility to keep a copy if full workflow reproducibility is required."
 
         return html
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2520,6 +2520,17 @@ export class Utils {
         return html
     }
 
+    static getTranslateBtnColorTooltip() : string {
+        let html = '**Reproducibility Status**<br><br>'
+        html = html+'**Green:** Graph is saved and ready for translation.<br>'
+        html = html+'**Red:** Graph is not saved, Save before translation.<br>'
+        html = html+'**Orange:** In test translation mode, do not use for workflow execution.<br>'
+        html = html+'**Blue:** Using a local graph, up to the user to keep a copy of the logical graph if you wish to keep full reproducibility of the workflow.'
+
+        return html
+    }
+
+
     static copyInputTextModalInput(): void {
         navigator.clipboard.writeText($('#inputTextModalInput').val().toString());
     }

--- a/static/base.css
+++ b/static/base.css
@@ -1658,10 +1658,10 @@ select.form-control{
 .navbar #navTranslateWrapper{
     position: relative;
     width: 110px;
+    height: 32px;
     border: white 1px solid;
     border-radius: 5px;
     margin: 4px 0px;
-    overflow: hidden;
 }
 
 .navbar #navTranslateBtn{
@@ -1690,7 +1690,7 @@ select.form-control{
     padding: unset;
     width: 20px;
     background: white;
-    border-radius: unset;
+    border-radius: 0px 4px 4px 0px;
 }
 
 .navbar #navTranslateWrapper button span{
@@ -1705,6 +1705,7 @@ select.form-control{
     inset: 0px auto 0px 0px;
     width: 7px;
     background-color: orange;
+    border-radius: 4px 0px 0px 4px;
 }
 
 #repositoryList ul.repositories {

--- a/static/base.css
+++ b/static/base.css
@@ -1655,6 +1655,58 @@ select.form-control{
     background: rgb(211, 211, 211);
 }
 
+.navbar #navTranslateWrapper{
+    position: relative;
+    width: 110px;
+    border: white 1px solid;
+    border-radius: 5px;
+    margin: 4px 0px;
+    overflow: hidden;
+}
+
+.navbar #navTranslateBtn{
+    position: absolute;
+    color: white;
+    padding: unset;
+    inset: 0px 20px 0px 7px;
+}
+
+.navbar #navTranslateBtn:hover{
+    background-color: white;
+    color: #002349;
+    cursor:pointer;
+}
+
+.navbar #navTranslateBtn span{
+    position: absolute;
+    inset: 50% auto auto 4px;
+    transform: translateY(-50%);
+}
+
+.navbar #navTranslateWrapper button{
+    border: none;
+    position: absolute;
+    inset: 0px 0px 0px auto;
+    padding: unset;
+    width: 20px;
+    background: white;
+    border-radius: unset;
+}
+
+.navbar #navTranslateWrapper button span{
+    inset: 50% -2px auto auto;
+    position: absolute;
+    transform: translateY(-50%);
+    color:#002349;
+}
+
+.navbar #navTranslateWrapper #navTranslateStatus{
+    position: absolute;
+    inset: 0px auto 0px 0px;
+    width: 7px;
+    background-color: orange;
+}
+
 #repositoryList ul.repositories {
     list-style-type: none;
     padding: 0px;

--- a/static/base.css
+++ b/static/base.css
@@ -1657,7 +1657,7 @@ select.form-control{
 
 .navbar #navTranslateWrapper{
     position: relative;
-    width: 120px;
+    width: 138px;
     height: 32px;
     border: white 1px solid;
     border-radius: 5px;

--- a/static/base.css
+++ b/static/base.css
@@ -1679,7 +1679,7 @@ select.form-control{
 
 .navbar #navTranslateBtn span{
     position: absolute;
-    inset: 50% auto auto 4px;
+    inset: 50% auto auto 6px;
     transform: translateY(-50%);
 }
 
@@ -1690,6 +1690,7 @@ select.form-control{
     padding: unset;
     width: 20px;
     background: white;
+    box-shadow: none;
     border-radius: 0px 4px 4px 0px;
 }
 
@@ -1703,7 +1704,7 @@ select.form-control{
 .navbar #navTranslateWrapper #navTranslateStatus{
     position: absolute;
     inset: 0px auto 0px 0px;
-    width: 7px;
+    width: 9px;
     background-color: orange;
     border-radius: 4px 0px 0px 4px;
 }

--- a/static/base.css
+++ b/static/base.css
@@ -1657,7 +1657,7 @@ select.form-control{
 
 .navbar #navTranslateWrapper{
     position: relative;
-    width: 110px;
+    width: 120px;
     height: 32px;
     border: white 1px solid;
     border-radius: 5px;

--- a/static/base.css
+++ b/static/base.css
@@ -1664,20 +1664,20 @@ select.form-control{
     margin: 4px 0px;
 }
 
-.navbar #navTranslateBtn{
+.navbar .navTranslateBtn{
     position: absolute;
     color: white;
     padding: unset;
     inset: 0px 20px 0px 7px;
 }
 
-.navbar #navTranslateBtn:hover{
+.navbar .navTranslateBtn:hover{
     background-color: white;
     color: #002349;
     cursor:pointer;
 }
 
-.navbar #navTranslateBtn span{
+.navbar .navTranslateBtn span{
     position: absolute;
     inset: 50% auto auto 6px;
     transform: translateY(-50%);

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -95,12 +95,12 @@
                 <div id="navTranslateWrapper">
                     <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}, eagleTooltip:Utils.getTranslateBtnColorTooltip()"></div>
                     <!-- ko ifnot: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
-                        <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
+                        <div class="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
                             <span>Translate</span>
                         </div>
                     <!-- /ko -->
                     <!-- ko if: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
-                        <div id="navTranslateBtn" data-bind="eagleTooltip:'Test Translation of the graph using the selected algorithm. This mode is for rapid graph development, reproducibility safeguards are switched off. Do not use for workflow execution. ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
+                        <div class="navTranslateBtn" data-bind="eagleTooltip:'Test Translation of the graph using the selected algorithm. This mode is for rapid graph development, reproducibility safeguards are switched off. Do not use for workflow execution. ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
                             <span>Test Translate</span>
                         </div>
                     <!-- /ko -->

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -92,7 +92,7 @@
 
         <ul class="nav navbar-nav ms-auto">
             <div id="navTranslateWrapper">
-                <div id="navTranslateStatus"></div>
+                <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
                 <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
                     <span>Translate</span>
                 </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -95,7 +95,12 @@
                 <div id="navTranslateWrapper">
                     <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
                     <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
-                        <span>Translate</span>
+                        <!-- ko if: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
+                            <span>Test Mode</span>
+                        <!-- /ko -->
+                        <!-- ko ifnot: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
+                            <span>Translate</span>
+                        <!-- /ko -->
                     </div>
                     <button class="btn btn-outline-secondary nav-link dropdown-toggle ms-auto" data-bs-toggle="dropdown" id="navbarDropdownTranslate" aria-expanded="true" data-bind="" type="button">
                         <span class="material-icons-outlined iconHoverEffect">
@@ -103,8 +108,8 @@
                         </span>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownTranslate">
-                        <a href="#">option1</a>
-                        <a href="#">option2</a>
+                        <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
+                        <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Mode</a>
                     </div>
                 </div>
             </li>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -93,15 +93,18 @@
         <ul class="nav navbar-nav ms-auto">
             <li class="nav-item dropdown">
                 <div id="navTranslateWrapper">
-                    <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
-                    <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
-                        <!-- ko if: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
-                            <span>Test Translate</span>
-                        <!-- /ko -->
-                        <!-- ko ifnot: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
+                    <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}, eagleTooltip:Utils.getTranslateBtnColorTooltip()"></div>
+                    <!-- ko ifnot: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
+                        <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
                             <span>Translate</span>
-                        <!-- /ko -->
-                    </div>
+                        </div>
+                    <!-- /ko -->
+                    <!-- ko if: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
+                        <div id="navTranslateBtn" data-bind="eagleTooltip:'Test Translation of the graph using the selected algorithm. This mode is for rapid graph development, reproducibility safeguards are switched off. Do not use for workflow execution. ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
+                            <span>Test Translate</span>
+                        </div>
+                    <!-- /ko -->
+
                     <button class="btn btn-outline-secondary nav-link dropdown-toggle ms-auto" data-bs-toggle="dropdown" id="navbarDropdownTranslate" aria-expanded="true" data-bind="" type="button">
                         <span class="material-icons-outlined iconHoverEffect">
                             arrow_drop_down
@@ -109,7 +112,7 @@
                     </button>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownTranslate">
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
-                        <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Mode</a>
+                        <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Translate</a>
                     </div>
                 </div>
             </li>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -91,9 +91,21 @@
         </ul>
 
         <ul class="nav navbar-nav ms-auto">
-            <div id="navDeployBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true)">
-                <a href='javascript:void(0)' data-bind="click: function(){$root.deployDefaultTranslationAlgorithm()}">Translate</a>
+            <div id="navTranslateWrapper">
+                <div id="navTranslateStatus"></div>
+                <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
+                    <span>Translate</span>
+                </div>
+                <button class="btn btn-outline-secondary show" data-bs-toggle="dropdown" aria-expanded="true" data-bind="" type="button">
+                    <span class="material-icons-outlined iconHoverEffect">
+                        arrow_drop_down
+                    </span>
+                </button>
+
             </div>
+            <!-- <div id="navDeployBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true)">
+                <a href='javascript:void(0)' data-bind="click: function(){$root.deployDefaultTranslationAlgorithm()}">Translate</a>
+            </div> -->
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -91,18 +91,23 @@
         </ul>
 
         <ul class="nav navbar-nav ms-auto">
-            <div id="navTranslateWrapper">
-                <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
-                <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
-                    <span>Translate</span>
+            <li class="nav-item dropdown">
+                <div id="navTranslateWrapper">
+                    <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
+                    <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
+                        <span>Translate</span>
+                    </div>
+                    <button class="btn btn-outline-secondary nav-link dropdown-toggle ms-auto" data-bs-toggle="dropdown" id="navbarDropdownTranslate" aria-expanded="true" data-bind="" type="button">
+                        <span class="material-icons-outlined iconHoverEffect">
+                            arrow_drop_down
+                        </span>
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownTranslate">
+                        <a href="#">option1</a>
+                        <a href="#">option2</a>
+                    </div>
                 </div>
-                <button class="btn btn-outline-secondary show" data-bs-toggle="dropdown" aria-expanded="true" data-bind="" type="button">
-                    <span class="material-icons-outlined iconHoverEffect">
-                        arrow_drop_down
-                    </span>
-                </button>
-
-            </div>
+            </li>
             <!-- <div id="navDeployBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true)">
                 <a href='javascript:void(0)' data-bind="click: function(){$root.deployDefaultTranslationAlgorithm()}">Translate</a>
             </div> -->

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -96,7 +96,7 @@
                     <div id="navTranslateStatus" data-bind="style: {'background-color':$root.getTranslatorColor()}"></div>
                     <div id="navTranslateBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true),click: function(){$root.deployDefaultTranslationAlgorithm()}">
                         <!-- ko if: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
-                            <span>Test Mode</span>
+                            <span>Test Translate</span>
                         <!-- /ko -->
                         <!-- ko ifnot: Setting.findValue(Setting.TEST_TRANSLATE_MODE) -->
                             <span>Translate</span>
@@ -113,9 +113,6 @@
                     </div>
                 </div>
             </li>
-            <!-- <div id="navDeployBtn" data-bind="eagleTooltip:'Translate graph using the selected algorithm ' + KeyboardShortcut.idToText('deploy_translator', true)">
-                <a href='javascript:void(0)' data-bind="click: function(){$root.deployDefaultTranslationAlgorithm()}">Translate</a>
-            </div> -->
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph


### PR DESCRIPTION
addition of a new translate button and the test translation feature.

## Summary by Sourcery

Introduce a "Test Translate" mode and update the navbar translate button.

New Features:
- Add a "Test Translate" mode which allows translation without requiring the graph to be saved.
- Update the navbar translate button to a dropdown allowing selection between "Translate" and "Test Translate" modes.
- Add a status indicator to the translate button showing graph save status and translation mode (normal, test, local file).
- Add a user setting to enable or disable "Test Translate" mode.

Enhancements:
- Refactor the navbar translate button into a dropdown component with status indication.