### PR TITLE
Eagle 1483

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -55,6 +55,7 @@ export namespace Daliuge {
         NUM_OF_COPIES = "num_of_copies",
         NUM_OF_CPUS = "num_cpus",
         NUM_OF_INPUTS = "num_of_inputs",
+        GATHER_AXIS = "gather_axis",
         NUM_OF_ITERATIONS = "num_of_iter",
         NUM_OF_TRIES = "n_tries",
     

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -335,7 +335,7 @@ export class KeyboardShortcut {
             id: "save_as_graph",
             text: "Save Graph As",
             keys: [new Key("s", Modifier.Shift)],
-            tags: ['download','canvas', 'save as '],
+            tags: ['download','canvas', 'save as'],
             run: (eagle): void => {eagle.saveGraphAs()}
         }),
         // TODO: two for palettes

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -335,7 +335,7 @@ export class KeyboardShortcut {
             id: "save_as_graph",
             text: "Save Graph As",
             keys: [new Key("s", Modifier.Shift)],
-            tags: ['download','canvas'],
+            tags: ['download','canvas', 'save as '],
             run: (eagle): void => {eagle.saveGraphAs()}
         }),
         // TODO: two for palettes

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1204,6 +1204,39 @@ export class Node {
         return 'This Node has **' + errorsWarnings.errors.length + '** errors and **' + errorsWarnings.warnings.length + '** warnings. \ Click to view the graph issues table.'
     }, this);
 
+    getInspectorFields : ko.PureComputed<Field[]> = ko.pureComputed(() => {
+        const activeConfig = Eagle.getInstance().logicalGraph().getActiveGraphConfig()
+
+        const importantFields : Field[] = [] //fields for a node we deem important eg. num copies for scatter nodes
+        const configFields : Field[] = [] 
+
+        this.getFields().forEach(function(field:Field){
+            // get important fields 
+            if(this.isGather()){
+                if(field.getDisplayText() === 'num_of_inputs' || field.getDisplayText() === 'gather_axis'){
+                    importantFields.push(field)
+                }
+            }else if (this.isScatter()){
+                if(field.getDisplayText() === 'num_of_copies'){
+                    importantFields.push(field)
+                }
+            }else if (this.isLoop()){
+                if(field.getDisplayText() === 'num_of_iter'){
+                    importantFields.push(field)
+                }
+            //check if the field is the func code field
+            }else if(field.getDisplayText() === 'func_code'){
+                importantFields.push(field)
+            }
+            //check if field is a graph config field
+            else if(activeConfig?.hasField(field)){
+                configFields.push(field)
+            }
+        })
+
+        return importantFields.concat(configFields)
+    }, this);
+
     // find the right icon for this node
     getIcon = () : string => {
         return CategoryData.getCategoryData(this.category()).icon;

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1209,23 +1209,23 @@ export class Node {
 
         const importantFields : Field[] = [] //fields for a node we deem important eg. num copies for scatter nodes
         const configFields : Field[] = [] 
+        const selectedNode = this
 
-        this.getFields().forEach(function(field:Field){
+        selectedNode.getFields().forEach(function(field:Field){
             // get important fields 
-            if(this.isGather()){
-                if(field.getDisplayText() === 'num_of_inputs' || field.getDisplayText() === 'gather_axis'){
+            if(selectedNode.isGather()){
+                if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_INPUTS || field.getDisplayText() === Daliuge.FieldName.GATHER_AXIS){
                     importantFields.push(field)
                 }
-            }else if (this.isScatter()){
-                if(field.getDisplayText() === 'num_of_copies'){
+            }else if (selectedNode.isScatter()){
+                if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_COPIES){
                     importantFields.push(field)
                 }
-            }else if (this.isLoop()){
-                if(field.getDisplayText() === 'num_of_iter'){
+            }else if (selectedNode.isLoop()){
+                if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_ITERATIONS){
                     importantFields.push(field)
                 }
-            //check if the field is the func code field
-            }else if(field.getDisplayText() === 'func_code'){
+            }else if(field.getDisplayText() === Daliuge.FieldName.FUNC_CODE){
                 importantFields.push(field)
             }
             //check if field is a graph config field

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1216,20 +1216,25 @@ export class Node {
             if(selectedNode.isGather()){
                 if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_INPUTS || field.getDisplayText() === Daliuge.FieldName.GATHER_AXIS){
                     importantFields.push(field)
+                    return
                 }
             }else if (selectedNode.isScatter()){
                 if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_COPIES){
                     importantFields.push(field)
+                    return
                 }
             }else if (selectedNode.isLoop()){
                 if(field.getDisplayText() === Daliuge.FieldName.NUM_OF_ITERATIONS){
                     importantFields.push(field)
+                    return
                 }
             }else if(field.getDisplayText() === Daliuge.FieldName.FUNC_CODE){
                 importantFields.push(field)
+                return
             }
+            
             //check if field is a graph config field
-            else if(activeConfig?.hasField(field)){
+            if(activeConfig?.hasField(field)){
                 configFields.push(field)
             }
         })

--- a/static/base.css
+++ b/static/base.css
@@ -439,16 +439,23 @@ color: #00bb00;}
     color: #2e3236;
 }
 
-#inspector .inspectorContents .inspectorField textarea{
+#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input{
     resize: none;
     padding:1px 3px;
     min-height: auto;
 }
 
-#inspector .inspectorContents .inspectorField input{
+#inspector .inspectorContents .inspectorField .checkboxWrapper {
     resize: none;
     padding:1px 3px;
     min-height: auto;
+}
+
+#inspector .inspectorContents .inspectorField .checkboxWrapper input {
+    position: absolute;
+    top: 50%;
+    left:50%;
+    transform: translate(-50%, -50%);
 }
 
 #inspector .inspectorContents .inspectorField .inspectorEditBtn{

--- a/static/base.css
+++ b/static/base.css
@@ -429,6 +429,22 @@ color: #00bb00;}
     font-size: 17px;
 }
 
