### PR TITLE
EAGLE-1492: Check graph after field value changed

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3938,6 +3938,9 @@ export class Eagle {
 
         // update the type of the field
         field.setType(newType);
+
+        // re-check the graph
+        this.checkGraph();
     }
 
     changeNodeParent = async () => {

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -2025,7 +2025,7 @@ export class Node {
 
             if (hasInputEdge && hasPydataValue){
                 const message: string = node.category() + " node (" + node.getName() + ") has a connected input edge, and also contains data in its '" + Daliuge.FieldName.PYDATA + "' field. The two sources of data could cause a conflict. Note that a " + Daliuge.FieldName.PYDATA + " field is considered a source of data if its value is NOT '" + Daliuge.DEFAULT_PYDATA_VALUE + "'.";
-                const issue: Errors.Issue = Errors.Show(message, function(){Utils.showNode(eagle, node.getId())});
+                const issue: Errors.Issue = Errors.ShowFix(message, function(){Utils.showNode(eagle, node.getId())}, function(){if (pydataField.getValue() === ""){pydataField.setValue(Daliuge.DEFAULT_PYDATA_VALUE);}}, "Replace empty pydata with default value (" + Daliuge.DEFAULT_PYDATA_VALUE + ")");
                 node.issues().push({issue:issue,validity:Errors.Validity.Warning})
             }
         }

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -334,6 +334,8 @@ export class ParameterTable {
             }
             case Eagle.FileType.Graph:
                 eagle.logicalGraph().fileInfo().modified = true;
+
+                eagle.checkGraph();
                 break;
         }
     }


### PR DESCRIPTION
Also add an autoFix function to the case where Memory has an input AND has pydata set. Function will turn an empty string pydata into 'None', but don't overwrite anything else.

## Summary by Sourcery

Add an auto-fix for empty pydata conflicts and recheck the graph after parameter changes

Enhancements:
- Attach an auto-fix via Errors.ShowFix to replace empty pydata values with the default
- Invoke eagle.checkGraph in ParameterTable after modifying a graph to revalidate it