### PR TITLE
EAGLE-1493: Old graphs break EAGLE

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -163,15 +163,6 @@ export class LogicalGraph {
         return result;
     }
 
-    static _determineNodeParentId(nodeData: any){
-        if (typeof nodeData.parentId !== 'undefined'){
-            return nodeData.parentId;
-        }
-        if (typeof nodeData.group !== 'undefined'){
-            return nodeData.group;
-        }
-    }
-
     static fromOJSJson(dataObject : any, file : RepositoryFile, errorsWarnings : Errors.ErrorsWarnings) : LogicalGraph {
         // create new logical graph object
         const result : LogicalGraph = new LogicalGraph();
@@ -196,7 +187,7 @@ export class LogicalGraph {
         // make sure to set parent for all nodes
         for (let i = 0 ; i < dataObject.nodeDataArray.length ; i++){
             const nodeData = dataObject.nodeDataArray[i];
-            const parentId = this._determineNodeParentId(nodeData);
+            const parentId = Node.determineNodeParentId(nodeData);
 
             // if parentId cannot be found, skip this node
             if (typeof parentId === 'undefined'){

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -163,6 +163,15 @@ export class LogicalGraph {
         return result;
     }
 
+    static _determineNodeParentId(nodeData: any){
+        if (typeof nodeData.parentId !== 'undefined'){
+            return nodeData.parentId;
+        }
+        if (typeof nodeData.group !== 'undefined'){
+            return nodeData.group;
+        }
+    }
+
     static fromOJSJson(dataObject : any, file : RepositoryFile, errorsWarnings : Errors.ErrorsWarnings) : LogicalGraph {
         // create new logical graph object
         const result : LogicalGraph = new LogicalGraph();
@@ -184,13 +193,20 @@ export class LogicalGraph {
         // set ids for all embedded nodes
         Utils.setEmbeddedApplicationNodeIds(result);
 
-        // make sure to set parentId for all nodes
+        // make sure to set parent for all nodes
         for (let i = 0 ; i < dataObject.nodeDataArray.length ; i++){
             const nodeData = dataObject.nodeDataArray[i];
-            const parentIndex = GraphUpdater.findIndexOfNodeDataArrayWithId(dataObject.nodeDataArray, nodeData.parentId);
+            const parentId = this._determineNodeParentId(nodeData);
 
+            // if parentId cannot be found, skip this node
+            if (typeof parentId === 'undefined'){
+                continue;
+            }
+
+            const parentIndex = GraphUpdater.findIndexOfNodeDataArrayWithId(dataObject.nodeDataArray, parentId);
             if (parentIndex !== -1){
-                result.nodes()[i].setParentId(result.nodes()[parentIndex].getId());
+                const parentNode: Node = result.nodes()[parentIndex];
+                result.nodes()[i].setParentId(parentNode.getId());
             }
         }
 

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1314,7 +1314,9 @@ export class Node {
     static fromOJSJson(nodeData : any, errorsWarnings: Errors.ErrorsWarnings, isPaletteNode: boolean) : Node {
         let id: NodeId = null;
 
-        if (typeof nodeData.id !== 'undefined'){
+        if (typeof nodeData.oid !== 'undefined'){
+            id = nodeData.oid;
+        } else if (typeof nodeData.id !== 'undefined'){
             id = nodeData.id;
         } else {
             id = Utils.generateNodeId();

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1500,8 +1500,9 @@ export class Node {
         }
 
         // set parentId if a parentId is defined
-        if (typeof nodeData.parentId !== 'undefined'){
-            node.parentId(nodeData.parentId);
+        const parentId = Node.determineNodeParentId(nodeData);
+        if (typeof parentId !== 'undefined'){
+            node.parentId(parentId);
         }
 
         // set embedId if defined
@@ -2099,6 +2100,16 @@ export class Node {
                     }
                 }
             }
+        }
+    }
+
+    // helper function used when loading graphs from JSON
+    static determineNodeParentId(nodeData: any){
+        if (typeof nodeData.parentId !== 'undefined'){
+            return nodeData.parentId;
+        }
+        if (typeof nodeData.group !== 'undefined'){
+            return nodeData.group;
         }
     }
 


### PR DESCRIPTION
EAGLE is now able to load that directory of old graphs.

Error was caused by:
- node JSON using "oid" attribute instead of "id". Added check for that
- node JSON using "group" attribute instead of "parentId". Added helper function for that.
