### PR TITLE
quick action improvements

### DIFF
--- a/src/QuickActions.ts
+++ b/src/QuickActions.ts
@@ -186,6 +186,7 @@ export class QuickActions {
                     }else{
                         $(".quickActionsFocus").removeClass('quickActionsFocus')
                         current.next().addClass('quickActionsFocus')
+                        // $('quickActionContainer').scrollTop(current.next().offset().top)
                     }
                 }
                 break;
@@ -208,6 +209,9 @@ export class QuickActions {
                 $('#quickActionSearchbar').trigger("focus")
                 break;
             }
+            
+            //scroll the quick selection item into view
+            $('#quickActionResults .quickActionsFocus').get(0)?.scrollIntoView(false);
         })
         
         $('#quickActionBackground').on('click.quickActionDismiss', function(){

--- a/src/QuickActions.ts
+++ b/src/QuickActions.ts
@@ -186,7 +186,6 @@ export class QuickActions {
                     }else{
                         $(".quickActionsFocus").removeClass('quickActionsFocus')
                         current.next().addClass('quickActionsFocus')
-                        // $('quickActionContainer').scrollTop(current.next().offset().top)
                     }
                 }
                 break;

--- a/static/base.css
+++ b/static/base.css
@@ -98,6 +98,12 @@ body {
     transform: translateX(-50%);
 }
 
+@media only screen and (max-width: 1920px) {
+    #quickActionContainer{
+        top: 8rem;
+    }
+}
+
 #quickActionInput{
     width: 50rem;
     height:4rem;


### PR DESCRIPTION
media tag to move quick select up for small screens 
scroll result into view on arrow keys

## Summary by Sourcery

Improve quick action dropdown usability on smaller screens and keyboard navigation

Enhancements:
- Add media query to raise quick action container position on screens narrower than 1920px
- Auto-scroll the currently highlighted quick action into view when navigating with arrow keys