+#inspector .inspectorContents .inspectorField {
+    padding:0px;
+}
+
+#inspector .inspectorContents .inspectorField span {
+    padding:1px 3px;
+    background: #e9ecef;
+    color: #2e3236;
+}
+
+#inspector .inspectorContents .inspectorField textarea {
+    resize: none;
+    padding:1px 3px;
+    min-height: auto;
+}
+
 #inspector .inspectorContents h5{
     font-size: 16px;
     margin: 2px 0px 0px 0px;

--- a/static/base.css
+++ b/static/base.css
@@ -443,13 +443,7 @@ color: #00bb00;}
     overflow-x: auto;
 }
 
-#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input,#inspector .inspectorContents .inspectorField select{
-    resize: none;
-    padding:1px 3px;
-    min-height: auto;
-}
-
-#inspector .inspectorContents .inspectorField .checkboxWrapper {
+#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input,#inspector .inspectorContents .inspectorField select,#inspector .inspectorContents .inspectorField .checkboxWrapper {
     resize: none;
     padding:1px 3px;
     min-height: auto;

--- a/static/base.css
+++ b/static/base.css
@@ -445,6 +445,23 @@ color: #00bb00;}
     min-height: auto;
 }
 
+#inspector .inspectorContents .inspectorField .inspectorEditBtn{
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background-color: #002e5f;
+    color: white;
+    display: none;
+    padding: 4px;
+    font-size: 12px;
+    border-radius: 50%;
+}
+
+#inspector .inspectorContents .inspectorField:hover .inspectorEditBtn{
+    display:inline-block
+}
+
 #inspector .inspectorContents h5{
     font-size: 16px;
     margin: 2px 0px 0px 0px;

--- a/static/base.css
+++ b/static/base.css
@@ -371,6 +371,8 @@ color: #00bb00;}
 
 #inspector .inspectorContents{
     padding-top: 7px;
+    max-height: 40vh;
+    overflow-y: auto;
 }
 
 #inspector .inspectorHeader input{
@@ -441,7 +443,7 @@ color: #00bb00;}
     overflow-x: auto;
 }
 
-#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input{
+#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input,#inspector .inspectorContents .inspectorField select{
     resize: none;
     padding:1px 3px;
     min-height: auto;

--- a/static/base.css
+++ b/static/base.css
@@ -444,6 +444,7 @@ color: #00bb00;}
     text-overflow: ellipsis;
     white-space: nowrap;
     display: inline-block;
