### PR TITLE
EAGLE-1177: Copy port description when renaming ports on Data components

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4420,7 +4420,7 @@ export class Eagle {
             newNode.removeAllOutputPorts();
 
             // add InputOutput port for dataType
-            const newInputOutputPort = new Field(Utils.generateFieldId(), srcPort.getDisplayText(), "", "", "", false, srcPort.getType(), false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.InputOutput);
+            const newInputOutputPort = new Field(Utils.generateFieldId(), srcPort.getDisplayText(), "", "", srcPort.getDescription(), false, srcPort.getType(), false, [], false, Daliuge.FieldType.Application, Daliuge.FieldUsage.InputOutput);
             newNode.addField(newInputOutputPort);
 
             // set the parent of the new node

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4372,12 +4372,16 @@ export class Eagle {
                 // re-name node and port according to the port name of the Application node
                 if (srcNode.isApplication()){
                     const newName = srcPort.getDisplayText();
+                    const newDescription = srcPort.getDescription();
                     destNode.setName(newName);
                     destPort.setDisplayText(newName);
+                    destPort.setDescription(newDescription);
                 } else {
                     const newName = destPort.getDisplayText();
+                    const newDescription = destPort.getDescription();
                     srcNode.setName(newName);
                     srcPort.setDisplayText(newName);
+                    srcPort.setDescription(newDescription);
                 }
 
                 setTimeout(() => {


### PR DESCRIPTION
This JIRA issue mentioned a number of things, some of which had already been fixed in other issues. The remaining things were:

- When a user drags an edge between two Application nodes, and an intermediate Data node is created, we now copy the description as well as the name of the Application port.
- When a user drags an edge into empty space, and then generates a Data node, we now copy the description as well as the name of the Application port.

## Summary by Sourcery

Copy port description alongside port name when renaming Data component ports and creating new Data nodes during drag-and-drop operations.

Bug Fixes:
- Preserve port description when renaming Data ports after connecting Application and Data nodes
- Include port description when generating new Data nodes on drag-and-drop into empty space