### PR TITLE
EAGLE-1472: Missing 'num_of_copies' field on Scatter created by 'Create Construct From Selection'

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1027,8 +1027,14 @@ export class Eagle {
         // ask the user what type of construct to use
         const userChoice: string = await Utils.requestUserChoice("Choose Construct", "Please choose a construct type to contain the selection", constructs, 0, false, "");
 
-        // create new subgraph
-        const parentNode: Node = new Node(userChoice, "", userChoice as Category);
+        // create new subgraph - look for named node in palette first, if not found use category
+        let parentNode: Node;
+        const paletteComponent = Utils.getPaletteComponentByName(userChoice);
+        if (paletteComponent !== null){
+            parentNode = paletteComponent.clone();
+        } else {
+            parentNode = new Node(userChoice, "", userChoice as Category);
+        }
 
         // add the parent node to the logical graph
         this.logicalGraph().addNodeComplete(parentNode);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -975,7 +975,15 @@ export class Eagle {
         }
 
         // create new subgraph
-        const parentNode: Node = new Node("Subgraph", "", Category.SubGraph);
+        // look for similarly named node in palettes first, clone it
+        // if not found in palettes, create a basic node from just the category
+        let parentNode: Node;
+        const paletteComponent = Utils.getPaletteComponentByName(Category.SubGraph);
+        if (paletteComponent !== null){
+            parentNode = paletteComponent.clone();
+        } else {
+            parentNode = new Node(Category.SubGraph, "", Category.SubGraph);
+        }
 
         // add the parent node to the logical graph
         this.logicalGraph().addNodeComplete(parentNode);
@@ -1027,7 +1035,9 @@ export class Eagle {
         // ask the user what type of construct to use
         const userChoice: string = await Utils.requestUserChoice("Choose Construct", "Please choose a construct type to contain the selection", constructs, 0, false, "");
 
-        // create new subgraph - look for named node in palette first, if not found use category
+        // create instance of construct chosen by user
+        // look for similarly named node in palettes first, clone it
+        // if not found in palettes, create a basic node from just the category
         let parentNode: Node;
         const paletteComponent = Utils.getPaletteComponentByName(userChoice);
         if (paletteComponent !== null){


### PR DESCRIPTION
Updated both 'Create Construct from Selection' and 'Create Subgraph from Selection' to clone the new parent (construct or subgraph) from that node in the 'Component Template' palette, instead of generating an empty component from scratch.

## Summary by Sourcery

Improve node creation for 'Create Construct from Selection' and 'Create Subgraph from Selection' by cloning existing palette components instead of generating empty nodes

New Features:
- Add fallback to basic node creation if no matching palette component is found

Enhancements:
- Modify node creation to clone existing palette components when available