+    cursor:pointer;
 }
 
 #inspector .inspectorContents .inspectorField textarea, #inspector .inspectorContents .inspectorField input, #inspector .inspectorContents .inspectorField select, #inspector .inspectorContents .inspectorField .checkboxWrapper{

--- a/static/base.css
+++ b/static/base.css
@@ -439,8 +439,11 @@ color: #00bb00;}
     padding:1px 3px;
     background: #e9ecef;
     color: #2e3236;
-    max-width: 40%;
-    overflow-x: auto;
+    max-width: 45%;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
 }
 
 #inspector .inspectorContents .inspectorField textarea, #inspector .inspectorContents .inspectorField input, #inspector .inspectorContents .inspectorField select, #inspector .inspectorContents .inspectorField .checkboxWrapper{

--- a/static/base.css
+++ b/static/base.css
@@ -437,6 +437,8 @@ color: #00bb00;}
     padding:1px 3px;
     background: #e9ecef;
     color: #2e3236;
+    max-width: 40%;
+    overflow-x: auto;
 }
 
 #inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input{
@@ -785,6 +787,7 @@ color: #00bb00;}
 ::-webkit-scrollbar {
     width: 5px;
     height: 5px;
+    background: #002349;
 }
 
 /* Track */

--- a/static/base.css
+++ b/static/base.css
@@ -443,7 +443,7 @@ color: #00bb00;}
     overflow-x: auto;
 }
 
-#inspector .inspectorContents .inspectorField textarea,#inspector .inspectorContents .inspectorField input,#inspector .inspectorContents .inspectorField select,#inspector .inspectorContents .inspectorField .checkboxWrapper {
+#inspector .inspectorContents .inspectorField textarea, #inspector .inspectorContents .inspectorField input, #inspector .inspectorContents .inspectorField select, #inspector .inspectorContents .inspectorField .checkboxWrapper{
     resize: none;
     padding:1px 3px;
     min-height: auto;

--- a/static/base.css
+++ b/static/base.css
@@ -439,7 +439,13 @@ color: #00bb00;}
     color: #2e3236;
 }
 
-#inspector .inspectorContents .inspectorField textarea {
+#inspector .inspectorContents .inspectorField textarea{
+    resize: none;
+    padding:1px 3px;
+    min-height: auto;
+}
+
+#inspector .inspectorContents .inspectorField input{
     resize: none;
     padding:1px 3px;
     min-height: auto;

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -108,10 +108,10 @@
                                         <!-- string value -->
                                         <!-- ko ifnot: $data.getType() === 'Integer' -->
                                             <!-- ko if: $data.getGraphConfigField() -->
-                                                <textarea class="form-control configValueInput" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
+                                                <textarea class="form-control configValueInput" rows="1" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
                                             <!-- /ko -->
                                             <!-- ko ifnot: $data.getGraphConfigField() -->
-                                                <textarea class="form-control" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
+                                                <textarea class="form-control" rows="1" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
                                             <!-- /ko -->
                                             
                                             <button class="inspectorEditBtn icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -94,7 +94,61 @@
                             <div class="inspectorFields m-2 mb-1" data-bind="foreach: ParameterTable.getTableFields()">
                                 <div class="inspectorField input-group mb-1">
                                     <span class="input-group-text" data-bind="text:$data.getDisplayText()"></span>
