### PR TITLE
Eagle 1529

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1103,7 +1103,7 @@ export class GraphRenderer {
             }   
 
             //check for alt clicking, if so, add the target node and its children to the selection
-            else if(event.button != 2 && !event.altKey&&node.isGroup()){
+            else if(event.button != 2 && !event.altKey&&node.isGroup() && !eagle.objectIsSelected(node)){
                 GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
             }
 

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1097,21 +1097,26 @@ export class GraphRenderer {
         // select handlers
         if(node !== null && event.button != 1 && !event.shiftKey){
 
+            //double click has highest priority, select only this node if it is a contruct
+            if(GraphRenderer.dragSelectionDoubleClick && node.isGroup()) {
+                eagle.setSelection(node, Eagle.FileType.Graph);
+            }   
+
+            //check for alt clicking, if so, add the target node and its children to the selection
+            else if(event.button != 2 && !event.altKey&&node.isGroup()){
+                GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
+            }
+
             // check if shift key is down, if so, add or remove selected node to/from current selection | keycode 2 is the middle mouse button
-            if (node !== null && event.shiftKey && !event.altKey){
+            else if (node !== null && event.shiftKey && event.altKey){
                 GraphRenderer.dragSelectionHandled(true)
                 eagle.editSelection(node, Eagle.FileType.Graph);
             } else if(!eagle.objectIsSelected(node)) {
                 eagle.setSelection(node, Eagle.FileType.Graph);
             }
 
-            //check for alt clicking, if so, add the target node and its children to the selection
-            if(event.altKey&&node.isGroup()||GraphRenderer.dragSelectionDoubleClick&&node.isGroup()){
-                GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
-            }
-
             //switch back to the node parameter table if a node is selected
-        if(Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE) === true && Setting.findValue(Setting.BOTTOM_WINDOW_MODE) !== Eagle.BottomWindowMode.NodeParameterTable){
+            if(Setting.findValue(Setting.BOTTOM_WINDOW_VISIBLE) === true && Setting.findValue(Setting.BOTTOM_WINDOW_MODE) !== Eagle.BottomWindowMode.NodeParameterTable){
                 ParameterTable.openTable(Eagle.BottomWindowMode.NodeParameterTable, ParameterTable.SelectType.Normal)
             }
         }else{
@@ -1190,7 +1195,7 @@ export class GraphRenderer {
             
             //checking if there was no drag distance, if so we are clicking a single object and we will toggle its selection
             if(Math.abs(GraphRenderer.selectionRegionStart.x-GraphRenderer.selectionRegionEnd.x)+Math.abs(GraphRenderer.selectionRegionStart.y - GraphRenderer.selectionRegionEnd.y)<3){
-                if(GraphRenderer.altSelect){
+                if(!GraphRenderer.altSelect){
                     GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
                 }
                 eagle.editSelection(node,Eagle.FileType.Graph);

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1096,7 +1096,6 @@ export class GraphRenderer {
 
         // select handlers
         if(node !== null && event.button != 1 && !event.shiftKey){
-
             //double click has highest priority, select only this node if it is a contruct
             if(GraphRenderer.dragSelectionDoubleClick && node.isGroup()) {
                 eagle.setSelection(node, Eagle.FileType.Graph);
@@ -1107,11 +1106,8 @@ export class GraphRenderer {
                 GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
             }
 
-            // check if shift key is down, if so, add or remove selected node to/from current selection | keycode 2 is the middle mouse button
-            else if (node !== null && event.shiftKey && event.altKey){
-                GraphRenderer.dragSelectionHandled(true)
-                eagle.editSelection(node, Eagle.FileType.Graph);
-            } else if(!eagle.objectIsSelected(node)) {
+            //normal node selection
+            else if(!eagle.objectIsSelected(node)) {
                 eagle.setSelection(node, Eagle.FileType.Graph);
             }
 


### PR DESCRIPTION
swapping construct selection behaviour single click, as well as click and drag, will now select the construct and its children.
double click or alt + left click will select only the clicked construct.
right clicking a construct will pull up the right click menu for just the construct

## Summary by Sourcery

Update GraphRenderer to implement new construct selection behaviors: single click and drag select a group and its children, double-click or Alt+click select only the targeted construct, and right-click opens the context menu for the individual construct.

Enhancements:
- Single-click and click-drag now select a construct together with its children
- Double-click and Alt+Left-Click now select only the clicked construct without its descendants
- Right-click on a construct opens the context menu without altering the current selection
- Refactor selection logic to prioritize double-click and Alt+click handlers and remove legacy selection branches