### PR TITLE
EAGLE-1479: Additional checks for Category.Data

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -278,7 +278,8 @@ export namespace Daliuge {
         },
         {
             categories: [
-                Category.PyFuncApp
+                Category.PyFuncApp,
+                Category.PythonMemberFunction
             ],
             fields: [
                 Daliuge.funcNameField
@@ -286,10 +287,10 @@ export namespace Daliuge {
         },
         {
             categories: [
-                Category.PythonMemberFunction
+                Category.Data
             ],
             fields: [
-                Daliuge.funcNameField
+                Daliuge.baseNameField
             ]
         }
     ];


### PR DESCRIPTION
Combined 'func_name' requirement for PyFuncApp and PythonMemberFunction.
Added 'base_name' requirement for Data.

## Summary by Sourcery

Update Daliuge node validation rules to extend func_name checks to PythonMemberFunction and introduce base_name checks for Data category

Enhancements:
- Include PythonMemberFunction in the func_nameField requirement alongside PyFuncApp
- Replace the PythonMemberFunction funcNameField check with a baseNameField requirement for the Data category