-                                    <textarea class="form-control" rows="1" data-bind="value:$data.value"></textarea>
+                                    <!-- <textarea class="form-control" rows="1" data-bind="value:$data.value"></textarea> -->
+                                     <div data-bind="text:console.log($data.getDisplayText(), $data.getType())"></div>
+                                        <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
+
+                                                <!-- ko if: $data.getType() === 'Integer' -->
+                                                    <!-- ko if: $data.getGraphConfigField() -->
+                                                        <input class="form-control configValueInput" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)"  data-bind="eagleTooltip: 'Configured Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">    
+                                                    <!-- /ko -->
+                                                    <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                        <input class="form-control" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind=" eagleTooltip: 'Graph Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">
+                                                    <!-- /ko -->
+                                                <!-- /ko -->
+
+                                                <!-- string value -->
+                                                <!-- ko ifnot: $data.getType() === 'Integer' -->
+                                                    <!-- ko if: $data.getGraphConfigField() -->
+                                                        <textarea class="form-control configValueInput" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
+                                                    <!-- /ko -->
+                                                    <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                        <textarea class="form-control" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
+                                                    <!-- /ko -->
+                                                     
+                                                    <button class="inspectorEditBtn icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>
+                                                <!-- /ko -->
+                                            <!-- /ko -->
+
+                                            <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
+                                                <!-- ko if: $data.getGraphConfigField() -->
+                                                    <div class="checkboxWrapper configValueInput form-control" data-bind="eagleTooltip: 'Configured Value'">
+                                                        <div>
+                                                            <input tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
+                                                        </div>
+                                                    </div>
+                                                <!-- /ko -->
+                                                <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                    <div class="checkboxWrapper form-control" data-bind="eagleTooltip: 'Graph Value'">
+                                                        <div>
+                                                            <input tabindex='-1' data-bind="checked: valIsTrue($data.value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
+                                                        </div>
+                                                    </div>
+                                                <!-- /ko -->
+                                            <!-- /ko -->
+
+                                            <!-- ko if: $data.getHtmlInputType() === 'select' -->
+                                                <!-- ko if: $data.getGraphConfigField() -->
+                                                    <select class="configValueInput form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data.getGraphConfigField()), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.getGraphConfigField().value">
+                                                        <!-- options are added dynamically -->
+                                                    </select>
+                                                <!-- /ko -->
+                                                <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                    <select class="form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), options: $data.options, value: $data.value">
+                                                        <!-- options are added dynamically -->
+                                                    </select>
+                                                <!-- /ko -->
+                                            <!-- /ko -->
                                 </div>
                             </div>
                         </div>

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -93,7 +93,8 @@
                             </div>
                             <div class="inspectorFields m-2 mb-1" data-bind="foreach: $root.selectedNode().getInspectorFields()">
                                 <div class="inspectorField input-group mb-1">
-                                    <span class="input-group-text" data-bind="text:$data.getDisplayText(), eagleTooltip:$data.getDescription()"></span>
+            
+                                    <span class="input-group-text" data-bind="text:$data.getDisplayText(), eagleTooltip:$data.getDescription(), click:function(){ParameterTable.openTableAndSelectField($root.selectedNode(), $data)}"></span>
                                     <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
 
                                         <!-- ko if: $data.getType() === 'Integer' -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -93,7 +93,7 @@
                             </div>
                             <div class="inspectorFields m-2 mb-1" data-bind="foreach: $root.selectedNode().getInspectorFields()">
                                 <div class="inspectorField input-group mb-1">
-                                    <span class="input-group-text" data-bind="text:$data.getDisplayText()"></span>
+                                    <span class="input-group-text" data-bind="text:$data.getDisplayText(), eagleTooltip:$data.getDescription()"></span>
                                     <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
 
                                         <!-- ko if: $data.getType() === 'Integer' -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -121,16 +121,12 @@
                                     <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
                                         <!-- ko if: $data.getGraphConfigField() -->
                                             <div class="checkboxWrapper configValueInput form-control" data-bind="eagleTooltip: 'Configured Value'">
-                                                <div>
                                                     <input tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
-                                                </div>
                                             </div>
                                         <!-- /ko -->
                                         <!-- ko ifnot: $data.getGraphConfigField() -->
                                             <div class="checkboxWrapper form-control" data-bind="eagleTooltip: 'Graph Value'">
-                                                <div>
                                                     <input tabindex='-1' data-bind="checked: valIsTrue($data.value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
-                                                </div>
                                             </div>
                                         <!-- /ko -->
                                     <!-- /ko -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -19,7 +19,7 @@
                         
                         <div class="headerButtons inspectorHeaderButtons" id="objectInspectorHeaderIconRow">
                             <div class="row">
-                                <div class="col-6 col">
+                                <div class="col-5 col">
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $data.getGitHTML()" data-bs-toggle="tooltip" data-html="true">link</i>
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'Id: '+$data.getId()" data-bs-toggle="tooltip" data-html="true">fingerprint</i>
                                     <i class="material-icons interactive clickable iconHoverEffect" onclick=eagle.editNodeDescription() data-bs-placement="right" data-bind="eagleTooltip: $data.getDescriptionHTML()" data-bs-toggle="tooltip" data-html="true">library_books</i>
