### PR TITLE
EAGLE-1480: Setting to keep fields during node category change

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4536,7 +4536,10 @@ export class Eagle {
                     oldCategoryTemplate = oldNode;
                 }
 
-                Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate);
+                // TODO: setting here? Or ask user whether they want to remove old fields?
+                const removeOldFields: boolean = true; //Setting.findValue(Setting.REMOVE_OLD_FIELDS_DURING_CATEGORY_CHANGE);
+
+                Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate, removeOldFields);
             }
         }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4493,9 +4493,12 @@ export class Eagle {
     }, this)
 
     inspectorChangeNodeCategoryRequest = async (event: Event): Promise<void> => {
-        if (Setting.findValue(Setting.CONFIRM_NODE_CATEGORY_CHANGES)){
+        const confirmNodeCategoryChanges = Setting.findValue(Setting.CONFIRM_NODE_CATEGORY_CHANGES);
+        const keepOldFields = Setting.findValue(Setting.KEEP_OLD_FIELDS_DURING_CATEGORY_CHANGE);
 
-            // request confirmation from user
+        // request confirmation from user
+        // old request if 'confirm' setting is true AND we're not going to keep the old fields
+        if (confirmNodeCategoryChanges && !keepOldFields){
             try {
                 await Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES));
             } catch (error){
@@ -4536,10 +4539,10 @@ export class Eagle {
                     oldCategoryTemplate = oldNode;
                 }
 
-                // TODO: setting here? Or ask user whether they want to remove old fields?
-                const removeOldFields: boolean = true; //Setting.findValue(Setting.REMOVE_OLD_FIELDS_DURING_CATEGORY_CHANGE);
+                // consult user setting - whether they want to remove old fields
+                const keepOldFields: boolean = Setting.findValue(Setting.KEEP_OLD_FIELDS_DURING_CATEGORY_CHANGE);
 
-                Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate, removeOldFields);
+                Utils.transformNodeFromTemplates(oldNode, oldCategoryTemplate, newCategoryTemplate, keepOldFields);
             }
         }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4547,6 +4547,9 @@ export class Eagle {
         this.undo().pushSnapshot(this, "Edit Node Category");
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph.valueHasMutated();
+
+        // refresh the ParameterTable, since fields may have been added/removed
+        ParameterTable.updateContent(this.selectedNode());
     }
     
     // NOTE: clones the node internally

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -360,6 +360,7 @@ export class Setting {
     static readonly ALLOW_MODIFIED_GRAPH_TRANSLATION: string = "AllowModifiedGraphTranslation";
     static readonly APPLY_ACTIVE_GRAPH_CONFIG_BEFORE_TRANSLATION: string = "ApplyActiveGraphConfigBeforeTranslation";
     static readonly FETCH_REPOSITORY_FOR_URLS: string = "FetchRepositoryForUrls";
+    static readonly KEEP_OLD_FIELDS_DURING_CATEGORY_CHANGE: string = "KeepOldFieldsDuringCategoryChange";
 }
 
 export namespace Setting {
@@ -480,6 +481,7 @@ const settings : SettingsGroup[] = [
             new Setting(true, "Allow modified graph translation", Setting.ALLOW_MODIFIED_GRAPH_TRANSLATION, "Allow users to submit graphs for translation even when not saved or committed", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Apply active graph config before translation", Setting.APPLY_ACTIVE_GRAPH_CONFIG_BEFORE_TRANSLATION, "Apply the active graph config to the graph before sending the graph for translation", false, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Fetch repository for URLs", Setting.FETCH_REPOSITORY_FOR_URLS, "Automatically fetch the contents of the object's repository when a graph/palette is specified in the URL", true, Setting.Type.Boolean, false, false ,false, false, false),
+            new Setting(true, "Keep Old Fields during Category Change", Setting.KEEP_OLD_FIELDS_DURING_CATEGORY_CHANGE, "When changing the category of an existing node, several fields may become useless and would normally be deleted. Enabling this setting will keep those fields.", false, Setting.Type.Boolean, false, false, false, false, false)
         ]
     )
 ];

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2745,8 +2745,8 @@ export class Utils {
         }
     }
 
