### PR TITLE
EAGLE-1487: fixed pydata field value warning, and working 'save to git'

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1635,11 +1635,6 @@ export class Eagle {
     }
 
     saveGraph = async () : Promise<void> => {
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(Eagle.FileType.Graph, "Save Graph");
-            return;
-        }
-
         return new Promise(async(resolve, reject) => {
             const eagle: Eagle = Eagle.getInstance();
 
@@ -1676,10 +1671,6 @@ export class Eagle {
     }
 
     saveGraphAs = async () : Promise<void> => {
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(Eagle.FileType.Graph, "Save Graph As");
-            return;
-        }
         return new Promise(async(resolve, reject) => {
             const isLocalFile = this.logicalGraph().fileInfo().repositoryService === Repository.Service.File;
 
@@ -1715,12 +1706,6 @@ export class Eagle {
      * Saves the file to a local download folder.
      */
     saveFileToLocal = async (fileType : Eagle.FileType) : Promise<void> => {
-        // check that graph editing is permitted
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(fileType, "Save " + fileType);
-            return;
-        }
-
         return new Promise(async(resolve, reject) => {
             switch (fileType){
                 case Eagle.FileType.Graph:
@@ -1763,12 +1748,6 @@ export class Eagle {
     }
 
     saveAsFileToLocal = async (fileType: Eagle.FileType): Promise<void> => {
-        // check that graph editing is permitted
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(fileType, "Save " + fileType + " As");
-            return;
-        }
-
         return new Promise(async(resolve, reject) => {
             switch (fileType){
                 case Eagle.FileType.Graph:
@@ -1891,11 +1870,6 @@ export class Eagle {
      * Performs a Git commit of a graph/palette. Asks user for a file name before saving.
      */
     commitToGitAs = async (fileType : Eagle.FileType) : Promise<void> => {
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(fileType, "Commit to Git As");
-            return;
-        }
-
         return new Promise(async(resolve, reject) => {
             let fileInfo : ko.Observable<FileInfo>;
             let obj : LogicalGraph | Palette;
@@ -1974,11 +1948,6 @@ export class Eagle {
      * Performs a Git commit of a graph/palette.
      */
     commitToGit = async (fileType : Eagle.FileType) : Promise<void> => {
-        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
-            Utils.notifyUserOfEditingIssue(fileType, "Commit to Git");
-            return;
-        }
-
         return new Promise(async(resolve, reject) => {
             let fileInfo : ko.Observable<FileInfo>;
             let obj : LogicalGraph | Palette;

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1974,7 +1974,7 @@ export class Eagle {
      * Performs a Git commit of a graph/palette.
      */
     commitToGit = async (fileType : Eagle.FileType) : Promise<void> => {
-        if (Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
+        if (!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)){
             Utils.notifyUserOfEditingIssue(fileType, "Commit to Git");
             return;
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -2024,7 +2024,7 @@ export class Node {
             }
 
             if (hasInputEdge && hasPydataValue){
-                const message: string = node.category() + " node (" + node.getName() + ") has a connected input edge, and also contains data in its '" + Daliuge.FieldName.PYDATA + "' field. The two sources of data could cause a conflict. Note that a " + Daliuge.FieldName.PYDATA + " field is considered a source of data if its value is NOT 'None'.";
+                const message: string = node.category() + " node (" + node.getName() + ") has a connected input edge, and also contains data in its '" + Daliuge.FieldName.PYDATA + "' field. The two sources of data could cause a conflict. Note that a " + Daliuge.FieldName.PYDATA + " field is considered a source of data if its value is NOT '" + Daliuge.DEFAULT_PYDATA_VALUE + "'.";
                 const issue: Errors.Issue = Errors.Show(message, function(){Utils.showNode(eagle, node.getId())});
                 node.issues().push({issue:issue,validity:Errors.Validity.Warning})
             }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -2014,7 +2014,8 @@ export class Node {
 
         // check that Memory and SharedMemory nodes have at least one input OR have a pydata field with a non-"None" value
         if (node.category() === Category.Memory || node.category() === Category.SharedMemory){
-            const hasPydataValue: boolean = node.getFieldByDisplayText(Daliuge.FieldName.PYDATA)?.getValue() !== Daliuge.DEFAULT_PYDATA_VALUE;
+            const pydataField: Field = node.getFieldByDisplayText(Daliuge.FieldName.PYDATA);
+            const hasPydataValue: boolean = pydataField !== null && pydataField.getValue() !== Daliuge.DEFAULT_PYDATA_VALUE;
 
             if (!hasInputEdge && !hasPydataValue){
                 const message: string = node.category() + " node (" + node.getName() + ") has no connected input edges, and no data in its '" + Daliuge.FieldName.PYDATA + "' field. The node will not contain data.";
@@ -2023,7 +2024,7 @@ export class Node {
             }
 
             if (hasInputEdge && hasPydataValue){
-                const message: string = node.category() + " node (" + node.getName() + ") has a connected input edge, and also contains data in its '" + Daliuge.FieldName.PYDATA + "' field. The two sources of data could cause a conflict.";
+                const message: string = node.category() + " node (" + node.getName() + ") has a connected input edge, and also contains data in its '" + Daliuge.FieldName.PYDATA + "' field. The two sources of data could cause a conflict. Note that a " + Daliuge.FieldName.PYDATA + " field is considered a source of data if its value is NOT 'None'.";
                 const issue: Errors.Issue = Errors.Show(message, function(){Utils.showNode(eagle, node.getId())});
                 node.issues().push({issue:issue,validity:Errors.Validity.Warning})
             }


### PR DESCRIPTION
Fixed two things:
- Broken pydata field value warning when the pydata field doesn't exist (and a better warning message)
- Graph > Git Storage > Save menu item warning about graph editing permissions

## Summary by Sourcery

Correct improper pydata warning logic and refine its message, and fix the Git commit permission check so “Save to Git” only warns when editing is disallowed.

Bug Fixes:
- Fix pydata field existence check and improve the Memory/SharedMemory node warning message when pydata is missing or conflicting.
- Fix the ‘Save to Git’ menu item to only show a warning if graph editing is not permitted.