### PR TITLE
EAGLE-1463: New menu item for "Create New Graph From Url"

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -110,27 +110,20 @@ def index():
     FLASK GET routing method for '/'
 
     Defines what is returned when the base URL is called.
-    The following URL GET parameters are defined here in addition:
-
-    service
-    repository
-    branch
-    path
-    filename
 
     IF the URL does not specify a graph to load, the default template with no additional information is rendered.
     """
-    service    = request.args.get("service")
-    repository = request.args.get("repository")
-    branch     = request.args.get("branch")
-    path       = request.args.get("path")
-    filename   = request.args.get("filename")
-    url        = request.args.get("url")
-    mode       = request.args.get("mode")
+    service    = request.args.get("service", "")
+    repository = request.args.get("repository", "")
+    branch     = request.args.get("branch", "")
+    path       = request.args.get("path", "")
+    filename   = request.args.get("filename", "")
+    url        = request.args.get("url", "")
+    mode       = request.args.get("mode", "")
 
     # if the url does not specify a graph to load, just send render the default template with no additional information
-    if service is None:
-        if mode is None:
+    if service == "":
+        if mode == "":
             return render_template("base.html", version=version, commit_hash=commit_hash)
         else:
             return render_template("base.html", version=version, commit_hash=commit_hash, mode=mode)

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1418,6 +1418,25 @@ export class Eagle {
         this.logicalGraph.valueHasMutated();
     }
 
+    newLogicalGraphFromUrl = async(): Promise<void> => {
+        // TODO: check for ALLOW_GRAPH_EDITING
+
+        let url: string;
+        try {
+            url = await Utils.requestUserString("Url", "Enter Url of Graph to load", "", false);
+        } catch(error){
+            console.error(error);
+            return;
+        }
+
+        try {
+            Repositories.selectFile(new RepositoryFile(new Repository(Repository.Service.Url, "", "", false), "", url));
+        } catch(error){
+            console.error(error);
+            return;
+        }
+    }
+
     displayObjectAsJson = (fileType: Eagle.FileType) : void => {
         let jsonString: string;
         

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -506,4 +506,21 @@ export class FileInfo {
 
         return result;
     }
+
+    static generateUrl(fileInfo: FileInfo): string {
+        let url = window.location.origin;
+
+        url += "/?service=" + fileInfo.repositoryService;
+
+        if (fileInfo.repositoryService === Repository.Service.Url){
+            url += "&url=" + fileInfo.downloadUrl;
+        } else {
+            url += "&repository=" + fileInfo.repositoryName;
+            url += "&branch=" + fileInfo.repositoryBranch;
+            url += "&path=" + encodeURI(fileInfo.path);
+            url += "&filename=" + encodeURI(fileInfo.name);
+        }
+
+        return url;
+    }
 }

--- a/src/Palette.ts
+++ b/src/Palette.ts
@@ -273,18 +273,12 @@ export class Palette {
         // if we don't know where this file came from then we can't build a URL
         // for example, if the palette was loaded from local disk, then we can't build a URL for others to reach it
         if (fileInfo.repositoryService === Repository.Service.Unknown || fileInfo.repositoryService === Repository.Service.File){
-            Utils.showNotification("Palette URL", "Source of palette is a local file or unknown, unable to create URL for graph.", "danger");
+            Utils.showNotification("Palette URL", "Source of palette is a local file or unknown, unable to create URL for palette.", "danger");
             return;
         }
 
-        // build palette url
-        let palette_url = window.location.origin;
-
-        palette_url += "/?service=" + fileInfo.repositoryService;
-        palette_url += "&repository=" + fileInfo.repositoryName;
-        palette_url += "&branch=" + fileInfo.repositoryBranch;
-        palette_url += "&path=" + encodeURI(fileInfo.path);
-        palette_url += "&filename=" + encodeURI(fileInfo.name);
+        // generate URL
+        const palette_url = FileInfo.generateUrl(fileInfo);
 
         // copy to clipboard
         navigator.clipboard.writeText(palette_url);

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -1,15 +1,12 @@
 import * as ko from "knockout";
 
-import {Eagle} from './Eagle';
-import {GitHub} from './GitHub';
-import {GitLab} from './GitLab';
-import {Palette} from './Palette';
-import {Repository} from './Repository';
-import {RepositoryFolder} from './RepositoryFolder';
-import {RepositoryFile} from './RepositoryFile';
-import {Setting} from './Setting';
-import {Utils} from './Utils';
+import { Eagle } from './Eagle';
 import { EagleStorage } from "./EagleStorage";
+import { Palette } from './Palette';
+import { Repository } from './Repository';
+import { RepositoryFile } from './RepositoryFile';
+import { Setting } from './Setting';
+import { Utils } from './Utils';
 
 export class Repositories {
 
@@ -50,6 +47,7 @@ export class Repositories {
                 await Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges);
             } catch (error) {
                 console.error(error);
+                eagle.hideEagleIsLoading();
                 return;
             }
 

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -59,6 +59,16 @@ export class Repositories {
         }
     }
     
+    static translateStringToService(service: string): Repository.Service {
+        for (const s in Repository.Service){
+            if (s.toLowerCase() === service.toLowerCase()){
+                return s as Repository.Service;
+            }
+        }
+
+        return Repository.Service.Unknown;
+    }
+
     // use a custom modal to ask user for repository service and url at the same time
     addCustomRepository = async () => {
         let customRepository: Repository;

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -135,6 +135,7 @@ export class Repository {
                 // if we could not find one step in the path, then abort
                 if (!foundPathPart){
                     reject(new Error("Could not find path part (" + pathPart + "), pointer is at " + pointer.name));
+                    return;
                 }
             }
 
@@ -165,6 +166,7 @@ export class Repository {
                 // if we could not find one step in the path, then abort
                 if (!foundPathPart){
                     reject(new Error("Could not find path part (" + pathPart + "), pointer is at " + pointer.name));
+                    return;
                 }
             }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -316,73 +316,103 @@ export class Utils {
     }
     
     static async httpGet(url: string): Promise<string> {
-        return $.ajax({
-            url: url
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
     static async httpGetJSON(url: string, json: object): Promise<object> {
-        return $.ajax({
-            url: url,
-            type: 'GET',
-            data: JSON.stringify(json),
-            contentType: 'application/json'
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url,
+                type: 'GET',
+                data: JSON.stringify(json),
+                contentType: 'application/json'
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
     static async httpPost(url : string, data : string): Promise<string> {
-        return $.ajax({
-            url: url,
-            type: 'POST',
-            data: data,
-            processData: false,  // tell jQuery not to process the data
-            contentType: false   // tell jQuery not to set contentType
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: data,
+                processData: false,  // tell jQuery not to process the data
+                contentType: false   // tell jQuery not to set contentType
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
     static async httpPostJSON(url : string, json : object): Promise<string> {
-        return $.ajax({
-            url: url,
-            type: 'POST',
-            data: JSON.stringify(json),
-            contentType: 'application/json'
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: JSON.stringify(json),
+                contentType: 'application/json'
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
     static async httpPostJSONString(url : string, jsonString : string): Promise<string> {
-        return $.ajax({
-            url: url,
-            type: 'POST',
-            data: jsonString,
-            contentType: 'application/json'
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: jsonString,
+                contentType: 'application/json'
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
     static async httpPostForm(url : string, formData : FormData): Promise<string> {
-        return $.ajax({
-            url: url,
-            type: 'POST',
-            data: formData,
-            processData: false,  // tell jQuery not to process the data
-            contentType: false   // tell jQuery not to set contentType
-        })
-        .fail((xhr, textStatus) => {
-            return Promise.reject(Utils.parseAjaxError(xhr, textStatus));
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: formData,
+                processData: false,  // tell jQuery not to process the data
+                contentType: false   // tell jQuery not to set contentType
+            })
+            .fail((xhr, textStatus) => {
+                reject(Utils.parseAjaxError(xhr, textStatus));
+            })
+            .done((data) => {
+                resolve(data);
+            });
         });
     }
 
@@ -2525,7 +2555,7 @@ export class Utils {
         html += '**Green:** Graph is saved and ready for translation.<br>'
         html += '**Red:** Graph is not saved, Save before translation.<br>'
         html += '**Orange:** In test translation mode, do not use for workflow execution.<br>'
-        html += "**Blue:** Graph is a local file, it is the user's responsibility to keep a copy if full workflow reproducibility is required."
+        html += "**Blue:** Graph is not stored in a git repository, it is the user's responsibility to keep a copy if full workflow reproducibility is required."
 
         return html
     }
@@ -2617,7 +2647,8 @@ export class Utils {
             try {
                 data = await Utils.httpGet(fileName);
             } catch (error) {
-                reject(error)
+                reject(error);
+                return;
             }
 
             resolve(data);

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -129,6 +129,7 @@
                                 </a>
                                 <a class="dropdown-item" id="createNewGraphFromJson" href="#" data-bind="click: newLogicalGraphFromJson">Create New Graph from JSON</a>
                                 <a class="dropdown-item" id="addToGraphFromJson" href="#" data-bind="click: addToGraphFromJson">Add to Graph from JSON</a>
+                                <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: newLogicalGraphFromUrl">Create New Graph from URL</a>
                                 <a class="dropdown-item" id="addEdgeToLogicalGraph" href="#" data-bind="click: addEdgeToLogicalGraph">Add Edge to Graph
                                     <span data-bind="text: KeyboardShortcut.idToText('add_edge', true)"></span>
                                 </a>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -160,7 +160,7 @@
                                 </a>
                             </div>
                         </span>
-                        <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: function(){loadFileFromUrl()}">Open Graph from URL</a>
+                        <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: function(){loadFileFromUrl(Eagle.FileType.Graph)}">Open from URL</a>
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item" id="displayGraphAsJson" href="#" data-bind="click: function(){displayObjectAsJson(Eagle.FileType.Graph);}">Display As Json</a>
                         <a class="dropdown-item" id="screenshotGraph" href="#" data-bind="click: saveGraphScreenshot">Screenshot</a>
@@ -205,7 +205,7 @@
                             </a>
                         </div>
                     </span>
-                    <a class="dropdown-item" id="createNewPaletteFromUrl" href="#" data-bind="click: function(){loadFileFromUrl(Eagle.FileType.Palette)}">Open Palette from URL</a>
+                    <a class="dropdown-item" id="createNewPaletteFromUrl" href="#" data-bind="click: function(){loadFileFromUrl(Eagle.FileType.Palette)}">Open from URL</a>
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" id="saveToPalette" href="#" data-bind="click: addGraphNodesToPalette">Add Graph Nodes</a>
                 <!-- /ko -->

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -129,7 +129,6 @@
                                 </a>
                                 <a class="dropdown-item" id="createNewGraphFromJson" href="#" data-bind="click: newLogicalGraphFromJson">Create New Graph from JSON</a>
                                 <a class="dropdown-item" id="addToGraphFromJson" href="#" data-bind="click: addToGraphFromJson">Add to Graph from JSON</a>
-                                <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: newLogicalGraphFromUrl">Create New Graph from URL</a>
                                 <a class="dropdown-item" id="addEdgeToLogicalGraph" href="#" data-bind="click: addEdgeToLogicalGraph">Add Edge to Graph
                                     <span data-bind="text: KeyboardShortcut.idToText('add_edge', true)"></span>
                                 </a>
@@ -161,6 +160,7 @@
                                 </a>
                             </div>
                         </span>
+                        <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: function(){loadFileFromUrl()}">Open Graph from URL</a>
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item" id="displayGraphAsJson" href="#" data-bind="click: function(){displayObjectAsJson(Eagle.FileType.Graph);}">Display As Json</a>
                         <a class="dropdown-item" id="screenshotGraph" href="#" data-bind="click: saveGraphScreenshot">Screenshot</a>
@@ -205,6 +205,7 @@
                             </a>
                         </div>
                     </span>
+                    <a class="dropdown-item" id="createNewPaletteFromUrl" href="#" data-bind="click: function(){loadFileFromUrl(Eagle.FileType.Palette)}">Open Palette from URL</a>
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" id="saveToPalette" href="#" data-bind="click: addGraphNodesToPalette">Add Graph Nodes</a>
                 <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -53,9 +53,7 @@
                     <!-- ko if: $data.searchExclude() -->
                     <a href="#" data-bind="click: function(){$data.setSearchExclude(false)}"><span>Include In Search</span></a>
                     <!-- /ko -->
-                    <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown && $data.fileInfo().repositoryService !== Repository.Service.File -->
                     <a href="#" data-bind="click: $data.copyUrl"><span>Copy URL</span></a>
-                    <!-- /ko -->
                     <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show ModelData</span></a>
                 </div>
                 <div class="accordion-item paletteWrapper" data-bind="attr: {'data-palette-index': $index}, event: { dragover: SideWindow.nodeDragOver, drop: $root.nodeDropPalette }">


### PR DESCRIPTION
Adding a graph URL to the EAGLE URL is a handy way to get EAGLE to auto-load a graph, since it fetches the graph via HTTP and will work for brand new users who don't have Git access tokens set.

We could even use this to embed EAGLE in documentation, with the arbitrary graph auto-loaded.

This PR:

- Adds a menu item to "Create New Graph From Url", asking the user to input the URL via a modal
- Fixes the "Copy Graph Url" button to generate correct URLs for graphs loaded this way
- Allows the "service" specified in the EAGLE URL to be any case (lower/upper/any)
- Handles incorrect URLs with a better error message
- Updates the translator button colour indicator to show blue when the graph was loaded from a URL

## Summary by Sourcery

Implement a new feature to create graphs from URLs, enhancing EAGLE's graph loading capabilities

New Features:
- Add menu item to create a new graph from a URL
- Support loading graphs directly via URL in EAGLE

Enhancements:
- Improve URL-based graph loading with case-insensitive service handling
- Update graph URL generation to support URL-loaded graphs
- Enhance error handling for graph loading

Chores:
- Refactor HTTP utility methods to use Promise-based approach
- Modify translator color indicator logic