### PR TITLE
tooltips for inspector description buttons never empty

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -345,6 +345,14 @@ export class LogicalGraph {
         return commentNodes;
     }
 
+    getInspectorShortDescriptionHTML : ko.PureComputed<string> = ko.pureComputed(() => {
+        return 'Edit Short Graph Description: </br>' + Utils.markdown2html(this.fileInfo().shortDescription);
+    }, this);
+
+    getInspectorDetailedDescriptionHTML : ko.PureComputed<string> = ko.pureComputed(() => {
+        return 'Edit Detailed Graph Description: </br>' + Utils.markdown2html(this.fileInfo().detailedDescription);
+    }, this);
+
     setGraphConfigs = (graphConfigs: GraphConfig[]): void => {
         this.graphConfigs(graphConfigs);
     }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -692,6 +692,10 @@ export class Node {
         return Utils.markdown2html(this.description());
     }, this);
 
+    getInspectorDescriptionHTML : ko.PureComputed<string> = ko.pureComputed(() => {
+        return 'Edit Node Description: </br>' + Utils.markdown2html(this.description());
+    }, this);
+
     getSubjectId = () : NodeId => {
         return this.subject();
     }

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -22,7 +22,7 @@
                                 <div class="col-5 col">
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $data.getGitHTML()" data-bs-toggle="tooltip" data-html="true">link</i>
                                     <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: 'Id: '+$data.getId()" data-bs-toggle="tooltip" data-html="true">fingerprint</i>
-                                    <i class="material-icons interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getDescriptionHTML(), click: $root.editNodeDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
+                                    <i class="material-icons interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getInspectorDescriptionHTML(), click: $root.editNodeDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
                                     <!-- ko if: $data.getAllErrorsWarnings().errors.length > 0 || $data.getAllErrorsWarnings().warnings.length > 0 -->
                                         <i class="material-icons interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}, click: $root.showGraphErrors" data-bs-toggle="tooltip" data-html="true">error</i>
                                     <!-- /ko -->
@@ -346,8 +346,8 @@
                                 <i class="material-icons interactive" data-bs-placement="right" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().fullPath()" data-bs-toggle="tooltip" data-html="true">link</i>
 
                                 <i id="inspectorGraphInfoBtn" class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: 'View Graph Model Data', click: function(){Utils.showModelDataModal('Graph Info', $root.logicalGraph().fileInfo());}" data-bs-toggle="tooltip" data-html="true">info</i>
-                                <i id="shortDescriptionEditBtn" class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().shortDescription, click: $root.editGraphShortDescription" data-bs-toggle="tooltip" data-html="true">sticky_note_2</i>
-                                <i class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().fileInfo().detailedDescription, click: $root.editGraphDetailedDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
+                                <i id="shortDescriptionEditBtn" class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().getInspectorShortDescriptionHTML(), click: $root.editGraphShortDescription" data-bs-toggle="tooltip" data-html="true">sticky_note_2</i>
+                                <i class="material-icons interactive clickable iconHoverEffect" data-bind="eagleTooltip: $root.logicalGraph().getInspectorDetailedDescriptionHTML(), click: $root.editGraphDetailedDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
                             </div>
                             <div class="col-6 col text-right">
                                 <i class="material-icons interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: 'View graph configurations table', click: GraphConfigurationsTable.openTable" data-bs-toggle="tooltip" data-html="true">dns</i>


### PR DESCRIPTION
## Summary by Sourcery

Ensure inspector description buttons always display non-empty tooltips by adding pureComputed HTML descriptions with edit prompts and markdown support

Enhancements:
- Introduce computed HTML tooltip getters on LogicalGraph and Node to include edit prompts and rendered markdown for descriptions
- Update inspector template bindings to use new tooltip getters for node and graph short and detailed description buttons