### PR TITLE
Eagle 1488

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2571,7 +2571,7 @@ export class Eagle {
 
     sortPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closeDropdownMenus();
+        this.closeDropdownMenu();
 
         const preSortCopy = palette.getNodes().slice();
 
@@ -2588,7 +2588,7 @@ export class Eagle {
 
     selectAllInPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closeDropdownMenus();
+        this.closeDropdownMenu();
 
         this.selectedObjects([]);
         for (const node of palette.getNodes()){
@@ -4456,7 +4456,7 @@ export class Eagle {
         });
     }
 
-    closeDropdownMenus = ()=>{
+    closeDropdownMenu = ()=>{
         //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
         setTimeout(function() {
             if($(".dropdown-menu:hover").length === 0){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2588,7 +2588,7 @@ export class Eagle {
 
     selectAllInPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closeDropdownMenu();
+        // this.closeDropdownMenu();
 
         this.selectedObjects([]);
         for (const node of palette.getNodes()){
@@ -4456,23 +4456,6 @@ export class Eagle {
         });
     }
 
-    closeDropdownMenu = ()=>{
-        //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
-        setTimeout(function() {
-            if($(".dropdown-menu:hover").length === 0){
-                $(".dropdown-toggle").removeClass("show")
-                $(".dropdown-menu").removeClass("show")
-                $(".dropdown-trigger").removeClass("show") // some dropdowns use this class instead of the dropdown-toggle class because that one comes with a lot of unwanted css from bootstrap in some cases.
-            }
-        }, EagleConfig.DROPDOWN_DISMISS_DELAY);
-    }
-    closeDropdownMenuJQUERY = (targetElement:any)=>{
-        console.log('targetelement: ',targetElement)
-        //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
-        $(targetElement).removeClass("show")
-        $(targetElement).parent().find('.dropdown-toggle').removeClass('show')
-    }
-
     editGraphShortDescription = async(): Promise<void> => {
         const markdownEditingEnabled: boolean = Setting.findValue(Setting.MARKDOWN_EDITING_ENABLED);
 
@@ -4743,11 +4726,12 @@ export namespace Eagle
 $( document ).ready(function() {
     // jquery event listeners start here
 
-    $('.dropdown-trigger').on('mouseout',function(){
-        const element = this
+    $('body').on('mouseout','.dropdown-area',function(){
+        const targetElement = this
         setTimeout(function() {
-            if($(".dropdown-trigger:hover").length === 0){
-                Eagle.getInstance().closeDropdownMenuJQUERY(element)
+            if($(".dropdown-area:hover").length === 0){
+                $(targetElement).removeClass("show")
+                $(targetElement).parent().find('.dropdown-control').removeClass('show')
             }
         }, EagleConfig.DROPDOWN_DISMISS_DELAY);
     })

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4466,6 +4466,12 @@ export class Eagle {
             }
         }, EagleConfig.DROPDOWN_DISMISS_DELAY);
     }
+    closeDropdownMenuJQUERY = (targetElement:any)=>{
+        console.log('targetelement: ',targetElement)
+        //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
+        $(targetElement).removeClass("show")
+        $(targetElement).parent().find('.dropdown-toggle').removeClass('show')
+    }
 
     editGraphShortDescription = async(): Promise<void> => {
         const markdownEditingEnabled: boolean = Setting.findValue(Setting.MARKDOWN_EDITING_ENABLED);
@@ -4736,6 +4742,15 @@ export namespace Eagle
 // TODO: ready is deprecated here, use something else
 $( document ).ready(function() {
     // jquery event listeners start here
+
+    $('.dropdown-trigger').on('mouseout',function(){
+        const element = this
+        setTimeout(function() {
+            if($(".dropdown-trigger:hover").length === 0){
+                Eagle.getInstance().closeDropdownMenuJQUERY(element)
+            }
+        }, EagleConfig.DROPDOWN_DISMISS_DELAY);
+    })
 
     //added to prevent console warnings caused by focused elements in a modal being hidden 
     $('.modal').on('hide.bs.modal',function(){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4462,7 +4462,7 @@ export class Eagle {
             if($(".dropdown-menu:hover").length === 0){
                 $(".dropdown-toggle").removeClass("show")
                 $(".dropdown-menu").removeClass("show")
-                $(".dropdown-trigger").removeClass("show")
+                $(".dropdown-trigger").removeClass("show") // some dropdowns use this class instead of the dropdown-toggle class because that one comes with a lot of unwanted css from bootstrap in some cases.
             }
         }, 400);
     }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2572,9 +2572,6 @@ export class Eagle {
     }
 
     sortPalette = (palette: Palette): void => {
-        // close the palette menu
-        // this.closeDropdownMenu();
-
         const preSortCopy = palette.getNodes().slice();
 
         palette.sort();
@@ -2589,9 +2586,6 @@ export class Eagle {
     }
 
     selectAllInPalette = (palette: Palette): void => {
-        // close the palette menu
-        // this.closeDropdownMenu();
-
         this.selectedObjects([]);
         for (const node of palette.getNodes()){
             this.editSelection(node, Eagle.FileType.Palette);
@@ -4731,7 +4725,7 @@ $( document ).ready(function() {
     $('body').on('mouseout','.dropdown-area',function(){
         const targetElement = this
         //we are using a timeout stored in a global variable so we have only one timeout that resets when another mouseout is called.
-        //if we dont do this we end up with several timouts conflicting.
+        //if we don't do this we end up with several timeouts conflicting.
         clearTimeout(Eagle.getInstance().dropdownMenuHoverTimeout)
 
         Eagle.getInstance().dropdownMenuHoverTimeout = setTimeout(function() {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -107,7 +107,7 @@ export class Eagle {
 
     showDataNodes : ko.Observable<boolean>;
     snapToGrid : ko.Observable<boolean>;
-    dropdownMenuHoverTimeout : any = 0;
+    dropdownMenuHoverTimeout : number = 0;
 
     static paletteComponentSearchString : ko.Observable<string>;
     static componentParamsSearchString : ko.Observable<string>;

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2544,11 +2544,6 @@ export class Eagle {
         return null;
     }
 
-    closePaletteMenus=() : void => {
-        $("#paletteList .dropdown-toggle").removeClass("show")
-        $("#paletteList .dropdown-menu").removeClass("show")
-    }
-
     closePalette = async (palette : Palette): Promise<void> => {
         for (let i = 0 ; i < this.palettes().length ; i++){
             const p = this.palettes()[i];
@@ -2576,7 +2571,7 @@ export class Eagle {
 
     sortPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closePaletteMenus();
+        this.closeDropdownMenus();
 
         const preSortCopy = palette.getNodes().slice();
 
@@ -2593,7 +2588,7 @@ export class Eagle {
 
     selectAllInPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closePaletteMenus();
+        this.closeDropdownMenus();
 
         this.selectedObjects([]);
         for (const node of palette.getNodes()){
@@ -4461,12 +4456,13 @@ export class Eagle {
         });
     }
 
-    hideNavbarDropdown = ()=>{
+    closeDropdownMenus = ()=>{
         //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
         setTimeout(function() {
             if($(".dropdown-menu:hover").length === 0){
                 $(".dropdown-toggle").removeClass("show")
                 $(".dropdown-menu").removeClass("show")
+                $(".dropdown-trigger").removeClass("show")
             }
         }, 400);
     }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4461,6 +4461,16 @@ export class Eagle {
         });
     }
 
+    hideNavbarDropdown = ()=>{
+        //hide navbar dropdown after a tiny delay, if the cursor has not returned to hovering on the dropdown
+        setTimeout(function() {
+            if($(".dropdown-menu:hover").length === 0){
+                $(".dropdown-toggle").removeClass("show")
+                $(".dropdown-menu").removeClass("show")
+            }
+        }, 400);
+    }
+
     editGraphShortDescription = async(): Promise<void> => {
         const markdownEditingEnabled: boolean = Setting.findValue(Setting.MARKDOWN_EDITING_ENABLED);
 
@@ -4730,12 +4740,6 @@ export namespace Eagle
 // TODO: ready is deprecated here, use something else
 $( document ).ready(function() {
     // jquery event listeners start here
-    
-    //hides the dropdown navbar elements when stopping hovering over the element
-    $(".dropdown-menu").on("mouseleave", function(){
-        $(".dropdown-toggle").removeClass("show")
-        $(".dropdown-menu").removeClass("show")
-    })
 
     //added to prevent console warnings caused by focused elements in a modal being hidden 
     $('.modal').on('hide.bs.modal',function(){

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -107,6 +107,7 @@ export class Eagle {
 
     showDataNodes : ko.Observable<boolean>;
     snapToGrid : ko.Observable<boolean>;
+    dropdownMenuHoverTimeout : any = 0;
 
     static paletteComponentSearchString : ko.Observable<string>;
     static componentParamsSearchString : ko.Observable<string>;
@@ -183,6 +184,7 @@ export class Eagle {
 
         this.showDataNodes = ko.observable(true);
         this.snapToGrid = ko.observable(false);
+        this.dropdownMenuHoverTimeout = null;
 
         this.selectedObjects.subscribe(function(){
             //TODO check if the selectedObjects array has changed, if not, abort
@@ -4728,8 +4730,12 @@ $( document ).ready(function() {
 
     $('body').on('mouseout','.dropdown-area',function(){
         const targetElement = this
-        setTimeout(function() {
-            if($(".dropdown-area:hover").length === 0){
+        //we are using a timeout stored in a global variable so we have only one timeout that resets when another mouseout is called.
+        //if we dont do this we end up with several timouts conflicting.
+        clearTimeout(Eagle.getInstance().dropdownMenuHoverTimeout)
+
+        Eagle.getInstance().dropdownMenuHoverTimeout = setTimeout(function() {
+            if($(".dropdown-menu:hover").length === 0){
                 $(targetElement).removeClass("show")
                 $(targetElement).parent().find('.dropdown-control').removeClass('show')
             }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2571,7 +2571,7 @@ export class Eagle {
 
     sortPalette = (palette: Palette): void => {
         // close the palette menu
-        this.closeDropdownMenu();
+        // this.closeDropdownMenu();
 
         const preSortCopy = palette.getNodes().slice();
 
@@ -4464,7 +4464,7 @@ export class Eagle {
                 $(".dropdown-menu").removeClass("show")
                 $(".dropdown-trigger").removeClass("show") // some dropdowns use this class instead of the dropdown-toggle class because that one comes with a lot of unwanted css from bootstrap in some cases.
             }
-        }, 400);
+        }, EagleConfig.DROPDOWN_DISMISS_DELAY);
     }
 
     editGraphShortDescription = async(): Promise<void> => {

--- a/src/EagleConfig.ts
+++ b/src/EagleConfig.ts
@@ -49,6 +49,9 @@ const colors: ColorMap = {
 
 export class EagleConfig {
 
+    // General UI
+    public static readonly DROPDOWN_DISMISS_DELAY: number = 400;
+
     // graph behaviour
     public static readonly NODE_SUGGESTION_RADIUS = 300
     public static readonly NODE_SUGGESTION_SNAP_RADIUS = 150

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,12 +165,6 @@ $(function(){
 
     //request a first time visitor welcome to eagle if applicable
     initiateWelcome(firstTimeVisit);
-
-    //hides the dropdown navbar elements when stopping hovering over the element
-    $(".dropdown-menu").on("mouseleave", function(){
-        $(".dropdown-toggle").removeClass("show")
-        $(".dropdown-menu").removeClass("show")
-    })
   
     $('.modal').on('hidden.bs.modal', function () {
         $('.modal-dialog').css({"left":"0px", "top":"0px"})

--- a/static/tables.css
+++ b/static/tables.css
@@ -499,6 +499,11 @@
     border-radius: 10px;
 }
 
+.eagleTableDisplay  td button, #editFieldModal .dropdown-menu button:focus{
+    outline: none !important;
+    box-shadow: none !important;
+}
+
 .eagleTableDisplay td button:disabled{
     color: rgb(113 113 113);
 }

--- a/templates/modals/edit_field.html
+++ b/templates/modals/edit_field.html
@@ -86,7 +86,7 @@
                                             <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                 <div class="dropdown parameterTableTypeCustomSelect">
                                                     <a class="dropdown-toggle" data-bind="text:$data.defaultValue" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="parameterTableTpeCustomSelect">
+                                                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="parameterTableTpeCustomSelect">
                                                         <!-- ko foreach:$data.options()-->
                                                             <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                 <input class="defaultSelectCustom" data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -121,7 +121,7 @@
                                     <div class="input-group mb-3">
                                         <input id="editFieldModalTypeInput" type="text" class="form-control" aria-label="Text input with dropdown button" autocomplete="off" data-bind="value:type">
                                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
-                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end">
+                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
                                             <!-- ko foreach:$root.types()-->
                                                 <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                             <!-- /ko --> 

--- a/templates/modals/edit_field.html
+++ b/templates/modals/edit_field.html
@@ -85,8 +85,8 @@
                                             <!-- /ko --> 
                                             <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                 <div class="dropdown parameterTableTypeCustomSelect">
-                                                    <a class="dropdown-toggle" data-bind="text:$data.defaultValue" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                    <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="parameterTableTpeCustomSelect">
+                                                    <a class="dropdown-toggle dropdown-control" data-bind="text:$data.defaultValue" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
+                                                    <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="parameterTableTpeCustomSelect">
                                                         <!-- ko foreach:$data.options()-->
                                                             <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                 <input class="defaultSelectCustom" data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -120,8 +120,8 @@
                                 <div class="col">
                                     <div class="input-group mb-3">
                                         <input id="editFieldModalTypeInput" type="text" class="form-control" aria-label="Text input with dropdown button" autocomplete="off" data-bind="value:type">
-                                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
-                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end dropdown-trigger">
+                                        <button class="btn btn-outline-secondary dropdown-toggle dropdown-control" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
+                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end dropdown-area">
                                             <!-- ko foreach:$root.types()-->
                                                 <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                             <!-- /ko --> 

--- a/templates/modals/edit_field.html
+++ b/templates/modals/edit_field.html
@@ -86,7 +86,7 @@
                                             <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                 <div class="dropdown parameterTableTypeCustomSelect">
                                                     <a class="dropdown-toggle" data-bind="text:$data.defaultValue" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="parameterTableTpeCustomSelect">
+                                                    <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="parameterTableTpeCustomSelect">
                                                         <!-- ko foreach:$data.options()-->
                                                             <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                 <input class="defaultSelectCustom" data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -121,7 +121,7 @@
                                     <div class="input-group mb-3">
                                         <input id="editFieldModalTypeInput" type="text" class="form-control" aria-label="Text input with dropdown button" autocomplete="off" data-bind="value:type">
                                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
-                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
+                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end dropdown-trigger">
                                             <!-- ko foreach:$root.types()-->
                                                 <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                             <!-- /ko --> 

--- a/templates/modals/edit_field.html
+++ b/templates/modals/edit_field.html
@@ -86,7 +86,7 @@
                                             <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                 <div class="dropdown parameterTableTypeCustomSelect">
                                                     <a class="dropdown-toggle" data-bind="text:$data.defaultValue" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="parameterTableTpeCustomSelect">
+                                                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="parameterTableTpeCustomSelect">
                                                         <!-- ko foreach:$data.options()-->
                                                             <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                 <input class="defaultSelectCustom" data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -121,7 +121,7 @@
                                     <div class="input-group mb-3">
                                         <input id="editFieldModalTypeInput" type="text" class="form-control" aria-label="Text input with dropdown button" autocomplete="off" data-bind="value:type">
                                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Types</button>
-                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
+                                        <ul id="editFieldModalTypeSelect" class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
                                             <!-- ko foreach:$root.types()-->
                                                 <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                             <!-- /ko --> 

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -120,7 +120,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -180,7 +180,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -224,7 +224,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -238,7 +238,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -110,7 +110,7 @@
                             arrow_drop_down
                         </span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="navbarDropdownTranslate">
+                    <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownTranslate">
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Translate</a>
                     </div>
@@ -120,7 +120,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -180,7 +180,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -224,7 +224,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -238,7 +238,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -120,7 +120,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -180,7 +180,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -224,7 +224,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -238,7 +238,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -110,7 +110,7 @@
                             arrow_drop_down
                         </span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="navbarDropdownTranslate">
+                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="navbarDropdownTranslate">
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Translate</a>
                     </div>
@@ -120,7 +120,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -180,7 +180,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -224,7 +224,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -238,7 +238,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenu()}" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -105,22 +105,22 @@
                         </div>
                     <!-- /ko -->
 
-                    <button class="btn btn-outline-secondary nav-link dropdown-toggle ms-auto" data-bs-toggle="dropdown" id="navbarDropdownTranslate" aria-expanded="true" data-bind="" type="button">
+                    <button class="btn btn-outline-secondary nav-link dropdown-control dropdown-toggle ms-auto" data-bs-toggle="dropdown" id="navbarDropdownTranslate" aria-expanded="true" data-bind="" type="button">
                         <span class="material-icons-outlined iconHoverEffect">
                             arrow_drop_down
                         </span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownTranslate">
+                    <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownTranslate">
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Translate</a>
                     </div>
                 </div>
             </li>
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a class="nav-link dropdown-toggle dropdown-control ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -177,10 +177,10 @@
             </li>
             <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) || Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a class="nav-link dropdown-toggle dropdown-control iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -221,10 +221,10 @@
             </li>
             <!-- /ko -->
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a class="nav-link dropdown-toggle dropdown-control ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -235,10 +235,10 @@
                 </div>  
             </li>
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a class="nav-link dropdown-toggle dropdown-control iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -110,7 +110,7 @@
                             arrow_drop_down
                         </span>
                     </button>
-                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownTranslate">
+                    <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="navbarDropdownTranslate">
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(false)}">Translate</a>
                         <a class="dropdown-item" href="#" data-bind="click: function(){Setting.find(Setting.TEST_TRANSLATE_MODE).setValue(true)}">Test Translate</a>
                     </div>
@@ -120,7 +120,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownGraph" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Graph
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownGraph">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownGraph">
                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                         <span class="dropdown-item dropDropDownParent" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownGraphNew">New
                             <div class="dropDropDown">
@@ -180,7 +180,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownPalette" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Palette
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownPalette">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownPalette">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                     <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                         <div class="dropDropDown">
@@ -224,7 +224,7 @@
                 <a class="nav-link dropdown-toggle ms-auto iconHoverEffect" href="#" id="navbarDropdownConfig" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Config
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownConfig">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownConfig">
                     <a class="dropdown-item" id="createNewConfig" href="#" data-bind="click: newConfig">New
                         <span data-bind="text: KeyboardShortcut.idToKeysText('new_config', true)"></span>
                     </a>
@@ -238,7 +238,7 @@
                 <a class="nav-link dropdown-toggle iconHoverEffect" href="#" id="navbarDropdownHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Help
                 </a>
-                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.hideNavbarDropdown()}" aria-labelledby="navbarDropdownHelp">
+                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseout: $root.closeDropdownMenus()}" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -33,7 +33,7 @@
 
         <div class="dropdown parameterTableVisibilityContainer">
             <a class="dropdown-toggle icon-table_column_visibility componentTableVisibilityBtn iconHoverEffect" data-bs-toggle="dropdown"></a>
-            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
+            <div class="dropdown-menu dropdown-menu-right dropdown-trigger">
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleKeyAttribute()}"><span>Key Parameter</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().keyAttribute()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFieldId()}"><span>Field ID</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().fieldId()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleDefaultValue()}"><span>Default Value</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().defaultValue()"></div>
@@ -293,7 +293,7 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="dropdown parameterTableTypeCustomSelect">
                                                                 <a class="dropdown-toggle" data-bind="text:$data.defaultValue, disabled: ParameterTable.getNodeLockedState($data)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="parameterTableTpeCustomSelect">
+                                                                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="parameterTableTpeCustomSelect">
                                                                     <!-- ko foreach:$data.options()-->
                                                                         <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                             <input data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -333,12 +333,12 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="input-group">
                                                                 <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">
-                                                                <button class="btn btn-outline-secondary dropdown-trigger" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
+                                                                <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
                                                                     <span class="material-icons-outlined iconHoverEffect">
                                                                         arrow_drop_down
                                                                     </span>
                                                                 </button>
-                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenu}" data-bind="attr:{id:'typeFor_'+$data.getId()}">
+                                                                <ul class="dropdown-menu dropdown-menu-end dropdown-trigger" data-bind="attr:{id:'typeFor_'+$data.getId()}">
                                                                     <!-- ko foreach:$root.types() -->
                                                                         <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                                                     <!-- /ko -->

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -33,7 +33,7 @@
 
         <div class="dropdown parameterTableVisibilityContainer">
             <a class="dropdown-toggle icon-table_column_visibility componentTableVisibilityBtn iconHoverEffect" data-bs-toggle="dropdown"></a>
-            <div class="dropdown-menu dropdown-menu-right">
+            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleKeyAttribute()}"><span>Key Parameter</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().keyAttribute()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFieldId()}"><span>Field ID</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().fieldId()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleDefaultValue()}"><span>Default Value</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().defaultValue()"></div>
@@ -293,7 +293,7 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="dropdown parameterTableTypeCustomSelect">
                                                                 <a class="dropdown-toggle" data-bind="text:$data.defaultValue, disabled: ParameterTable.getNodeLockedState($data)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="parameterTableTpeCustomSelect">
+                                                                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="parameterTableTpeCustomSelect">
                                                                     <!-- ko foreach:$data.options()-->
                                                                         <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                             <input data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -333,12 +333,12 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="input-group">
                                                                 <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">
-                                                                <button class="btn btn-outline-secondary" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
+                                                                <button class="btn btn-outline-secondary dropdown-trigger" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
                                                                     <span class="material-icons-outlined iconHoverEffect">
                                                                         arrow_drop_down
                                                                     </span>
                                                                 </button>
-                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="attr:{id:'typeFor_'+$data.getId()}">
+                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenus}" data-bind="attr:{id:'typeFor_'+$data.getId()}">
                                                                     <!-- ko foreach:$root.types() -->
                                                                         <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                                                     <!-- /ko -->

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -32,8 +32,8 @@
         </div> 
 
         <div class="dropdown parameterTableVisibilityContainer">
-            <a class="dropdown-toggle icon-table_column_visibility componentTableVisibilityBtn iconHoverEffect" data-bs-toggle="dropdown"></a>
-            <div class="dropdown-menu dropdown-menu-right dropdown-trigger">
+            <a class="dropdown-toggle dropdown-control icon-table_column_visibility componentTableVisibilityBtn iconHoverEffect" data-bs-toggle="dropdown"></a>
+            <div class="dropdown-menu dropdown-menu-right dropdown-area">
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleKeyAttribute()}"><span>Key Parameter</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().keyAttribute()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFieldId()}"><span>Field ID</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().fieldId()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleDefaultValue()}"><span>Default Value</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().defaultValue()"></div>
@@ -292,8 +292,8 @@
                                                         <!-- /ko -->
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="dropdown parameterTableTypeCustomSelect">
-                                                                <a class="dropdown-toggle" data-bind="text:$data.defaultValue, disabled: ParameterTable.getNodeLockedState($data)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                                <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="parameterTableTpeCustomSelect">
+                                                                <a class="dropdown-toggle dropdown-control" data-bind="text:$data.defaultValue, disabled: ParameterTable.getNodeLockedState($data)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
+                                                                <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="parameterTableTpeCustomSelect">
                                                                     <!-- ko foreach:$data.options()-->
                                                                         <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                             <input data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -333,12 +333,12 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="input-group">
                                                                 <input  class="typesInput form-control" type="text" autocomplete="off" data-bind="value:type, attr:{id:'typeInputFor_'+$data.getId()}">
-                                                                <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
+                                                                <button class="btn btn-outline-secondary dropdown-control" data-bs-toggle="dropdown" aria-expanded="false" data-bind="attr:{id:'typeButtonFor_'+$data.getId()}" type="button">
                                                                     <span class="material-icons-outlined iconHoverEffect">
                                                                         arrow_drop_down
                                                                     </span>
                                                                 </button>
-                                                                <ul class="dropdown-menu dropdown-menu-end dropdown-trigger" data-bind="attr:{id:'typeFor_'+$data.getId()}">
+                                                                <ul class="dropdown-menu dropdown-menu-end dropdown-area" data-bind="attr:{id:'typeFor_'+$data.getId()}">
                                                                     <!-- ko foreach:$root.types() -->
                                                                         <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                                                     <!-- /ko -->

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -33,7 +33,7 @@
 
         <div class="dropdown parameterTableVisibilityContainer">
             <a class="dropdown-toggle icon-table_column_visibility componentTableVisibilityBtn iconHoverEffect" data-bs-toggle="dropdown"></a>
-            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
+            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleKeyAttribute()}"><span>Key Parameter</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().keyAttribute()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleFieldId()}"><span>Field ID</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().fieldId()"></div>
                 <div class="dropdown-item" data-bind="click:function(){ParameterTable.getActiveColumnVisibility().toggleDefaultValue()}"><span>Default Value</span><input type="checkbox" data-bind="checked:ParameterTable.getActiveColumnVisibility().defaultValue()"></div>
@@ -293,7 +293,7 @@
                                                         <!-- ko if: Setting.findValue(Setting.ALLOW_COMPONENT_EDITING) -->
                                                             <div class="dropdown parameterTableTypeCustomSelect">
                                                                 <a class="dropdown-toggle" data-bind="text:$data.defaultValue, disabled: ParameterTable.getNodeLockedState($data)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></a>
-                                                                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="parameterTableTpeCustomSelect">
+                                                                <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="parameterTableTpeCustomSelect">
                                                                     <!-- ko foreach:$data.options()-->
                                                                         <div class="dropdown-item" data-bind="click:function(data, event){$parent.setDefaultValue($data);}">
                                                                             <input data-bind="value:$data, event: {change:function(data,event){$parent.editOption($index(),$(event.target).val())}}" type="text">
@@ -338,7 +338,7 @@
                                                                         arrow_drop_down
                                                                     </span>
                                                                 </button>
-                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenus}" data-bind="attr:{id:'typeFor_'+$data.getId()}">
+                                                                <ul class="dropdown-menu dropdown-menu-end" data-bind="event:{mouseleave: $root.closeDropdownMenu}" data-bind="attr:{id:'typeFor_'+$data.getId()}">
                                                                     <!-- ko foreach:$root.types() -->
                                                                         <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                                                     <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -7,7 +7,7 @@
             <a class="dropdown-toggle material-icons iconHoverEffect" href="#" id="paletteWindowdropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 more_vert
             </a>
-            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="paletteWindowdropdown">
+            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="paletteWindowdropdown">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                 <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                     <div class="dropDropDown">
@@ -38,7 +38,7 @@
         <div data-bind="foreach: palettes">
             <div class="paletteCardWrapper">
                 <button type="button" class="material-icons md-18 dropdown-toggle paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
-                <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
+                <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
                     <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
                     <a href="#" data-bind="click: $root.selectAllInPalette, clickBubble: false" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -7,7 +7,7 @@
             <a class="dropdown-toggle material-icons iconHoverEffect" href="#" id="paletteWindowdropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 more_vert
             </a>
-            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="paletteWindowdropdown">
+            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenus}" aria-labelledby="paletteWindowdropdown">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                 <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                     <div class="dropDropDown">
@@ -38,7 +38,7 @@
         <div data-bind="foreach: palettes">
             <div class="paletteCardWrapper">
                 <button type="button" class="material-icons md-18 dropdown-toggle paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
-                <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closePaletteMenus}">
+                <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closeDropdownMenus}">
                     <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
                     <a href="#" data-bind="click: $root.selectAllInPalette, clickBubble: false" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -7,7 +7,7 @@
             <a class="dropdown-toggle material-icons iconHoverEffect" href="#" id="paletteWindowdropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 more_vert
             </a>
-            <div class="dropdown-menu dropdown-menu-right" data-bind="event:{mouseleave: $root.closeDropdownMenu}" aria-labelledby="paletteWindowdropdown">
+            <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="paletteWindowdropdown">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                 <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                     <div class="dropDropDown">
@@ -38,7 +38,7 @@
         <div data-bind="foreach: palettes">
             <div class="paletteCardWrapper">
                 <button type="button" class="material-icons md-18 dropdown-toggle paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
-                <div class="dropdown-menu" data-bind="event:{mouseleave: $root.closeDropdownMenu}">
+                <div class="dropdown-menu dropdown-trigger">
                     <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
                     <a href="#" data-bind="click: $root.selectAllInPalette, clickBubble: false" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -4,10 +4,10 @@
             <button class="btn btn-primary btn-block btn_wide" id="explorePalettesButton" data-bind="click: showExplorePalettes, eagleTooltip: 'Retrieve information on all palettes in ' + Setting.findValue(Setting.EXPLORE_PALETTES_REPOSITORY)" data-bs-placement="bottom">Explore Palettes</button>
         </span>
         <span id="paletteWindowdropdownWrapper" class="dropdown">
-            <a class="dropdown-toggle material-icons iconHoverEffect" href="#" id="paletteWindowdropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="dropdown-toggle dropdown-control material-icons iconHoverEffect" href="#" id="paletteWindowdropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 more_vert
             </a>
-            <div class="dropdown-menu dropdown-menu-right dropdown-trigger" aria-labelledby="paletteWindowdropdown">
+            <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="paletteWindowdropdown">
                 <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                 <span class="dropdown-item dropDropDownParent" href="#">New<img src="/static/assets/img/arrow_right_white_24dp.svg" alt="">
                     <div class="dropDropDown">
@@ -37,15 +37,15 @@
     <div class="accordion">
         <div data-bind="foreach: palettes">
             <div class="paletteCardWrapper">
-                <button type="button" class="material-icons md-18 dropdown-toggle paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
-                <div class="dropdown-menu dropdown-trigger">
-                    <a href="#" data-bind="click: $root.sortPalette, clickBubble: false" data-html="true"><span>Sort</span></a>
-                    <a href="#" data-bind="click: $root.selectAllInPalette, clickBubble: false" data-html="true"><span>Select All</span></a>
+                <button type="button" class="material-icons md-18 dropdown-toggle dropdown-control paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
+                <div class="dropdown-menu dropdown-area">
+                    <a href="#" data-bind="click: $root.sortPalette" data-html="true"><span>Sort</span></a>
+                    <a href="#" data-bind="click: $root.selectAllInPalette" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
-                    <a href="#" data-bind="click: $root.closePalette, clickBubble: false" data-html="true"><span>Remove</span></a>
+                    <a href="#" data-bind="click: $root.closePalette" data-html="true"><span>Remove</span></a>
                     <!-- /ko -->
                     <!-- ko if: $data.fileInfo().repositoryService !== Repository.Service.Unknown -->
-                    <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}, clickBubble: false" data-html="true"><span>Reload</span></a>
+                    <a href="#" data-bind="click: function(){$root.reloadPalette($data, $index())}" data-html="true"><span>Reload</span></a>
                     <!-- /ko -->
                     <!-- ko if: Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                         <a href="#" data-bind="click: $root.savePaletteToDisk" data-html="true"><span>Save Locally</span></a>


### PR DESCRIPTION
- converted old jquery event bindings to knockout
To elaborate a little bit, i was questioning if i should replace jquery with ko, because the jquery binding requires quite a bit less code, where as ko needs data-bind event handlers to be added on all html objects. ultimately for the sake of code readability, i chose to convert it to ko as that is what you would expect. this makes it easier to understand troubleshoot in the future. 

- made a generic function for hiding bootstrap dropdown menus and applied it to all examples in the ui.
- added a small buffer to the hide function to make use of the menus less finicky

## Summary by Sourcery

Refactor dropdown hide behavior by replacing legacy jQuery hover handlers with a buffered Knockout event-driven method, update all templates and code to use the new closeDropdownMenu function, and add CSS to suppress focus outlines on dropdown controls.

Enhancements:
- Introduce a generic closeDropdownMenu method with a 400ms buffer to hide Bootstrap dropdowns.
- Replace direct jQuery mouseleave bindings with Knockout data-bind event handlers across HTML templates and main/Eagle code.
- Remove the deprecated closePaletteMenus function and obsolete jQuery handlers in favor of the new KO-based approach.
- Add CSS rules to eliminate focus outlines and box shadows on table dropdown buttons.