@@ -27,7 +27,7 @@
                                         <i class="material-icons interactive clickable iconHoverEffect" onclick=eagle.showGraphErrors() data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}" data-bs-toggle="tooltip" data-html="true">error</i>
                                     <!-- /ko -->
                                 </div>
-                                <div class="col-6 col text-right">
+                                <div class="col-7 col text-right">
                                     <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                                         <button type="button" id="openNodeParamsTable" class="btn btn-secondary btn-sm" data-bind="click: function(){ParameterTable.openTable(Eagle.BottomWindowMode.NodeParameterTable, ParameterTable.SelectType.Normal);}, clickBubble: false, eagleTooltip: KeyboardShortcut.idToFullText('open_parameter_table')" data-bs-placement="left">
                                             <i class="material-icons md-20 clickable iconHoverEffect">table_chart</i>
@@ -91,64 +91,62 @@
                                     <!-- /ko -->
                                 </div>  
                             </div>
-                            <div class="inspectorFields m-2 mb-1" data-bind="foreach: ParameterTable.getTableFields()">
+                            <div class="inspectorFields m-2 mb-1" data-bind="foreach: $root.selectedNode().getInspectorFields()">
                                 <div class="inspectorField input-group mb-1">
                                     <span class="input-group-text" data-bind="text:$data.getDisplayText()"></span>
-                                    <!-- <textarea class="form-control" rows="1" data-bind="value:$data.value"></textarea> -->
-                                     <div data-bind="text:console.log($data.getDisplayText(), $data.getType())"></div>
-                                        <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
+                                    <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
 
-                                                <!-- ko if: $data.getType() === 'Integer' -->
-                                                    <!-- ko if: $data.getGraphConfigField() -->
-                                                        <input class="form-control configValueInput" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)"  data-bind="eagleTooltip: 'Configured Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">    
-                                                    <!-- /ko -->
-                                                    <!-- ko ifnot: $data.getGraphConfigField() -->
-                                                        <input class="form-control" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind=" eagleTooltip: 'Graph Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">
-                                                    <!-- /ko -->
-                                                <!-- /ko -->
-
-                                                <!-- string value -->
-                                                <!-- ko ifnot: $data.getType() === 'Integer' -->
-                                                    <!-- ko if: $data.getGraphConfigField() -->
-                                                        <textarea class="form-control configValueInput" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
-                                                    <!-- /ko -->
-                                                    <!-- ko ifnot: $data.getGraphConfigField() -->
-                                                        <textarea class="form-control" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
-                                                    <!-- /ko -->
-                                                     
-                                                    <button class="inspectorEditBtn icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>
-                                                <!-- /ko -->
+                                        <!-- ko if: $data.getType() === 'Integer' -->
+                                            <!-- ko if: $data.getGraphConfigField() -->
+                                                <input class="form-control configValueInput" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)"  data-bind="eagleTooltip: 'Configured Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">    
                                             <!-- /ko -->
-
-                                            <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
-                                                <!-- ko if: $data.getGraphConfigField() -->
-                                                    <div class="checkboxWrapper configValueInput form-control" data-bind="eagleTooltip: 'Configured Value'">
-                                                        <div>
-                                                            <input tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
-                                                        </div>
-                                                    </div>
-                                                <!-- /ko -->
-                                                <!-- ko ifnot: $data.getGraphConfigField() -->
-                                                    <div class="checkboxWrapper form-control" data-bind="eagleTooltip: 'Graph Value'">
-                                                        <div>
-                                                            <input tabindex='-1' data-bind="checked: valIsTrue($data.value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
-                                                        </div>
-                                                    </div>
-                                                <!-- /ko -->
+                                            <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                <input class="form-control" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind=" eagleTooltip: 'Graph Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged}">
                                             <!-- /ko -->
+                                        <!-- /ko -->
 
