### PR TITLE
Eagle 1509

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -169,9 +169,14 @@ ko.bindingHandlers.graphRendererPortPosition = {
 
         switch(dataType){
             case 'comment': {
+                if(n.getSubjectId() === null){
+                    return
+                }
+
                 const adjacentNode: Node = eagle.logicalGraph().findNodeByIdQuiet(n.getSubjectId());
 
                 if (adjacentNode === null){
+                     console.warn("Could not find adjacentNode for comment with subjectId", n.getSubjectId());
                     return;
                 }
 
@@ -911,7 +916,7 @@ export class GraphRenderer {
         const destNode: Node = lg.findNodeByIdQuiet(commentNode.getSubjectId());
 
         if(srcNode === null || destNode === null){
-            return null
+            return ''
         }
 
         return GraphRenderer._getPath(null,srcNode, destNode, null, null);

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -172,7 +172,6 @@ ko.bindingHandlers.graphRendererPortPosition = {
                 const adjacentNode: Node = eagle.logicalGraph().findNodeByIdQuiet(n.getSubjectId());
 
                 if (adjacentNode === null){
-                    console.warn("Could not find adjacentNode for comment with subjectId", n.getSubjectId());
                     return;
                 }
 
@@ -910,6 +909,10 @@ export class GraphRenderer {
 
         const srcNode: Node = commentNode;
         const destNode: Node = lg.findNodeByIdQuiet(commentNode.getSubjectId());
+
+        if(srcNode === null || destNode === null){
+            return null
+        }
 
         return GraphRenderer._getPath(null,srcNode, destNode, null, null);
     }

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -416,8 +416,8 @@ export class KeyboardShortcut {
             run: (eagle): void => {eagle.changeNodeParent();}
         }),
         new KeyboardShortcut({
-            id: "change_selected_node_subject",
-            text: "Change Selected Node Subject",
+            id: "connect_comment_node",
+            text: "Connect comment node",
             keys: [new Key("u", Modifier.Shift)],
             tags: ['comment'],
             run: (eagle): void => {eagle.changeNodeSubject();}

--- a/src/RightClick.ts
+++ b/src/RightClick.ts
@@ -628,6 +628,9 @@ export class RightClick {
                 if(data.getCategory() === Category.Docker){
                     $('#customContextMenu').append('<a onclick=eagle.fetchDockerHTML()>Browse DockerHub</a>')
                 }
+                if(data.isComment()){
+                    $('#customContextMenu').append('<a onclick=eagle.changeNodeSubject()>Connect to Node</a>')
+                }
                 if(Setting.findValue(Setting.ALLOW_PALETTE_EDITING)){
                     $('#customContextMenu').append('<a onclick=eagle.addSelectedNodesToPalette("contextMenuRequest")>Add to palette</a>')
                 }

--- a/src/tutorials/graphConfigs.ts
+++ b/src/tutorials/graphConfigs.ts
@@ -94,10 +94,10 @@ newTut.newTutStep("Creating Graph Configurations", "A graph may have many config
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
 
-newTut.newTutStep("Graph Configurations", "You can view the graph configuration fields by opening the Graph Configurations table here. <em>click to continue</em>", function(){return $("#openGraphConfigurationTable")})
+newTut.newTutStep("Graph Configurations", "You can view the graph configuration fields by opening the Graph Configurations table here. <em>click to continue</em>", function(){return $('#bottomTabKeyParamsSwitcher')})
 .setType(TutorialStep.Type.Press)
 
-newTut.newTutStep("Graph Configurations", "Our name field has been added to the graph configuration, where we can quickly change it for future runs of the graph. <em>next to continue</em>", function(){return $('.column_DisplayText').first()})
+newTut.newTutStep("Graph Configurations", "Our 'greet' field has been added to the graph configuration, where we can quickly change it for future runs of the graph. <em>next to continue</em>", function(){return $('.column_DisplayText').first()})
 .setAlternateHighlightTargetFunc(function(){return $('.parameterTable')})
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
@@ -111,13 +111,16 @@ newTut.newTutStep("Adjusting Graph Configurations", "For example, lets greet Joh
 newTut.newTutStep("Managing Graph Configurations", "<em>Click to Switch to the graph configurations table</em>", function(){return $('#bottomTabGraphConfigurationsSwitcher')})
 .setType(TutorialStep.Type.Press)
 
-newTut.newTutStep("Managing Graph Configurations", "In this table we can view, edit, copy or delete existing graph configurations saved in this graph. <em>next to continue</em>", function(){return $('.column-actions').first()})
+newTut.newTutStep("Managing Graph Configurations", "In this table we can view, edit, copy or delete existing graph configurations saved in this graph. <em>next to continue</em>", function(){return $('#graphConfigurationsTableWrapper tr').first()})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
 newTut.newTutStep("Managing Graph Configurations", "Lets say we want another version of this config, but also be able to easily change the output file path. First, we must duplicate our existing graph configuration. <em>Click to duplicate our first configuration</em>", function(){return $('.btmWindowDuplicateBtn').first()})
 .setType(TutorialStep.Type.Press)
 
 newTut.newTutStep("Managing Graph Configurations", "Our configuration has been duplicated, lets add the additional field. <em>next to continue</em>", function(){return $('#graphConfigurationsTableWrapper tr:last')})
+.setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
+
+newTut.newTutStep("Activating Graph Configurations", "As you can see, the newly created configuration is active. You can change the active config or disable them by using the toggle buttons. <em>next to continue</em>", function(){return $('.column-active:last')})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
 
 newTut.newTutStep("Adding another field", "<em>Click on the File node named 'hello' to select it.</em>",  function(){return TutorialSystem.initiateFindGraphNodeIdByNodeName('hello')})
@@ -142,14 +145,8 @@ newTut.newTutStep("Adjusting Graph Configurations", "We can see that the FilePat
 .setWaitType(TutorialStep.Wait.Delay)
 .setDelayAmount(200)
 
-newTut.newTutStep("Saving Graph Configurations", "Graph Configurations are stored within a the Graph. Save the graph as you would normally to save the config.", function(){return $('.bottomWindowHeader')})
+newTut.newTutStep("Saving Graph Configurations", "Graph Configurations are stored within the Graph. Save the graph as you would normally to save the config.", function(){return $('.bottomWindowHeader')})
 .setAlternateHighlightTargetFunc(function(){return $('#bottomWindow .content')})
-
-newTut.newTutStep("Activating Graph Configurations", "To select which configuration is active for use, view them in the graph configurations table. <em>Click to Switch</em>", function(){return $('#bottomTabGraphConfigurationsSwitcher')})
-.setType(TutorialStep.Type.Press)
-
-newTut.newTutStep("Activating Graph Configurations", "As you can see, the newly created configuration with filepath is active. You may simply click the active button to toggle which configuration is active. <em>next to continue</em>", function(){return $('.column-active').eq(1)})
-.setAlternateHighlightTargetFunc(function(){return $('.parameterTable')})
 
 newTut.newTutStep("Well Done!", "You have completed the Hello world graph creation tutorial! Be sure to check our <a target='_blank' href='https://eagle-dlg.readthedocs.io'>online documentation</a> for additional help and guidance.", function(){return $("#logicalGraphParent")})
 .setPreFunction(function(){$('.forceShow').removeClass('forceShow')}) //allowing the graph navbar dropdown to hide

--- a/templates/base.html
+++ b/templates/base.html
@@ -210,7 +210,7 @@
                         <button type="button" class="btn btn-primary iconHoverEffect" data-bind="click: function(){SideWindow.toggleShown('bottom')}, clickBubble:false"><i class="md-20 icon-cross clickable"></i></button>
                     </div>
                     <div class="content">
-                        <!-- ko if: $root.getEagleIsReady() -->
+                        <!-- ko if: $root.getEagleIsReady() && Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE) -->
                             <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.NodeParameterTable -->
                                 {% include 'node_parameter_table.html' %}
                             <!-- /ko -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -51,6 +51,11 @@
                                             <i class="material-icons md-20 clickable iconHoverEffect">library_add</i>
                                         </button>
                                     <!-- /ko -->
+                                    <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph && $data.isComment() -->
+                                        <button type="button" id="connectCommentNode" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.changeNodeSubject()}, clickBubble: false, eagleTooltip: KeyboardShortcut.idToFullText('connect_comment_node')" data-bs-placement="left">
+                                            <i class="material-icons md-20 clickable iconHoverEffect">polyline</i>
+                                        </button>
+                                    <!-- /ko -->
                                     <!-- ko if: Eagle.selectedLocation() == Eagle.FileType.Graph || Setting.findValue(Setting.ALLOW_PALETTE_EDITING) -->
                                         <button type="button" id="deleteSelectedNode" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.deleteSelection(false,false,false);}, clickBubble: false, eagleTooltip: KeyboardShortcut.idToFullText('delete_selection')" data-bs-placement="left">
                                             <i class="material-icons md-20 clickable iconHoverEffect">delete</i>


### PR DESCRIPTION
- more tutorial improvements
- comment node edge drawing code improvements 
- physical buttons in comment node inspector and right click menu for linking 
- renamed keyboard shortcut to something more recognisable for users

## Summary by Sourcery

Enhance the Graph Configurations tutorial flow with updated selectors, field names, and an activation step; introduce UI controls and a shortcut for linking comment nodes; bolster GraphRenderer safety with null checks; and respect the bottom window visibility setting.

New Features:
- Add a toolbar button and right-click menu entry to link comment nodes to target nodes using the new 'connect_comment_node' shortcut

Enhancements:
- Refine the Graph Configurations tutorial by updating selectors, renaming fields, adjusting highlights and delays, and adding an activation step
- Strengthen GraphRenderer by removing a console warning and adding null checks when drawing comment edges
- Conditionally render the bottom window content based on the BOTTOM_WINDOW_VISIBLE setting

Chores:
- Rename the keyboard shortcut id from 'change_selected_node_subject' to 'connect_comment_node' and update its display text