### PR TITLE
EAGLE-1490: 'Select all' item to the palette triple dot menu

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2597,6 +2597,18 @@ export class Eagle {
         }
     }
 
+    selectAllInPalette = (palette: Palette): void => {
+        // close the palette menu
+        this.closePaletteMenus();
+
+        this.selectedObjects([]);
+        for (const node of palette.getNodes()){
+            this.editSelection(node, Eagle.FileType.Palette);
+        }
+
+        Utils.showNotification("Select All", "All components in '" + palette.fileInfo().name + "' palette selected", "info", false);
+    }
+
     getParentNameAndId = (parentId: NodeId) : string => {
         if(parentId === null){
             return ""

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -40,6 +40,7 @@
                 <button type="button" class="material-icons md-18 dropdown-toggle paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
                 <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closePaletteMenus}">
                     <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
+                    <a href="#" data-bind="click: $root.selectAllInPalette, clickBubble: false" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
                     <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove</span></a>
                     <!-- /ko -->


### PR DESCRIPTION
Adds all items to the list of selected objects. Useful when dragging all components in to the graph to test them all at once.

## Summary by Sourcery

New Features:
- Add 'Select All' option to the palette triple-dot menu to select all components in a palette