-                                            <!-- ko if: $data.getHtmlInputType() === 'select' -->
-                                                <!-- ko if: $data.getGraphConfigField() -->
-                                                    <select class="configValueInput form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data.getGraphConfigField()), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.getGraphConfigField().value">
-                                                        <!-- options are added dynamically -->
-                                                    </select>
-                                                <!-- /ko -->
-                                                <!-- ko ifnot: $data.getGraphConfigField() -->
-                                                    <select class="form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), options: $data.options, value: $data.value">
-                                                        <!-- options are added dynamically -->
-                                                    </select>
-                                                <!-- /ko -->
+                                        <!-- string value -->
+                                        <!-- ko ifnot: $data.getType() === 'Integer' -->
+                                            <!-- ko if: $data.getGraphConfigField() -->
+                                                <textarea class="form-control configValueInput" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
                                             <!-- /ko -->
+                                            <!-- ko ifnot: $data.getGraphConfigField() -->
+                                                <textarea class="form-control" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged}"></textarea>
+                                            <!-- /ko -->
+                                            
+                                            <button class="inspectorEditBtn icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>
+                                        <!-- /ko -->
+                                    <!-- /ko -->
+
+                                    <!-- ko if: $data.getHtmlInputType() === 'checkbox' -->
+                                        <!-- ko if: $data.getGraphConfigField() -->
+                                            <div class="checkboxWrapper configValueInput form-control" data-bind="eagleTooltip: 'Configured Value'">
+                                                <div>
+                                                    <input tabindex='-1' data-bind="checked: valIsTrue($data.getGraphConfigField().value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.getGraphConfigField().toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
+                                                </div>
+                                            </div>
+                                        <!-- /ko -->
+                                        <!-- ko ifnot: $data.getGraphConfigField() -->
+                                            <div class="checkboxWrapper form-control" data-bind="eagleTooltip: 'Graph Value'">
+                                                <div>
+                                                    <input tabindex='-1' data-bind="checked: valIsTrue($data.value()), disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, event: {change: function(){$data.toggle(); ParameterTable.fieldValueChanged();}}" type="checkbox">
+                                                </div>
+                                            </div>
+                                        <!-- /ko -->
+                                    <!-- /ko -->
+
+                                    <!-- ko if: $data.getHtmlInputType() === 'select' -->
+                                        <!-- ko if: $data.getGraphConfigField() -->
+                                            <select class="configValueInput form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Configured Value', disabled: ParameterTable.getCurrentParamValueReadonly($data.getGraphConfigField()), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.getGraphConfigField().value">
+                                                <!-- options are added dynamically -->
+                                            </select>
+                                        <!-- /ko -->
+                                        <!-- ko ifnot: $data.getGraphConfigField() -->
+                                            <select class="form-control" aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), options: $data.options, value: $data.value">
+                                                <!-- options are added dynamically -->
+                                            </select>
+                                        <!-- /ko -->
+                                    <!-- /ko -->
                                 </div>
                             </div>
                         </div>

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -91,6 +91,12 @@
                                     <!-- /ko -->
                                 </div>  
                             </div>
+                            <div class="inspectorFields m-2 mb-1" data-bind="foreach: ParameterTable.getTableFields()">
+                                <div class="inspectorField input-group mb-1">
+                                    <span class="input-group-text" data-bind="text:$data.getDisplayText()"></span>
+                                    <textarea class="form-control" rows="1" data-bind="value:$data.value"></textarea>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 <!-- /ko -->

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -162,7 +162,7 @@
                                                 <!-- kept for now as we will need the space for the row drag handle -->
                                             </td>
                                             <!-- /ko -->
-                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->    
+                                            <!-- ko if: ParameterTable.getActiveColumnVisibility().displayText() -->
                                                 <td class='columnCell column_DisplayText' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('displayText', $data) }, eagleTooltip:description">
                                                     <input class="tableParameter selectionTargets tableFieldDisplayName" placeholder="New Parameter" type="string" data-bind="value: displayText, disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], click: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}, event:{blur: function(){$(event.target).removeClass('newEmpty')} ,keyup: function(event, data){ParameterTable.select($data.displayText(), 'displayText', $data, $index())}}">
                                                     <!-- ko if: Eagle.selectedLocation() === Eagle.FileType.Graph -->
@@ -189,7 +189,7 @@
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().value()  -->
                                                 <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
 
