### PR TITLE
EAGLE-1502: Node setGroupStart/setGroupEnd functions should clone fields from Daliuge.ts

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -193,6 +193,9 @@ export namespace Daliuge {
     export const funcCodeField = new Field(null, FieldName.FUNC_CODE, "", "def func_name(args): return args", "Python function code", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.Component, FieldUsage.NoPort);
     export const funcNameField = new Field(null, FieldName.FUNC_NAME, "", "func_name", "Python function name", false, Daliuge.DataType.Python, false, [], false, Daliuge.FieldType.Component, FieldUsage.NoPort);
 
+    export const persistField = new Field(null, FieldName.PERSIST, "false", "false", "Specifies whether this data component contains data that should not be deleted after execution", false, Daliuge.DataType.Boolean, false, [], false, Daliuge.FieldType.Component, Daliuge.FieldUsage.NoPort);
+    export const streamingField = new Field(null, FieldName.STREAMING, "false", "false", "Specifies whether this data component streams input and output data", false, Daliuge.DataType.Boolean, false, [], false, Daliuge.FieldType.Component, Daliuge.FieldUsage.NoPort);
+
     // This list defines the fields required for ALL nodes belonging to a given Category.Type
     export const categoryTypeFieldsRequired = [
         {

--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -170,8 +170,8 @@ export namespace Daliuge {
     }
 
     // These are the canonical example definition of each field
-    export const groupStartField = new Field(null, FieldName.GROUP_START, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
-    export const groupEndField = new Field(null, FieldName.GROUP_END, "true", "true", "", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
+    export const groupStartField = new Field(null, FieldName.GROUP_START, "true", "true", "Is this node the start of a group?", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
+    export const groupEndField = new Field(null, FieldName.GROUP_END, "true", "true", "Is this node the end of a group?", false, DataType.Boolean, false, [], false, FieldType.Component, FieldUsage.NoPort);
 
     export const branchYesField = new Field(null, FieldName.TRUE, "", "", "The affirmative output from a branch node", false, DataType.Object, false, [], false, FieldType.Component, FieldUsage.OutputPort);
     export const branchNoField  = new Field(null, FieldName.FALSE,  "", "", "he negative output from a branch node", false, DataType.Object, false, [], false, FieldType.Component, FieldUsage.OutputPort);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -3734,14 +3734,13 @@ export class Eagle {
 
                 // make sure we can find a port on the PythonMemberFunction
                 if (sourcePort === null){
-                    sourcePort = Daliuge.selfField.clone();
-                    sourcePort.setId(Utils.generateFieldId());
+                    sourcePort = Daliuge.selfField.clone().setId(Utils.generateFieldId());
                     newNode.addField(sourcePort);
                     Utils.showNotification("Component Warning", "The PythonMemberFunction does not have a '" + Daliuge.FieldName.SELF + "' port. Added this port to enable connection.", "warning");
                 }
 
                 // create a new input/output "object" port on the PythonObject
-                const inputOutputPort = new Field(Utils.generateFieldId(), Daliuge.FieldName.SELF, "", "", "", true, sourcePort.getType(), false, null, false, Daliuge.FieldType.Component, Daliuge.FieldUsage.InputOutput);
+                const inputOutputPort: Field = Daliuge.selfField.clone().setId(Utils.generateFieldId()).setType(sourcePort.getType());
                 pythonObjectNode.addField(inputOutputPort);
 
                 // add edge to Logical Graph (connecting the PythonMemberFunction and the automatically-generated PythonObject)

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -81,32 +81,36 @@ export class Field {
         return this.id();
     }
 
-    setId = (id: FieldId): void => {
+    setId = (id: FieldId): Field => {
         this.id(id);
+        return this;
     }
 
     getDisplayText = () : string => {
         return this.displayText();
     }
 
-    setDisplayText = (displayText: string): void => {
+    setDisplayText = (displayText: string): Field => {
         this.displayText(displayText);
+        return this;
     }
 
     getValue = () : string => {
         return this.value();
     }
 
-    setValue = (value: string): void => {
+    setValue = (value: string): Field => {
         this.value(value);
+        return this;
     }
 
     getDefaultValue = () : string => {
         return this.defaultValue();
     }
 
-    setDefaultValue = (value: string): void => {
+    setDefaultValue = (value: string): Field => {
         this.defaultValue(value);
+        return this;
     }
 
     hasDefaultValue = () : boolean => {
@@ -117,8 +121,9 @@ export class Field {
         return this.description();
     }
 
-    setDescription = (description: string): void => {
+    setDescription = (description: string): Field => {
         this.description(description);
+        return this;
     }
 
     getDescriptionText : ko.PureComputed<string> = ko.pureComputed(() => {
@@ -133,18 +138,21 @@ export class Field {
         return {x: this.outputX(), y: this.outputY()};
     }
 
-    setInputPosition = (x: number, y: number) : void => {
+    setInputPosition = (x: number, y: number) : Field => {
         this.inputX(x);
         this.inputY(y);
+        return this;
     }
 
-    setOutputPosition = (x: number, y: number) : void => {
+    setOutputPosition = (x: number, y: number) : Field => {
         this.outputX(x);
         this.outputY(y);
+        return this;
     }
 
-    setInputAngle = (angle:number) : void => {
-        this.inputAngle = angle
+    setInputAngle = (angle:number) : Field => {
+        this.inputAngle = angle;
+        return this;
     }
 
     getInputAngle = () : number => {
@@ -155,8 +163,9 @@ export class Field {
         this.displayText.valueHasMutated()
     }
 
-    setOutputAngle = (angle:number) :void => {
-        this.outputAngle = angle
+    setOutputAngle = (angle:number): Field => {
+        this.outputAngle = angle;
+        return this;
     }
 
     getOutputAngle = () : number => {
@@ -167,8 +176,9 @@ export class Field {
         return this.readonly();
     }
 
-    setReadonly = (readonly: boolean): void => {
+    setReadonly = (readonly: boolean): Field => {
         this.readonly(readonly);
+        return this;
     }
 
     toggleReadOnly = () => {
@@ -183,8 +193,9 @@ export class Field {
         return Utils.dataTypePrefix(this.type()) === type;
     }
     
-    setEncoding = (encoding: Daliuge.Encoding) => {
+    setEncoding = (encoding: Daliuge.Encoding): Field => {
         this.encoding(encoding);
+        return this;
     }
 
     getEncoding = () : Daliuge.Encoding => {
@@ -203,12 +214,14 @@ export class Field {
         this.defaultValue((!Utils.asBool(this.defaultValue())).toString());
     }
 
-    setType = (type: Daliuge.DataType) : void => {
+    setType = (type: Daliuge.DataType) : Field => {
         this.type(type);
+        return this;
     }
 
-    setPrecious = (precious: boolean) : void => {
+    setPrecious = (precious: boolean) : Field => {
         this.precious(precious);
+        return this;
     }
 
     togglePrecious = () : void => {
@@ -223,7 +236,7 @@ export class Field {
         return this.options();
     }
 
-    editOption = (optionIndex:any,newVal:string) : void => {
+    editOption = (optionIndex: number, newVal: string) : Field => {
         //if the option we are editing is selected well update the value or default value
         if(this.options()[optionIndex] === this.value()){
             this.value(newVal)
@@ -234,9 +247,10 @@ export class Field {
 
         this.options()[optionIndex] = newVal
         this.options.valueHasMutated()
+        return this;
     }
 
-    addOption = (newOption:string) : void => {
+    addOption = (newOption: string) : Field => {
         let duplicate = false;
         
         for(const option of this.options()){
@@ -249,12 +263,14 @@ export class Field {
             this.options().push(newOption)
             this.options.valueHasMutated()
         }
+
+        return this;
     }
 
-    removeOption = (index:number) : void => {
+    removeOption = (index:number) : Field => {
         if(this.options().length <= 1){
             Utils.showNotification("Cannot Remove","There must be at least one option in the select!",'danger');
-            return
+            return this;
         }
 
         //checking if a selected option is being deleted
@@ -278,46 +294,54 @@ export class Field {
             this.defaultValue(this.options()[0])
         }
         this.options.valueHasMutated()
+
+        return this;
     }
 
     isPositionalArgument = () : boolean => {
         return this.positional();
     }
 
-    togglePositionalArgument = () : void => {
+    togglePositionalArgument = () : Field => {
         this.positional(!this.positional());
+        return this;
     }
 
-    setPositionalArgument = (positional: boolean): void => {
+    setPositionalArgument = (positional: boolean): Field => {
         this.positional(positional);
+        return this;
     }
 
     getParameterType = (): Daliuge.FieldType => {
         return this.parameterType();
     }
 
-    setParameterType = (parameterType: Daliuge.FieldType) : void => {
+    setParameterType = (parameterType: Daliuge.FieldType) : Field => {
         this.parameterType(parameterType);
+        return this;
     }
 
     getUsage = (): Daliuge.FieldUsage => {
         return this.usage();
     }
 
-    setUsage = (usage: Daliuge.FieldUsage) : void => {
+    setUsage = (usage: Daliuge.FieldUsage) : Field => {
         this.usage(usage);
+        return this;
     }
 
     getIsEvent = (): boolean => {
         return this.isEvent();
     }
 
-    setIsEvent = (isEvent: boolean) : void => {
+    setIsEvent = (isEvent: boolean) : Field => {
         this.isEvent(isEvent);
+        return this;
     }
 
-    toggleEvent = (): void => {
+    toggleEvent = (): Field => {
         this.isEvent(!this.isEvent());
+        return this;
     }
 
     getNodeId = () : NodeId => {
@@ -342,8 +366,9 @@ export class Field {
         return this.issues();
     }
 
-    addError(issue:Errors.Issue, validity:Errors.Validity){
+    addError = (issue:Errors.Issue, validity:Errors.Validity): Field => {
         this.issues().push({issue:issue,validity:validity})
+        return this;
     }
 
     // TODO: these colors could be added to EagleConfig.ts
@@ -369,15 +394,16 @@ export class Field {
         return errorsWarnings.warnings.length>0 && errorsWarnings.errors.length === 0;
     }
 
-    setNodeId = (id: NodeId) : void => {
+    setNodeId = (id: NodeId) : Field => {
         this.nodeId(id);
+        return this;
     }
 
     getGraphConfigField : ko.PureComputed<GraphConfigField> = ko.pureComputed(() => {
         return Eagle.getInstance().logicalGraph().getActiveGraphConfig()?.findNodeById(this.nodeId())?.findFieldById(this.id());
     }, this);
 
-    clear = () : void => {
+    clear = () : Field => {
         this.displayText("");
         this.value("");
         this.defaultValue("");
@@ -394,6 +420,7 @@ export class Field {
         this.id(null);
         this.isEvent(false);
         this.nodeId(null);
+        return this;
     }
 
     clone = () : Field => {
@@ -432,8 +459,9 @@ export class Field {
         return f;
     }
 
-    resetToDefault = () : void => {
+    resetToDefault = () : Field => {
         this.value(this.defaultValue());
+        return this;
     }
 
     // TODO: rename this slightly so that it is more obvious that it is a user-facing version of the value
@@ -446,7 +474,7 @@ export class Field {
         return tooltipText;
     }
 
-    copyWithIds = (src: Field, nodeId: NodeId, id: FieldId) : void => {
+    copyWithIds = (src: Field, nodeId: NodeId, id: FieldId) : Field => {
         this.displayText(src.displayText());
         this.value(src.value());
         this.defaultValue(src.defaultValue());
@@ -464,6 +492,8 @@ export class Field {
         // NOTE: these two are not copied from the src, but come from the function's parameters
         this.id(id);
         this.nodeId(nodeId);
+
+        return this;
     }
 
     isInputPort = () : boolean => {
@@ -609,37 +639,41 @@ export class Field {
         return this.inputPeek()
     }
 
-    setInputPeek = (value:boolean) : void => {
+    setInputPeek = (value:boolean) : Field => {
         this.inputPeek(value);
+        return this;
     }
 
     isOutputPeek = () : boolean => {
         return this.outputPeek()
     }
 
-    setOutputPeek = (value:boolean) : void => {
+    setOutputPeek = (value:boolean) : Field => {
         this.outputPeek(value);
+        return this;
     }
 
-    getInputConnected = () :boolean => {
+    getInputConnected = (): boolean => {
         return this.inputConnected()
     }
 
-    setInputConnected = (value:boolean) : void => {
-        this.inputConnected(value)
+    setInputConnected = (value:boolean) : Field => {
+        this.inputConnected(value);
+        return this;
     }
 
-    getOutputConnected = () :boolean => {
+    getOutputConnected = (): boolean => {
         return this.outputConnected()
     }
 
-    setOutputConnected = (value:boolean) : void => {
-        this.outputConnected(value)
+    setOutputConnected = (value:boolean) : Field => {
+        this.outputConnected(value);
+        return this;
     }
 
     // used to transform the value attribute of a field into a variable with the correct type
     // the value attribute is always stored as a string internally
-    static stringAsType(value: string, type: Daliuge.DataType) : any {
+    static stringAsType(value: string, type: Daliuge.DataType) : boolean | number | string {
         switch (type){
             case Daliuge.DataType.Boolean:
                 return Utils.asBool(value);
@@ -653,7 +687,7 @@ export class Field {
     }
 
     static toOJSJson(field : Field) : object {
-        const result : any = {
+        return {
             name:field.displayText(),
             value:Field.stringAsType(field.value(), field.type()),
             defaultValue:field.defaultValue(),
@@ -667,9 +701,7 @@ export class Field {
             id: field.id(),
             parameterType: Daliuge.fieldTypeToDlgMap[field.parameterType()] || Daliuge.DLGFieldType.Unknown,
             usage: field.usage(),
-        }
-
-        return result;
+        };
     }
 
     static toOJSJsonPort(field : Field) : object {

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -975,19 +975,13 @@ export class Node {
 
     setGroupStart = (value: boolean) => {
         if (!this.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_START)){
-            this.addField(new Field(
-                Utils.generateFieldId(),
-                Daliuge.FieldName.GROUP_START,
-                value.toString(),
-                "false",
-                "Is this node the start of a group?",
-                false,
-                Daliuge.DataType.Boolean,
-                false,
-                [],
-                false,
-                Daliuge.FieldType.Component,
-                Daliuge.FieldUsage.NoPort));
+            // create a new groupStart field (clone from Daliuge)
+            const groupStartField: Field = Daliuge.groupStartField.clone();
+            groupStartField.setId(Utils.generateFieldId());
+            groupStartField.setValue(value.toString());
+
+            // add field to node
+            this.addField(groupStartField);
         } else {
             this.getFieldByDisplayText(Daliuge.FieldName.GROUP_START).setValue(value.toString());
         }
@@ -995,19 +989,13 @@ export class Node {
 
     setGroupEnd = (value: boolean) => {
         if (!this.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_END)){
-            this.addField(new Field(
-                Utils.generateFieldId(),
-                Daliuge.FieldName.GROUP_END,
-                value.toString(),
-                "false",
-                "Is this node the end of a group?",
-                false,
-                Daliuge.DataType.Boolean,
-                false,
-                [],
-                false,
-                Daliuge.FieldType.Component,
-                Daliuge.FieldUsage.NoPort));
+            // create a new groupEnd field (clone from Daliuge)
+            const groupEndField: Field = Daliuge.groupEndField.clone();
+            groupEndField.setId(Utils.generateFieldId());
+            groupEndField.setValue(value.toString());
+
+            // add field to node
+            this.addField(groupEndField);
         } else {
             this.getFieldByDisplayText(Daliuge.FieldName.GROUP_END).setValue(value.toString());
         }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -976,9 +976,7 @@ export class Node {
     setGroupStart = (value: boolean) => {
         if (!this.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_START)){
             // create a new groupStart field (clone from Daliuge)
-            const groupStartField: Field = Daliuge.groupStartField.clone();
-            groupStartField.setId(Utils.generateFieldId());
-            groupStartField.setValue(value.toString());
+            const groupStartField: Field = Daliuge.groupStartField.clone().setId(Utils.generateFieldId()).setValue(value.toString());
 
             // add field to node
             this.addField(groupStartField);
@@ -990,9 +988,7 @@ export class Node {
     setGroupEnd = (value: boolean) => {
         if (!this.hasFieldWithDisplayText(Daliuge.FieldName.GROUP_END)){
             // create a new groupEnd field (clone from Daliuge)
-            const groupEndField: Field = Daliuge.groupEndField.clone();
-            groupEndField.setId(Utils.generateFieldId());
-            groupEndField.setValue(value.toString());
+            const groupEndField: Field = Daliuge.groupEndField.clone().setId(Utils.generateFieldId()).setValue(value.toString());
 
             // add field to node
             this.addField(groupEndField);
@@ -1531,37 +1527,13 @@ export class Node {
 
         // handle obsolete 'precious' attribute, add it as a 'persist' field
         if (typeof nodeData.precious !== 'undefined'){
-            const preciousField = new Field(
-                Utils.generateFieldId(),
-                Daliuge.FieldName.PERSIST,
-                nodeData.precious.toString(), 
-                "false",
-                "Specifies whether this data component contains data that should not be deleted after execution",
-                false,
-                Daliuge.DataType.Boolean,
-                false,
-                [],
-                false,
-                Daliuge.FieldType.Component,
-                Daliuge.FieldUsage.NoPort);
-            node.addField(preciousField);
+            const persistField = Daliuge.persistField.clone().setId(Utils.generateFieldId()).setValue(nodeData.precious.toString());
+            node.addField(persistField);
         }
 
         // handle obsolete 'streaming' attribute, add it as a 'streaming' field
         if (typeof nodeData.streaming !== 'undefined'){
-            const streamingField = new Field(
-                Utils.generateFieldId(),
-                Daliuge.FieldName.STREAMING,
-                nodeData.streaming.toString(),
-                "false",
-                "Specifies whether this data component streams input and output data",
-                false,
-                Daliuge.DataType.Boolean,
-                false,
-                [],
-                false,
-                Daliuge.FieldType.Component,
-                Daliuge.FieldUsage.NoPort);
+            const streamingField = Daliuge.streamingField.clone().setId(Utils.generateFieldId()).setValue(nodeData.streaming.toString());
             node.addField(streamingField);
         }
 

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -702,9 +702,8 @@ export class ParameterTable {
         let fieldIndex:number //variable holds the index of which row to highlight after creation
         const eagle = Eagle.getInstance()
 
-        const copiedField = eagle.selectedNode().findFieldById(fieldId).clone()
-        copiedField.setId(Utils.generateFieldId())
-        copiedField.setDisplayText(copiedField.getDisplayText()+' copy')
+        const copiedField = eagle.selectedNode().findFieldById(fieldId).clone().setId(Utils.generateFieldId());
+        copiedField.setDisplayText(copiedField.getDisplayText()+' copy');
         if(ParameterTable.hasSelection()){
             //if a cell in the table is selected in this case the new node will be placed below the currently selected node
             fieldIndex = ParameterTable.selectionParentIndex() + 1

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2049,8 +2049,7 @@ export class Utils {
 
         // if a field was not found, clone one from the example and add to node
         if (field === null){
-            field = exampleField.clone();
-            field.setId(Utils.generateFieldId());
+            field = exampleField.clone().setId(Utils.generateFieldId());
             node.addField(field);
         }
 
@@ -2242,8 +2241,7 @@ export class Utils {
 
         // otherwise, if not found, just add a clone of the required field
         if (!field){
-            field = requiredField.clone();
-            field.setId(Utils.generateFieldId());
+            field = requiredField.clone().setId(Utils.generateFieldId());
             node.addField(field);
         }
 
@@ -2745,8 +2743,7 @@ export class Utils {
 
         // set new ids for any fields in this node
         for (const field of newNode.getFields()){
-            field.setId(Utils.generateFieldId());
-            field.setNodeId(newNodeId);
+            field.setId(Utils.generateFieldId()).setNodeId(newNodeId);
         }
 
         // set new ids for embedded applications within node, and new ids for ports within those embedded nodes
@@ -2756,8 +2753,7 @@ export class Utils {
             if(clone.getFields() != null){
                 // set new ids for any fields in this node
                 for (const field of clone.getFields()){
-                    field.setId(Utils.generateFieldId());
-                    field.setNodeId(newInputAppId);
+                    field.setId(Utils.generateFieldId()).setNodeId(newInputAppId);
                 }
             }
             newNode.setInputApplication(clone)
@@ -2772,8 +2768,7 @@ export class Utils {
             if(clone.getFields() != null){
                 // set new ids for any fields in this node
                 for (const field of clone.getFields()){
-                    field.setId(Utils.generateFieldId());
-                    field.setNodeId(newOutputAppId);
+                    field.setId(Utils.generateFieldId()).setNodeId(newOutputAppId);
                 }
             }
             newNode.setOutputApplication(clone)

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -236,7 +236,7 @@
                                     <h5>Closes Loop</h5>
                                 </div>
                                 <div class="col-8 col contentObjectValue">
-                                    <button class="btn btn-secondary btn-sm radioBtn iconHoverEffect" id="objectInspectorToggleClosesLoop" type="button" data-bind="click: function(){$root.selectedEdge().toggleClosesLoop();},disabled:!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)">
+                                    <button class="btn btn-secondary btn-sm radioBtn iconHoverEffect" id="objectInspectorToggleClosesLoop" type="button" data-bind="click: $root.toggleEdgeClosesLoop, disabled:!Setting.findValue(Setting.ALLOW_GRAPH_EDITING)">
                                         <i class="material-icons md-18" data-bind="visible: $root.selectedEdge().isClosesLoop()">radio_button_checked</i>
                                         <i class="material-icons md-18" data-bind="hidden: $root.selectedEdge().isClosesLoop()">radio_button_unchecked</i>
                                     </button>


### PR DESCRIPTION
- Modified Node.setGroupStart and Node.setGroupEnd to clone "group_start" and "group_end" fields from Daliuge.ts, rather than create new fields completely from scratch.
- Also create canonical examples of "persist" and "streaming" fields in Daliuge.ts
- Use the new "persist" and "streaming" fields within JSON parsing code, instead of creating fields from scratch
- Modified a lot of Field.ts to make setX() functions return the field itself, so that function calls can be chained
- Fixed bug where "Closes Loop" radio button in edge inspector was calling the wrong function, which didn't do everything required to set Node field values as well as the "closes loop" flag.

## Summary by Sourcery

Use canonical field templates and fluent setter chaining to unify field cloning and initialization across the codebase, and correct the Closes Loop toggle handler.

Bug Fixes:
- Fix the Closes Loop radio button in the edge inspector to call the correct toggleEdgeClosesLoop function

Enhancements:
- Make all Field.setX() methods return the field instance to enable fluent chaining
- Define canonical groupStart, groupEnd, persist, and streaming Field examples in Daliuge.ts
- Refactor Node.setGroupStart/setGroupEnd and JSON import logic to clone these canonical fields instead of recreating them
- Update Utils, Eagle, and ParameterTable code to leverage chained setter calls when cloning and initializing fields