### PR TITLE
fixed edge error color not being shown for closes loop

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2329,12 +2329,6 @@ export class GraphRenderer {
             selectedColor = EagleConfig.getColor('edgeWarningSelected');
         }
 
-        // check if the edge is a "closes loop" edge
-        if (edge.isClosesLoop()){
-            normalColor = EagleConfig.getColor('edgeClosesLoop');
-            selectedColor = EagleConfig.getColor('edgeClosesLoopSelected');
-        }
-
         return eagle.objectIsSelected(edge) ? selectedColor : normalColor;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed the special-case branch for loop-closing edges so they now use the standard error color configuration instead of a custom loop color.