### PR TITLE
Eagle 1517

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -714,13 +714,13 @@ export class Eagle {
         setTimeout(function(){
             $('#inspector').removeClass('inspectorTransition')
         },100)
-
-        if(this.selectedObjects().length > 0){
-            return Setting.findValue(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE)
-        }else{
-            return Setting.findValue(Setting.GRAPH_INSPECTOR_COLLAPSED_STATE)
-        }
+        
+        return Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE)
     }, this);
+
+    toggleInspectorCollapsedState = () : void => {
+        Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle()
+    };
 
     getGraphModifiedDateText = () : string => {
         return this.logicalGraph().fileInfo().lastModifiedDatetimeText().split(',')[0]

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -354,9 +354,16 @@ export class KeyboardShortcut {
             run: (eagle): void => {eagle.addSelectedNodesToPalette('normal');}
         }),
         new KeyboardShortcut({
+            id: "toggle_inspector",
+            text: "Toggle Inspector",
+            keys: [new Key("i")],
+            tags: ['information'],
+            run: (eagle): void => {eagle.toggleInspectorCollapsedState();}
+        }),
+        new KeyboardShortcut({
             id: "insert_graph_from_local_disk",
             text: "Insert graph from local disk",
-            keys: [new Key("i")],
+            keys: [new Key("i", Modifier.Shift)],
             tags: ['canvas','subGraph','upload'],
             run: (eagle): void => {eagle.getGraphFileToInsert();}
         }),

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -301,8 +301,7 @@ export class Setting {
     static readonly BOTTOM_WINDOW_HEIGHT : string = "BottomWindowHeight";
     static readonly BOTTOM_WINDOW_VISIBLE : string = "BottomWindowVisible";
     static readonly BOTTOM_WINDOW_MODE : string = "BottomWindowMode";
-    static readonly OBJECT_INSPECTOR_COLLAPSED_STATE : string = "ObjectInspectorVisibility";
-    static readonly GRAPH_INSPECTOR_COLLAPSED_STATE : string = "GraphInspectorVisibility";
+    static readonly INSPECTOR_COLLAPSED_STATE : string = "ObjectInspectorVisibility";
     
     static readonly OPEN_BUILTIN_PALETTE: string = "OpenBuiltinPalette";
     static readonly OPEN_TEMPLATE_PALETTE: string = "OpenTemplatePalette";
@@ -436,8 +435,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Bottom Window Height", Setting.BOTTOM_WINDOW_HEIGHT, "saving the height of the bottom window", true, Setting.Type.Number, 25, 25, 25, 25, 25),
             new Setting(false, "Bottom Window Visibility", Setting.BOTTOM_WINDOW_VISIBLE, "saving the visibility state of the bottom window", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(false, "Bottom Window Mode/Tab", Setting.BOTTOM_WINDOW_MODE, "saving the mode/tab of the bottom window", true, Setting.Type.Number, 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable'),
-            new Setting(false, "Graph Objects Inspector", Setting.OBJECT_INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph object inspector", true, Setting.Type.Boolean, false, false, false, false, false),
-            new Setting(false, "Graph Info Inspector", Setting.GRAPH_INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph inspector", true, Setting.Type.Boolean, false, false, false, false, false),
+            new Setting(false, "Graph and Object Inspector", Setting.INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph object inspector", true, Setting.Type.Boolean, false, false, false, false, false),
         ]
     ),
     new SettingsGroup(

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -4,6 +4,7 @@ import { TutorialStep, TutorialSystem } from '../Tutorial';
 import { SideWindow } from '../SideWindow';
 import { Setting } from '../Setting';
 import { Utils } from '../Utils';
+import { Modals } from "../Modals";
 
 const newTut = TutorialSystem.newTutorial('Graph Building', 'An introduction to graph building.')
 
@@ -32,18 +33,27 @@ newTut.newTutStep("Creating a new graph", "Then just <em>give it a name and pres
 .setBackSkip(true)
 
 newTut.newTutStep("Creating a new graph", "<em>And 'Ok' to save!</em>", function(){return $("#inputModal .affirmativeBtn")})
-.setWaitType(TutorialStep.Wait.Modal)
 .setType(TutorialStep.Type.Press)
 .setBackSkip(true)
 
-newTut.newTutStep("Graph Model Data", "This button brings up the 'Graph Modal Data' which allows you to add a description for your graph. <em>Try clicking it now to try it out</em>", function(){return $("#openGraphModelDataModal")})
+newTut.newTutStep("Editing Graph Descriptions", "Its important to add a description of what the use of the graph is. <em>Click to continue</em>", function(){return $("#shortDescriptionEditBtn")})
+.setType(TutorialStep.Type.Press)
+.setWaitType(TutorialStep.Wait.Delay)
+.setDelayAmount(400)//wait a moment for the graph to be created
+
+newTut.newTutStep("Editing Graph Descriptions", "Descriptions in EAGLE support markdown. In the short description we can enter the top level goal of the graph. For this graph enter a description like 'Simple Hello World Graph to greet someone' and <em>Press Enter</em> to Continue.", function(){return $("#inputMarkdownModalEditor")})
+.setWaitType(TutorialStep.Wait.Modal)
+.setType(TutorialStep.Type.Input)
+.setPreFunction(function(){Modals.toggleMarkdownEditMode(true)})
+
+newTut.newTutStep("Editing Graph Descriptions", "<em>Click OK to apply and continue", function(){return $('#inputMarkdownModal .modal-footer button.affirmativeBtn')})
+.setType(TutorialStep.Type.Press)
+
+newTut.newTutStep("Graph Information", "This button brings up the 'Graph Modal Data' which shows you all relevant information about a graph. <em>Try clicking it now to try it out</em>", function(){return $("#inspectorGraphInfoBtn")})
 .setType(TutorialStep.Type.Press)
 .setBackPreFunction(function(){$('.modal').modal("hide");}) //hiding open modals
 
-newTut.newTutStep("Editing Graph Descriptions", "You are able to enter a simple first glance and a more detailed description in addition to description nodes in the graph, should you need it.", function(){return $("#modelDataShortDescription")})
-.setWaitType(TutorialStep.Wait.Modal)
-
-newTut.newTutStep("Other Graph Information", "Most of the other information is automatically filled out when saving a graph, such as the version of EAGLE used for creating it.", function(){return $("#modelDataGeneratorVersion")})
+newTut.newTutStep("Graph Information", "This includes descriptions entered by the graph's creator and technical information such as the version of EAGLE used for creating it. Most of this is filled out automatically when saving the graph.", function(){return $("#modelDataGeneratorVersion")})
 .setWaitType(TutorialStep.Wait.Modal)
 
 newTut.newTutStep("Close the Modal", "<em>Press OK to close the modal and continue the Tutorial.</em>", function(){return $("#modelDataModalOKButton")})
@@ -75,7 +85,7 @@ newTut.newTutStep("The Parameter Table", "<em>Click to open the node fields tabl
 .setWaitType(TutorialStep.Wait.Element)
 .setType(TutorialStep.Type.Press)
 
-newTut.newTutStep("The Parameter Table", " The Component Parameters are settings pertaining to the DALiuGE component wrapper, the Application Arguments are settings exposed by the actual application code.", function(){return $('.parameterTable')})
+newTut.newTutStep("The Parameter Table", " The Component Parameters are settings pertaining to the DALiuGE component wrapper, the Application Arguments are settings exposed by the underlying application code.", function(){return $('.parameterTable thead')})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
 
@@ -118,12 +128,6 @@ newTut.newTutStep("Connecting nodes", "<em>Click and hold the output Port of the
 .setConditionFunction(function(eagle:Eagle){if(eagle.logicalGraph().getEdges().length != 0){return true}else{return false}}) //check if there are any edges present in the graph
 
 newTut.newTutStep("Graph Errors and warnings", "This is the error checking system, it is showing a check mark, so we did everything correctly. If there are errors in the graph you are able to troubleshoot them by clicking here.", function(){return $("#checkGraphDone")})
-
-// newTut.newTutStep("Graph Errors and warnings", "This modal may aid you in troubleshooting graphs. In this case these errors are all port type errors. Eagle can automatically fix errors such as these for you. To do this you can press 'F' in the graph or <em>click on 'Fix All'</em>", function(){return $("#errorModalFixAll")})
-// .setType(TutorialStep.Type.Press)
-// .setWaitType(TutorialStep.Wait.Modal)
-// .setAlternateHighlightTargetFunc(function(){return $("#errorModalFixAll").parent().parent()})
-// .setBackPreFunction(function(){$('#issuesDisplay').modal('show')})
 
 newTut.newTutStep("Saving a Graph", "Options to save your graph are available in the graph menu <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
 .setType(TutorialStep.Type.Press)

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -71,7 +71,7 @@ newTut.newTutStep("Editing Components", "The inspector panel provides access to 
 .setDelayAmount(200)
 .setPreFunction(function(){Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).setValue(false)})
 
-newTut.newTutStep("Click to open", "<em>Click to open the node fields table and continue.</em>", function(){return $("#inspector #openNodeParamsTable")})
+newTut.newTutStep("The Parameter Table", "<em>Click to open the node fields table and continue.</em>", function(){return $("#inspector #openNodeParamsTable")})
 .setWaitType(TutorialStep.Wait.Element)
 .setType(TutorialStep.Type.Press)
 

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -87,6 +87,7 @@ newTut.newTutStep("The Parameter Table", "<em>Click to open the node fields tabl
 
 newTut.newTutStep("The Parameter Table", " The Component Parameters are settings pertaining to the DALiuGE component wrapper, the Application Arguments are settings exposed by the underlying application code.", function(){return $('.parameterTable thead')})
 .setWaitType(TutorialStep.Wait.Delay)
+.setAlternateHighlightTargetFunc(function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('#bottomWindow .tableBody')})
 .setDelayAmount(200)
 
 newTut.newTutStep("Enter a Name", "In case of this hello world app we can change who we are greeting. <em>Enter a name and press enter to continue.</em>", function(){return $('.tableFieldStringValueInput').first()})

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -69,7 +69,7 @@ newTut.newTutStep("Graph Nodes", "Once added into your graph, the component is i
 newTut.newTutStep("Editing Components", "The inspector panel provides access to the complete set of specifications of a component.", function(){return $("#inspector")})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
-.setPreFunction(function(){Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).setValue(false)})
+.setPreFunction(function(){Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).setValue(false)})
 
 newTut.newTutStep("Click to open", "<em>Click to open the node fields table and continue.</em>", function(){return $("#inspector #openNodeParamsTable")})
 .setWaitType(TutorialStep.Wait.Element)

--- a/src/tutorials/graphConfigs.ts
+++ b/src/tutorials/graphConfigs.ts
@@ -120,7 +120,7 @@ newTut.newTutStep("Managing Graph Configurations", "Lets say we want another ver
 newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('#graphConfigurationsTableWrapper tr:last')})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
-newTut.newTutStep("Adding another field", "<em>Click on the File node to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('hello')})
+newTut.newTutStep("Adding another field", "<em>Click on the File node named 'hello' to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('hello')})
 .setType(TutorialStep.Type.Condition)
 .setWaitType(TutorialStep.Wait.Element)
 .setConditionFunction(function(){return TutorialSystem.isRequestedNodeSelected('hello')})

--- a/src/tutorials/graphConfigs.ts
+++ b/src/tutorials/graphConfigs.ts
@@ -77,7 +77,7 @@ newTut.newTutStep("Adding Graph Configuration Fields", "<em>Click on the HelloWo
 newTut.newTutStep("Adding Graph Configuration Fields", "<em>Click to open the node fields table and continue.</em>", function(){return $("#inspector #openNodeParamsTable")})
 .setWaitType(TutorialStep.Wait.Element)
 .setType(TutorialStep.Type.Press)
-.setPreFunction(function(){Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).setValue(false)})
+.setPreFunction(function(){Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).setValue(false)})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(400)
 

--- a/src/tutorials/graphConfigs.ts
+++ b/src/tutorials/graphConfigs.ts
@@ -117,7 +117,7 @@ newTut.newTutStep("Managing Graph Configurations", "In this table we can view, e
 newTut.newTutStep("Managing Graph Configurations", "Lets say we want another version of this config, but also be able to easily change the output file path. First, we must duplicate our existing graph configuration. <em>Click to duplicate our first configuration</em>", function(){return $('.btmWindowDuplicateBtn').first()})
 .setType(TutorialStep.Type.Press)
 
-newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('.bottomWindowHeader')})
+newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('#graphConfigurationsTableWrapper tr:last')})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
 newTut.newTutStep("Adding another field", "<em>Click on the File node to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('hello')})
@@ -127,12 +127,10 @@ newTut.newTutStep("Adding another field", "<em>Click on the File node to select 
 .setPreFunction(function(eagle:Eagle){eagle.resetEditor()})
 .setBackPreFunction(function(eagle:Eagle){eagle.resetEditor()})
 
-newTut.newTutStep("Adding another field", "<em>Click to Switch to the node fields table</em>", function(){return $('#bottomTabParamsTableSwitcher')})
-.setType(TutorialStep.Type.Press)
-
 newTut.newTutStep("Adding another field", "<em>Click on the heart to flag the file path field as a graph configuration field.</em>", function(){return $('.column_DisplayText button').first()})
 .setType(TutorialStep.Type.Press)
 .setPreFunction(function(){setTimeout(function(){$('.column_DisplayText button').first().css('visibility','visible')},200)})
+.setBackPreFunction(function(){ $('#bottomTabParamsTableSwitcher').trigger('click'); setTimeout(function(){$('.column_DisplayText button').first().css('visibility','visible')},200)})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(700)
 

--- a/src/tutorials/graphConfigs.ts
+++ b/src/tutorials/graphConfigs.ts
@@ -96,7 +96,6 @@ newTut.newTutStep("Creating Graph Configurations", "A graph may have many config
 
 newTut.newTutStep("Graph Configurations", "You can view the graph configuration fields by opening the Graph Configurations table here. <em>click to continue</em>", function(){return $("#openGraphConfigurationTable")})
 .setType(TutorialStep.Type.Press)
-// .setPreFunction(function(){$('.parameterTable').modal('hide')})
 
 newTut.newTutStep("Graph Configurations", "Our name field has been added to the graph configuration, where we can quickly change it for future runs of the graph. <em>next to continue</em>", function(){return $('.column_DisplayText').first()})
 .setAlternateHighlightTargetFunc(function(){return $('.parameterTable')})
@@ -109,16 +108,6 @@ newTut.newTutStep("Adjusting Graph Configurations", "We should describe what the
 newTut.newTutStep("Adjusting Graph Configurations", "For example, lets greet John. <em>Type 'John' and press enter to continue.</em>", function(){return $('.tableFieldStringValueInput').first()})
 .setType(TutorialStep.Type.Input)
 
-newTut.newTutStep("Saving Graph Configurations", "This will commit the new graph configuration changes into the graph. You will still need to save the graph to git, or locally. <em>Save the configuration</em>", function(){return $('#parameterTableSaveGraphConfig')})
-.setType(TutorialStep.Type.Press)
-.setPreFunction(function(){$('.parameterTable').modal('hide')})
-
-newTut.newTutStep("Saving Graph Configurations", "You must enter a description of what this graph config is designed to do, such as; 'with control over the name of who we are greeting' <em>Enter a description and click OK</em>",function(){return $('#inputModal .affirmativeBtn')})
-.setType(TutorialStep.Type.Press)
-.setAlternateHighlightTargetFunc(function(){return $('#inputModal .modal-content')})
-.setWaitType(TutorialStep.Wait.Delay)
-.setDelayAmount(200)
-
 newTut.newTutStep("Managing Graph Configurations", "<em>Click to Switch to the graph configurations table</em>", function(){return $('#bottomTabGraphConfigurationsSwitcher')})
 .setType(TutorialStep.Type.Press)
 
@@ -128,13 +117,13 @@ newTut.newTutStep("Managing Graph Configurations", "In this table we can view, e
 newTut.newTutStep("Managing Graph Configurations", "Lets say we want another version of this config, but also be able to easily change the output file path. First, we must duplicate our existing graph configuration. <em>Click to duplicate our first configuration</em>", function(){return $('.btmWindowDuplicateBtn').first()})
 .setType(TutorialStep.Type.Press)
 
-newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('.bottomWindowHeader span')})
+newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('.bottomWindowHeader')})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
-newTut.newTutStep("Adding another field", "<em>Click on the File node to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('File')})
+newTut.newTutStep("Adding another field", "<em>Click on the File node to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('hello')})
 .setType(TutorialStep.Type.Condition)
 .setWaitType(TutorialStep.Wait.Element)
-.setConditionFunction(function(){return TutorialSystem.isRequestedNodeSelected('File')})
+.setConditionFunction(function(){return TutorialSystem.isRequestedNodeSelected('hello')})
 .setPreFunction(function(eagle:Eagle){eagle.resetEditor()})
 .setBackPreFunction(function(eagle:Eagle){eagle.resetEditor()})
 
@@ -155,14 +144,8 @@ newTut.newTutStep("Adjusting Graph Configurations", "We can see that the FilePat
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
 
-newTut.newTutStep("Saving Graph Configurations", "Don't forget to save the new config</em>", function(){return $('#parameterTableSaveGraphConfig')})
-.setType(TutorialStep.Type.Press)
-
-newTut.newTutStep("Saving Graph Configurations", "update the description to better describe the new purpose of the configuration 'with control over the name of who we are greeting and output file path' <em>Enter a description and click OK",function(){return $('#inputModal .affirmativeBtn')})
-.setType(TutorialStep.Type.Press)
-.setAlternateHighlightTargetFunc(function(){return $('#inputModal .modal-content')})
-.setWaitType(TutorialStep.Wait.Delay)
-.setDelayAmount(200)
+newTut.newTutStep("Saving Graph Configurations", "Graph Configurations are stored within a the Graph. Save the graph as you would normally to save the config.", function(){return $('.bottomWindowHeader')})
+.setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
 newTut.newTutStep("Activating Graph Configurations", "To select which configuration is active for use, view them in the graph configurations table. <em>Click to Switch</em>", function(){return $('#bottomTabGraphConfigurationsSwitcher')})
 .setType(TutorialStep.Type.Press)

--- a/src/tutorials/quickStart.ts
+++ b/src/tutorials/quickStart.ts
@@ -13,6 +13,8 @@ newTut.newTutStep("Right Panel", "This Panel houses your repositories, allowing 
 
 newTut.newTutStep("Hints Bar", "Keep an eye on this section to learn important shortcuts and methods. The content changes when selecting different components in the canvas.", function(){return $("#statusBar")})
 
+newTut.newTutStep("Inspector", "Shows information and possible actions of the currently selected item, or the graph when nothing is selected.", function(){return $("#inspector")})
+
 newTut.newTutStep("User Interface Element Tooltips", "Much of Eagle's interface is using icons. You can always hover over the icons and most of the other elements to get more information on what they do.", function(){return $("#navbarSupportedContent .btn-group")})
     .setBackPreFunction(function (eagle) {Utils.hideShortcutsModal()})
 
@@ -63,6 +65,6 @@ newTut.newTutStep("Click To Save Settings", "<em>Press 'Ok' (or hit Enter) to sa
     .setPreFunction(function(eagle){$('#settingsModalNegativeButton').on('click.tutButtonListener', eagle.tutorial().tutPressStepListener).addClass('tutButtonListener');})
     .setBackPreFunction(function(eagle){eagle.tutorial().openSettingsSection('#settingCategoryExternalServices'); $('#settingsModalNegativeButton').on('click.tutButtonListener',eagle.tutorial().tutPressStepListener).addClass('tutButtonListener');$("#settingsModalAffirmativeButton").trigger("focus");})
 
-newTut.newTutStep("Translate Button", "Once configured, you are able to send your graph to the Translator", function(){return $("#navDeployBtn")})
+newTut.newTutStep("Translate Button", "Once configured, you are able to send your graph to the Translator", function(){return $("#navTranslateWrapper")})
 
 newTut.newTutStep("Well Done!", "You have completed the quick introduction tutorial! Be sure to check our <a target='_blank' href='https://eagle-dlg.readthedocs.io'>online documentation</a> for additional help and guidance. To continue to our tutorial on graph building press <a  onclick='TutorialSystem.initiateTutorial(`Graph Building`)' href='#'>here!</a>", function(){return $("#logicalGraphParent")})

--- a/static/base.css
+++ b/static/base.css
@@ -598,6 +598,10 @@ color: #00bb00;}
     width:100%;
 }
 
+#modelDataModal .modal-body{
+    padding:0px;
+}
+
 #modelDataModal .modal-body tr td input{
     width: 100%;
 }
@@ -1120,6 +1124,7 @@ select.form-control{
     resize: both;
     overflow: hidden;
     height: 50vh;
+    width: 50vw;
     max-height: 95vh;
     max-width: 95vw;
     background-color: aliceblue;

--- a/static/tables.css
+++ b/static/tables.css
@@ -510,13 +510,17 @@
 
 .eagleTableDisplay td button.parameterTableEditParam, .eagleTableDisplay td button.parameterTableCommentBtn, #modelDataModalTable td button.modelDataTableEditParam {
     position: absolute;
-    right: 4px;
-    top: 4px;
-    background-color: #002e5f;
-    color: white;
     display: none;
-    padding: 1% 0px 0px 0px;
     font-size: 12px;
+    padding: 0px;
+    height: 20px;
+    width: 20px;
+    border-radius: 10px;
+    right: 5px;
+    top: 50%;
+    background-color: #002e5f;
+    transform: translateY(-50%);
+    color: white;
 }
 
 .eagleTableDisplay  td:hover button.parameterTableEditParam{

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -338,15 +338,15 @@
                         <div class="row">
                             <div class="col col-6">
                                 <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.File -->
-                                <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Local Graph File'" data-bs-toggle="tooltip" data-html="true">folder_open</i>
+                                    <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Local Graph File'" data-bs-toggle="tooltip" data-html="true">folder_open</i>
                                 <!-- /ko -->
                                 <!-- ko if: $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitHub || $root.logicalGraph().fileInfo().repositoryService === Repository.Service.GitLab -->
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'This is a Graph File from GitHub or GitLab'" data-bs-toggle="tooltip" data-html="true">account_tree</i>
                                 <!-- /ko -->
                                 <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().fullPath()" data-bs-toggle="tooltip" data-html="true">link</i>
 
-                                <i class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: 'View Graph Model Data', click: function(){Utils.showModelDataModal('Graph Info', $root.logicalGraph().fileInfo());}" data-bs-toggle="tooltip" data-html="true">info</i>
-                                <i class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().shortDescription, click: $root.editGraphShortDescription" data-bs-toggle="tooltip" data-html="true">sticky_note_2</i>
+                                <i id="inspectorGraphInfoBtn" class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: 'View Graph Model Data', click: function(){Utils.showModelDataModal('Graph Info', $root.logicalGraph().fileInfo());}" data-bs-toggle="tooltip" data-html="true">info</i>
+                                <i id="shortDescriptionEditBtn" class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().shortDescription, click: $root.editGraphShortDescription" data-bs-toggle="tooltip" data-html="true">sticky_note_2</i>
                                 <i class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().detailedDescription, click: $root.editGraphDetailedDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
                             </div>
                             <div class="col-6 col text-right">

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -13,7 +13,7 @@
                                 <input data-bind="value:$data.name, eagleTooltip: $data.getName()"></input>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: KeyboardShortcut.idToFullText('toggle_inspector')">close</i>
                             </div>
                         </div> 
                         
@@ -170,7 +170,7 @@
                                 <h4>Edge Attributes</h4>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: KeyboardShortcut.idToFullText('toggle_inspector')">close</i>
                             </div>
                         </div>
                         
@@ -266,7 +266,7 @@
                                 <h4>Multi Selection</h4>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: KeyboardShortcut.idToFullText('toggle_inspector')">close</i>
                             </div>
                         </div>
                         
@@ -330,7 +330,7 @@
                             <h4>Graph Info</h4>
                         </div>
                         <div class="col-1 col iconHoverEffect">
-                            <i class="material-icons" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                            <i class="material-icons" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: KeyboardShortcut.idToFullText('toggle_inspector')">close</i>
                         </div>
                     </div>
                     
@@ -401,7 +401,7 @@
         <!-- /ko -->
             
         <!-- ko if: Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE) -->
-            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle">info</i>
+            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: KeyboardShortcut.idToFullText('toggle_inspector')">info</i>
         <!-- /ko -->
     <!-- /ko -->
 </div>

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -1,7 +1,7 @@
 <div id="inspector" data-bind="style: {'visibility':eagle.getEagleIsReady(), left: Utils.getLeftWindowWidth() + 10, bottom: Utils.getInspectorOffset() + 'vh'},css:{'inspectorCollapsed': $root.getInspectorCollapseState()}">
     <!-- Graph object inspector -->
     <!-- ko if: $root.selectedObjects().length > 0 -->
-        <!-- ko ifnot: Setting.findValue(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE) -->
+        <!-- ko ifnot: Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE) -->
 
 
             <!-- SINGLE NODE INSPECTOR -->
@@ -13,7 +13,7 @@
                                 <input data-bind="value:$data.name, eagleTooltip: $data.getName()"></input>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
                             </div>
                         </div> 
                         
@@ -170,7 +170,7 @@
                                 <h4>Edge Attributes</h4>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
                             </div>
                         </div>
                         
@@ -266,7 +266,7 @@
                                 <h4>Multi Selection</h4>
                             </div>
                             <div class="col-1 col">
-                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                                <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
                             </div>
                         </div>
                         
@@ -314,15 +314,15 @@
             <!-- /ko -->
         <!-- /ko -->      
     
-        <!-- ko if: Setting.findValue(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE) -->
-            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.OBJECT_INSPECTOR_COLLAPSED_STATE).toggle">info</i>
+        <!-- ko if: Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE) -->
+            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle">info</i>
         <!-- /ko -->
     <!-- /ko -->
 
 
     <!-- Graph info inspector -->
     <!-- ko if: $root.selectedObjects().length === 0 -->
-        <!-- ko ifnot: Setting.findValue(Setting.GRAPH_INSPECTOR_COLLAPSED_STATE) --> 
+        <!-- ko ifnot: Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE) --> 
             <!-- ko if: $root.logicalGraph().fileInfo() !== null -->
                 <div class="container">
                     <div class="row inspectorHeader">
@@ -330,7 +330,7 @@
                             <h4>Graph Info</h4>
                         </div>
                         <div class="col-1 col iconHoverEffect">
-                            <i class="material-icons" data-bind="click: Setting.find(Setting.GRAPH_INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
+                            <i class="material-icons" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle, eagleTooltip: 'Collapse the Inspector'">close</i>
                         </div>
                     </div>
                     
@@ -400,8 +400,8 @@
             <!-- /ko -->
         <!-- /ko -->
             
-        <!-- ko if: Setting.findValue(Setting.GRAPH_INSPECTOR_COLLAPSED_STATE) -->
-            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.GRAPH_INSPECTOR_COLLAPSED_STATE).toggle">info</i>
+        <!-- ko if: Setting.findValue(Setting.INSPECTOR_COLLAPSED_STATE) -->
+            <i class="material-icons iconHoverEffect" data-bind="click: Setting.find(Setting.INSPECTOR_COLLAPSED_STATE).toggle">info</i>
         <!-- /ko -->
     <!-- /ko -->
 </div>


### PR DESCRIPTION
- new keyboard shortcut for toggling the inspector (requested by Ryan)
- new tooltips showing the new shortcut
- fixes and improvements for all three tutorials
- css fixes for edit description buttons in graph info modal

## Summary by Sourcery

Introduce a keyboard shortcut to toggle the inspector panel, unify its collapsed state setting, update related UI bindings and tooltips, refine tutorial flows to match the new inspector behavior, and fix CSS issues in table buttons and modal layouts.

New Features:
- Add 'Toggle Inspector' (i) keyboard shortcut to collapse and expand the inspector panel.

Bug Fixes:
- Adjust CSS for parameter table edit buttons to correct size, positioning, and visibility.
- Fix modal body padding and dimensions in graph info and markdown editor dialogs.

Enhancements:
- Consolidate object and graph inspector collapse states into a single INSPECTOR_COLLAPSED_STATE setting.
- Embed the new shortcut text in inspector collapse/expand tooltips.
- Update Graph Building, Graph Configs, and Quick Start tutorials to reflect UI changes, add proper delays, and remove outdated steps.