### PR TITLE
Eagle 1415

### DIFF
--- a/static/graph.css
+++ b/static/graph.css
@@ -409,7 +409,7 @@
     
 }
 
-
-.node .graphDataNode{
-    bottom: -26px;
+.node .graphDataNode{    
+    bottom: 0px;
+    transform: translate(-50%, 100%);
 }

--- a/static/graph.css
+++ b/static/graph.css
@@ -408,3 +408,8 @@
     transition: width .2s cubic-bezier(0.68, 2.15, 0.5, 0.75), height .2s cubic-bezier(0.68, 2.15, 0.5, 0.75);
     
 }
+
+
+.node .graphDataNode{
+    bottom: -26px;
+}


### PR DESCRIPTION
moved the headers of data nodes to the bottom of the node.
just have a quick look at if the distance of the header from the node is behaving correctly

## Summary by Sourcery

Enhancements:
- Adjusted CSS positioning to move data node headers to the bottom of the node