### PR TITLE
EAGLE-1494: Combine palette header right click menu and palette triple-dot menu

### DIFF
--- a/src/RightClick.ts
+++ b/src/RightClick.ts
@@ -23,19 +23,6 @@ export class RightClick {
         RightClick.edgeDropSrcIsInput = null;
     }
 
-    static rightClickReloadPalette() : void {
-        const eagle: Eagle = Eagle.getInstance();
-        let index = 0
-        const palettes = eagle.palettes()
-
-        palettes.forEach(function(palette){
-            if (palette === Eagle.selectedRightClickObject()){
-                eagle.reloadPalette(palette,index)
-            }
-            index++
-        })
-    }
-
     static openSubMenu(menuElement: HTMLElement) : void {
         $(menuElement).find('.contextMenuDropdown').show()
     }
@@ -91,29 +78,6 @@ export class RightClick {
     static clearSearchField() : void {
         $('#rightClickSearchBar').val('')
         RightClick.checkSearchField()
-    }
-
-    static rightClickDeletePalette() : void {
-        const eagle: Eagle = Eagle.getInstance();
-        eagle.closePalette(Eagle.selectedRightClickObject())
-    }
-
-    static rightClickSavePaletteToDisk() : void {
-        const eagle: Eagle = Eagle.getInstance();
-        eagle.savePaletteToDisk(Eagle.selectedRightClickObject())
-    }
-
-    static rightClickSavePaletteToGit() : void {
-        const eagle: Eagle = Eagle.getInstance();
-        eagle.savePaletteToGit(Eagle.selectedRightClickObject())
-    }
-
-    static rightClickToggleSearchExclude(bool:boolean) : void {
-        Eagle.selectedRightClickObject().setSearchExclude(bool)
-    }
-
-    static rightClickCopyPaletteUrl = () : void => {
-        Eagle.selectedRightClickObject().copyUrl()
     }
 
     static closeCustomContextMenu(force:boolean) : void {
@@ -673,28 +637,6 @@ export class RightClick {
                 $('#customContextMenu').append('<a onclick=Eagle.selectedRightClickObject().toggleLoopAware()>Toggle Loop Aware</a>')
                 $('#customContextMenu').append('<a onclick=eagle.toggleEdgeClosesLoop()>Toggle Closes Loop</a>')
                 $('#customContextMenu').append('<a onclick=eagle.deleteSelection(true,false,false)>Delete</a>')
-    
-            }else if(passedObjectClass === 'rightClick_paletteHeader'){
-                
-                if(!data.fileInfo().builtIn){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickDeletePalette()"><span>Remove Palette</span></a>')
-                }
-                if(data.fileInfo().repositoryService !== Repository.Service.Unknown){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickReloadPalette()"><span>Reload Palette</span></a>')
-                }
-                if(Setting.findValue(Setting.ALLOW_PALETTE_EDITING)){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickSavePaletteToDisk()"><span>Save Locally</span></a>')
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickSavePaletteToGit()"><span>Save To Git</span></a>')
-                }
-                if(data.searchExclude()){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickToggleSearchExclude(false)"><span>Include In Search</span></a>')
-                }
-                if(!data.searchExclude()){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickToggleSearchExclude(true)"><span>Exclude From Search</span></a>')
-                }
-                if(data.fileInfo().repositoryService !== Repository.Service.Unknown && data.fileInfo().repositoryService !== Repository.Service.File){
-                    $('#customContextMenu').append('<a onclick="RightClick.rightClickCopyPaletteUrl()"><span>Copy Palette URL</span></a>')
-                }
             }
         }
         // adding a listener to function options that closes the menu if an option is clicked

--- a/templates/palette.html
+++ b/templates/palette.html
@@ -1,6 +1,6 @@
 <div class="container px-0">
     <!-- ko foreach: nodes -->
-        <!-- ko if: $data.fitsSearchQuery() -->
+        <!-- ko if: $parent.searchExclude() || $data.fitsSearchQuery() -->
             {% include 'palette-component.html' %}
         <!-- /ko -->
     <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -52,7 +52,10 @@
                         <a href="#" data-bind="click: $root.savePaletteToGit" data-html="true"><span>Save To Git</span></a>
                     <!-- /ko -->
                     <!-- ko if: $data.searchExclude() -->
-                    <a href="#" data-bind="click: function(){$data.setSearchExclude(false)}"><span>Include In Search</span></a>
+                    <a href="#" data-bind="click: function(){$data.setSearchExclude(false)}"><span>Include In Search Filter</span></a>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $data.searchExclude() -->
+                    <a href="#" data-bind="click: function(){$data.setSearchExclude(true)}"><span>Exclude From Search Filter</span></a>
                     <!-- /ko -->
                     <a href="#" data-bind="click: $data.copyUrl"><span>Copy URL</span></a>
                     <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show ModelData</span></a>
@@ -69,7 +72,7 @@
                                 <!-- /ko -->
                             </div>
                         </div>
-                        <div class="accordion-button rightClick_paletteHeader" type="button" data-bs-toggle="collapse" data-bind="click: toggle, eagleRightClick: {data:$data,type:'rightClick_paletteHeader'}, attr:{id:'palette' + $index(), 'data-bs-target':'#collapse' + $index(), 'aria-controls':'collapse' + $index(), 'aria-expanded':expanded}, css: {collapsed: !expanded}">
+                        <div class="accordion-button" type="button" data-bs-toggle="collapse" data-bind="click: toggle, attr:{id:'palette' + $index(), 'data-bs-target':'#collapse' + $index(), 'aria-controls':'collapse' + $index(), 'aria-expanded':expanded}, css: {collapsed: !expanded}">
                             <span>&nbsp;</span>
                             <h5 class="template-title" data-bs-placement="right" data-bind="text: fileInfo().nameAndModifiedIndicator(), eagleTooltip: fileInfo().getSummaryHTML(fileInfo().nameAndModifiedIndicator())"></h5>
                         </div>


### PR DESCRIPTION
Removed right click menu from palette header and stuck with the triple-dot menu.

Moved one missing function "Exclude From Search" over to the triple-dot menu.
Fixed bug where palette searchExclude didn't work.

## Summary by Sourcery

Consolidate palette header context actions into the triple-dot menu and correct searchExclude behavior to ensure excluded palettes bypass search filtering.

Bug Fixes:
- Fix palette searchExclude toggle so excluded palettes correctly bypass search filtering.

Enhancements:
- Remove palette header right-click menu and consolidate palette actions under the triple-dot menu.
- Move the Exclude/Include From Search actions to the palette’s triple-dot menu with updated labels.
- Update palette template logic to respect the searchExclude flag when displaying nodes.