-    static transformNodeFromTemplates(node: Node, sourceTemplate: Node, destinationTemplate: Node, removeOldFields: boolean = true): void {
-        if (removeOldFields){
+    static transformNodeFromTemplates(node: Node, sourceTemplate: Node, destinationTemplate: Node, keepOldFields: boolean = false): void {
+        if (!keepOldFields){
             // delete non-ports from the node (loop backwards since we are deleting from the array as we loop)
             for (let i = node.getFields().length - 1 ; i >= 0; i--){
                 const field: Field = node.getFields()[i];

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2745,16 +2745,18 @@ export class Utils {
         }
     }
 
-    static transformNodeFromTemplates(node: Node, sourceTemplate: Node, destinationTemplate: Node): void {
-        // delete non-ports from the node (loop backwards since we are deleting from the array as we loop)
-        for (let i = node.getFields().length - 1 ; i >= 0; i--){
-            const field: Field = node.getFields()[i];
+    static transformNodeFromTemplates(node: Node, sourceTemplate: Node, destinationTemplate: Node, removeOldFields: boolean = true): void {
+        if (removeOldFields){
+            // delete non-ports from the node (loop backwards since we are deleting from the array as we loop)
+            for (let i = node.getFields().length - 1 ; i >= 0; i--){
+                const field: Field = node.getFields()[i];
 
-            if (field.isInputPort() || field.isOutputPort()){
-                continue;
+                if (field.isInputPort() || field.isOutputPort()){
+                    continue;
+                }
+
+                node.removeFieldById(field.getId());
             }
-
-            node.removeFieldById(field.getId());
         }
 
         // copy non-ports from new template to node

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -84,7 +84,7 @@
                                 </div>
                                 <div class="col-8 col contentObjectValue">
                                     <!-- ko if: $data.getCategoryType() === Category.Type.Data || $data.getCategoryType() === Category.Type.Unknown -->
-                                        <select id="objectInspectorCategorySelect" data-bind="value: $data.getCategory(), options:$root.getEligibleNodeCategories(), event:{change:function(data,event){$root.inspectorChangeNodeCategoryRequest(event)}}, valueAllowUnset: true, disabled: $data.isLocked(), eagleTooltip:'NOTE: changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category'"></select>
+                                        <select id="objectInspectorCategorySelect" data-bind="value: $data.getCategory(), options:$root.getEligibleNodeCategories(), event:{change:function(data,event){$root.inspectorChangeNodeCategoryRequest(event)}}, valueAllowUnset: true, disabled: $data.isLocked(), eagleTooltip:'Change the category of a node'"></select>
                                     <!-- /ko -->
                                     <!-- ko if: $data.getCategoryType() !== Category.Type.Data && $data.getCategoryType() !== Category.Type.Unknown -->
                                         <span data-bind="text:$data.getCategory()"></span>


### PR DESCRIPTION
Feedback from Omar via GitHub issue.

Added a setting: KEEP_OLD_FIELDS_DURING_CATEGORY_CHANGE

This will skip the step that removes existing ports when changing the nodes category. Updated a tooltip and user confirmation so that user will not be warned about losing ports if they have enabled the setting.

The consequence of this change is that users may keep fields that will be useless once the node has changed category. I've created a new JIRA ticket (EAGLE-1482) to warn users about this in the future.

Also, fixed a bug where the ParameterTable did not get updated after a user changes a nodes category.

## Summary by Sourcery

Introduce a setting to retain existing fields when changing a node's category and update related UI and logic to respect this setting.

New Features:
- Add 'Keep Old Fields during Category Change' setting to control whether fields are retained when changing a node's category.

Bug Fixes:
- Fix ParameterTable not updating after a node's category is changed.

Enhancements:
- Update category change confirmation and tooltip to reflect the new setting.