-                                                    <!-- ko if: $data.getType() === 'Integer' -->    
+                                                    <!-- ko if: $data.getType() === 'Integer' -->
                                                         <td class='columnCell column_Value'>
                                                             <!-- ko if: $data.getGraphConfigField() -->
                                                                 <input class="tableParameter configValueInput" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('configValue', $data) }, eagleTooltip: 'Configured Value',disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'configValue', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'configValue', $data, $index())}}">    
@@ -262,12 +262,12 @@
                                             <!-- default value fields -->
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().defaultValue() -->
                                                 <!-- ko if: $data.getHtmlInputType() === 'number' || $data.getHtmlInputType() === 'text' || $data.getHtmlInputType() === 'password' -->
-                                                    <!-- ko if: $data.getType() === 'Integer' -->    
+                                                    <!-- ko if: $data.getType() === 'Integer' -->
                                                         <td class='columnCell column_DefaultValue' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('defaultValue', $data) }">
                                                             <input class="tableParameter" step="1" onfocus="this.previousValue = this.value" onkeydown="this.previousValue = this.value" oninput="validity.valid || (value = this.previousValue)" data-bind="disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}, click: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}}">
                                                         </td>
                                                     <!-- /ko -->
-                                                    <!-- ko ifnot: $data.getType() === 'Integer' -->    
+                                                    <!-- ko ifnot: $data.getType() === 'Integer' -->
                                                         <td class='columnCell column_DefaultValue' data-bind=" css: { selectedTableParameter: ParameterTable.isSelected('defaultValue', $data) }">
                                                             <textarea  style="resize: none;" class="tableParameter inputNoArrows" data-bind="disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}, click: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}}"></textarea>
                                                             <!-- ko if: !ParameterTable.getNodeLockedState($data) && $data.getDisplayText() === 'func_code' -->
@@ -288,7 +288,7 @@
                                                         <!-- ko ifnot: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <select aria-label="Label" aria-describedby="group-addon" data-bs-placement="bottom" data-bind="disabled: ParameterTable.getNodeLockedState($data), event: {change: ParameterTable.fieldValueChanged}, options: $data.options, value: $data.defaultValue">
                                                                 <!-- options are added dynamically -->
-                                                            </select> 
+                                                            </select>
                                                         <!-- /ko -->
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="dropdown parameterTableTypeCustomSelect">
@@ -299,7 +299,7 @@
                                                                             <input data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
                                                                             <button class="typeSelectDelete" data-bind="clickBubble:false, click: function(){$parent.removeOption($index())}"><i class="material-icons md-24 iconHoverEffect">delete</i></button>
                                                                         </div>
-                                                                    <!-- /ko --> 
+                                                                    <!-- /ko -->
                                                                     <div class="dropdown-item add" data-bind="click:function(data,event){event.stopPropagation();addOption('')}">
                                                                         <i class="material-icons iconHoverEffect">add</i>
                                                                     </div>
@@ -325,7 +325,7 @@
                                                         <select data-bind="options: $root.types(), value: type, disabled: ParameterTable.getNodeLockedState($data)">
                                                             <!-- options are added dynamically -->
                                                         </select>
-                                                    <!-- /ko --> 
+                                                    <!-- /ko -->
                                                     <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                         <div class="input-group">
                                                             <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">


### PR DESCRIPTION
added fields to the node inspector when selecting a node.
these fields include fields we deem as ' important' such as num_of_copies for scatters or func_code. followed by the fields on the node that are marked by the user as a config field, using the heart button.

it is worth mentioning that even though the value inputs are similar to those used in the parameter table, they are a significantly simplified version of them, so i deemed them different enough to not share the same code.

## Summary by Sourcery

Add a dynamic set of inspector fields to the node inspector showing key and user-configured properties with inline editing controls and improved styling.

New Features:
- Display 'important' node attributes (e.g., num_of_copies, func_code) and user-marked graph config fields in the node inspector.
- Support inline editing for various input types (number, text, textarea, checkbox, select) with tooltips and a quick code-edit button.

Enhancements:
- Implement Node.getInspectorFields to collect and order important and config fields for inspection.
- Limit inspector panel height with vertical scrolling and refine field layout styling and edit-button hover behavior.

Chores:
- Add GATHER_AXIS constant to Daliuge field enum.
- Clean up whitespace in node parameter table templates.
- Update KeyboardShortcut tags to include 'save as'.