### PR TITLE
Eagle 1462

### DIFF
--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -847,11 +847,7 @@ export class ParameterTable {
     }
 
     static getParameterTypeLockedState = (field:Field) : boolean => {
-        if( this.getNodeLockedState(field) || this.getParameterTypeOptions(field).length <2){
-            return true
-        }
-        
-        return false
+        return this.getNodeLockedState(field) || this.getParameterTypeOptions(field).length < 2;
     }
 }
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -845,6 +845,14 @@ export class ParameterTable {
 
         return parameterTypeList
     }
+
+    static getParameterTypeLockedState = (field:Field) : boolean => {
+        if( this.getNodeLockedState(field) || this.getParameterTypeOptions(field).length <2){
+            return true
+        }
+        
+        return false
+    }
 }
 
 export namespace ParameterTable {

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -830,6 +830,21 @@ export class ParameterTable {
             ParameterTable.sortFields();
         }
     }
+
+    static getParameterTypeOptions = (field:Field) : string[] => {
+        const parameterTypeList : string[] = []
+        const fieldParamType = field.getParameterType()
+
+        if(fieldParamType === Daliuge.FieldType.Construct){
+            parameterTypeList.push(Daliuge.FieldType.Construct)
+        }else if(fieldParamType === Daliuge.FieldType.Constraint){
+            parameterTypeList.push(Daliuge.FieldType.Constraint)
+        }else{
+            parameterTypeList.push(Daliuge.FieldType.Application,Daliuge.FieldType.Component)
+        }
+
+        return parameterTypeList
+    }
 }
 
 export namespace ParameterTable {

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -410,7 +410,7 @@
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().parameterType() -->
                                                 <td class='columnCell column_ParamType'>
                                                     <div class="checkboxWrapper">
-                                                        <select class="tableFieldParamTypeSelect" data-bind="options: Object.values(Daliuge.FieldType), value: parameterType, disabled: ParameterTable.getNodeLockedState($data)">
+                                                        <select class="tableFieldParamTypeSelect" data-bind="options: ParameterTable.getParameterTypeOptions($data), value: parameterType, disabled: ParameterTable.getNodeLockedState($data)">
                                                             <!-- options are added dynamically -->
                                                         </select>
                                                     </div>

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -410,7 +410,7 @@
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().parameterType() -->
                                                 <td class='columnCell column_ParamType'>
                                                     <div class="checkboxWrapper">
-                                                        <select class="tableFieldParamTypeSelect" data-bind="options: ParameterTable.getParameterTypeOptions($data), value: parameterType, disabled: ParameterTable.getNodeLockedState($data)">
+                                                        <select class="tableFieldParamTypeSelect" data-bind="options: ParameterTable.getParameterTypeOptions($data), value: parameterType, disabled: ParameterTable.getParameterTypeLockedState($data)">
                                                             <!-- options are added dynamically -->
                                                         </select>
                                                     </div>


### PR DESCRIPTION
new function to build list of parameter types the user should able to change to 
locking the parameter type select to display only if it is a construct or constraint

## Summary by Sourcery

Restrict and disable the parameter type dropdown based on field type and node lock state

Enhancements:
- Add getParameterTypeOptions to return only applicable types (construct, constraint, or default)
- Add getParameterTypeLockedState to disable the selector when the node is locked or has only one option
- Update the parameter type dropdown binding to use the new option list and locked state methods