### PR TITLE
EAGLE-1484: Change font in codemirror

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -6,11 +6,9 @@ html {
 body {
     /* prevent window from ever scrolling the whole page */
     overflow: hidden; 
-    height:100%
+    height:100%;
     /* zoom: 75%; */
-}
 
-* {
     font-family: Ubuntu Sans;
     font-style: normal;
     font-weight:400;
@@ -2290,10 +2288,6 @@ ul.nav.navbar-nav .dropdown-item:hover,ul.nav.navbar-nav .dropdown-item:focus{
     font-size: 1rem;
     font-weight: 300;
     margin-bottom: 10px;
-}
-
-.tooltip-inner em {
-    font-style:italic;
 }
 
 .tooltip-inner{

--- a/static/base.css
+++ b/static/base.css
@@ -9,7 +9,7 @@ body {
     height:100%;
     /* zoom: 75%; */
 
-    font-family: Ubuntu Sans;
+    font-family: 'Ubuntu Sans', sans-serif;
     font-style: normal;
     font-weight:400;
 }


### PR DESCRIPTION
Modify the global font change to use the CSS selector 'body' instead of '*'

## Summary by Sourcery

Apply global font-family via the body selector instead of the universal selector and clean up tooltip styling

Enhancements:
- Move global font-family declaration from the universal selector to the body selector
- Remove italic styling from <em> elements within tooltips