### PR TITLE
more descriptive graph config parameters table state if there is no config

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -543,10 +543,6 @@ color: #00bb00;}
     font-size: 16px;
 }
 
-.parameterTable .tableAddNewConfigBtn, .eagleTableDisplay .tableAddNewConfigBtn{
-    background-color: #0059a5;
-}
-
 #editFieldModal .dropdown {
     width:100%;
 }
@@ -626,12 +622,12 @@ color: #00bb00;}
     height: 100%;
 }
 
-.rightWindow .btn-primary, .leftWindow .btn-primary {
+.rightWindow .btn-primary, .leftWindow .btn-primary, #bottomWindow .tableAddNewConfigBtn{
     background-color: #0059a5;
     border-color: #0059a5;
 }
 
-.rightWindow .btn-primary:hover, .leftWindow .btn-primary:hover {
+.rightWindow .btn-primary:hover, .leftWindow .btn-primary:hover, #bottomWindow .tableAddNewConfigBtn:hover {
     background-color: #002f57;
     border-color: #002f57;
 }

--- a/static/base.css
+++ b/static/base.css
@@ -543,6 +543,10 @@ color: #00bb00;}
     font-size: 16px;
 }
 
+.parameterTable .tableAddNewConfigBtn, .eagleTableDisplay .tableAddNewConfigBtn{
+    background-color: #0059a5;
+}
+
 #editFieldModal .dropdown {
     width:100%;
 }

--- a/templates/config_parameter_table.html
+++ b/templates/config_parameter_table.html
@@ -19,13 +19,25 @@
     </div>
     <div class="tableBody">
         <div class="wrapper">
-            <!-- ko if: ParameterTable.getTableFields().length === 0 -->
+            <!-- ko if: logicalGraph().graphConfigs().length != 0 && ParameterTable.getTableFields().length === 0 -->
                 <div class="container h-100">
                     <div class="row align-items-center h-100">
                         <div class="col-md-12 text-center">
                             <span class="fs-3">No fields in Graph Configuration</span>
                             <br/>
                             <span class="fs-6">Fields can be added from the Fields Table when a graph node is selected</span>
+                        </div>
+                    </div>
+                </div>
+            <!-- /ko -->
+            <!-- ko if: logicalGraph().graphConfigs().length === 0-->
+                <div class="container h-100">
+                    <div class="row align-items-center h-100">
+                        <div class="col-md-12 text-center">
+                            <span class="fs-3">No graph configurations</span>
+                            <br/>
+                            <br/>
+                            <button class="btn btn-primary btn-block tableAddNewConfigBtn" data-bind="click: newConfig">Add New Config</button>
                         </div>
                     </div>
                 </div>

--- a/templates/graph_configurations_table.html
+++ b/templates/graph_configurations_table.html
@@ -24,7 +24,8 @@
                     <div class="col-md-12 text-center">
                         <span class="fs-3">No graph configurations</span>
                         <br/>
-                        <span class="fs-6">Create a configuration using the Config menu in the navbar</span>
+                        <br/>
+                        <button class="btn btn-primary btn-block tableAddNewConfigBtn" data-bind="click: newConfig">Add New Config</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
in the config parameter table it will now say you should create a config if there is none (previously it said you should add a field in this case)
additionally ive added a button to quickly create a new config next to this message. This has been added to both the config parameter table and the configs table

## Summary by Sourcery

Improve user experience for graph configurations by adding more descriptive messaging and quick-add buttons when no configurations exist

New Features:
- Added a direct 'Add New Config' button in both config parameter and graph configurations tables when no configurations are present

Enhancements:
- Updated empty state messaging to be more clear about the lack of graph configurations
- Added styling for the new configuration creation button