### PR TITLE
EAGLE-1499: Fields with 'Unknown' type generate warnings even when isEvent flag set

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -810,8 +810,8 @@ export class Field {
         //checks for input ports
         if(field.isInputPort()){
 
-            //check the data type is known
-            if (field.isType(Daliuge.DataType.Unknown)){
+            //check the data type is known (except in the case of event ports, they can be unknown)
+            if (!field.isEvent() && field.isType(Daliuge.DataType.Unknown)){
                 let issue: Errors.Issue
 
                 // for normal nodes
@@ -838,8 +838,8 @@ export class Field {
         // checks for output ports
         if(field.isOutputPort()){
 
-            //check the data type is known
-            if (field.isType(Daliuge.DataType.Unknown)){
+            //check the data type is known (except in the case of event ports, they can be unknown)
+            if (!field.isEvent() && field.isType(Daliuge.DataType.Unknown)){
                 let issue: Errors.Issue
 
                 //for normal nodes

--- a/static/tables.css
+++ b/static/tables.css
@@ -470,6 +470,11 @@
     border-right: solid 1px #bbbbbb;
 }
 
+.eagleTableDisplay .typeEvent {
+    color: black;
+    padding-left: 2px;
+}
+
 .eagleTableDisplay .input-group{
     border:black solid 1px;
     border-radius: 2px;

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -321,26 +321,31 @@
                                             
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().type() -->
                                                 <td class='columnCell column_Type'>
-                                                    <!-- ko ifnot: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
-                                                        <select data-bind="options: $root.types(), value: type, disabled: ParameterTable.getNodeLockedState($data)">
-                                                            <!-- options are added dynamically -->
-                                                        </select>
+                                                    <!-- ko if: $data.isEvent -->
+                                                    <span class="typeEvent">&lt;Event&gt;</span>
                                                     <!-- /ko -->
-                                                    <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
-                                                        <div class="input-group">
-                                                            <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">
-                                                            <button class="btn btn-outline-secondary" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
-                                                                <span class="material-icons-outlined iconHoverEffect">
-                                                                    arrow_drop_down
-                                                                </span>
-                                                            </button>
-                                                            <ul class="dropdown-menu dropdown-menu-end" data-bind="attr:{id:'typeFor_'+$data.getId()}">
-                                                                <!-- ko foreach:$root.types()-->
-                                                                    <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
-                                                                <!-- /ko --> 
-                                                            </ul>
-                                                        </div>
-                                                    <!-- /ko --> 
+                                                    <!-- ko ifnot: $data.isEvent -->
+                                                        <!-- ko ifnot: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
+                                                            <select data-bind="options: $root.types(), value: type, disabled: ParameterTable.getNodeLockedState($data)">
+                                                                <!-- options are added dynamically -->
+                                                            </select>
+                                                        <!-- /ko -->
+                                                        <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
+                                                            <div class="input-group">
+                                                                <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">
+                                                                <button class="btn btn-outline-secondary" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
+                                                                    <span class="material-icons-outlined iconHoverEffect">
+                                                                        arrow_drop_down
+                                                                    </span>
+                                                                </button>
+                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="attr:{id:'typeFor_'+$data.getId()}">
+                                                                    <!-- ko foreach:$root.types() -->
+                                                                        <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
+                                                                    <!-- /ko -->
+                                                                </ul>
+                                                            </div>
+                                                        <!-- /ko -->
+                                                    <!-- /ko -->
                                                 </td>
                                             <!-- /ko --> 
                                             <!-- ko if: ParameterTable.getActiveColumnVisibility().flags() -->


### PR DESCRIPTION
If the event flag is set, it doesn't matter what 'type' the field has. When the field is written to JSON, the type will be replaced by "Event".

- Remove warning generated for field with Unknown type, if the field is an event
- In Parameter Table, disable the display of type for event fields, instead show `<Event>`