### PR TITLE
RTD Update: Fix failing build with update .yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,10 +2,32 @@
 
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
# Problem

There was an update to the .readthedocs.yaml format that broke existing builds if they didn't have the necessary features. This means our documentation has not been built ~18months. 

# Solution

I've updated this so hopefully the documentation is built. I will also enable the `readthedocs` setting that builds PRs so we can confirm before we merge that it is successful. 