### PR TITLE
EAGLE-1530: Added what's new modal

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2932,6 +2932,10 @@ export class Eagle {
         $('#aboutModal').modal('show');
     }
 
+    showWhatsNew = () : void => {
+        $('#whatsNewModal').modal('show');
+    }
+
     onlineDocs = () : void => {
         // open in new tab:
         window.open(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2869,4 +2869,9 @@ export class Utils {
 
         return customRepositories;
     }
+
+    // https://stackoverflow.com/questions/6832596/how-can-i-compare-software-version-number-using-javascript-only-numbers
+    static compareVersions(version1: string, version2: string): number {
+        return version1.localeCompare(version2, undefined, { numeric: true, sensitivity: 'base' });
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,8 @@ let eagle : Eagle;
 $(function(){
     //Check if the user is a first time visitor to the site
     const firstTimeVisit = localStorage.getItem('activeUiMode') === null;
+    const lastSeenVersion = localStorage.getItem('lastSeenVersion') || "0.0.0";
+    const showWhatsNew = Utils.compareVersions((<any>window).version, lastSeenVersion) > 0;
 
     // Global variables.
     eagle = new Eagle();
@@ -166,6 +168,13 @@ $(function(){
     //request a first time visitor welcome to eagle if applicable
     initiateWelcome(firstTimeVisit);
   
+    // if not first time visit, but version is newer than last seen version, show the versions modal
+    if (!firstTimeVisit && showWhatsNew){
+        eagle.showWhatsNew();
+        // set the last seen version
+        localStorage.setItem('lastSeenVersion', (<any>window).version);
+    }
+
     $('.modal').on('hidden.bs.modal', function () {
         $('.modal-dialog').css({"left":"0px", "top":"0px"})
         $("#editFieldModal textarea").attr('style','')

--- a/static/base.css
+++ b/static/base.css
@@ -1054,6 +1054,10 @@ select.form-control{
     display: inline-block;
 }
 
+.modal .modal-body pre{
+    overflow:unset;
+}
+
 #settingsCategoriesAccordion .accordion-button {
     padding: 5px 15px;
     background-color: rgb(194 200 220);

--- a/static/base.css
+++ b/static/base.css
@@ -1199,7 +1199,12 @@ select.form-control{
 }
 
 #aboutModal .modal-content{
-    width: 60vw;
+    width: 30vw;
+    height: 45vh;
+}
+
+#whatsNewModal .modal-content{
+    width: 40vw;
     height: 60vh;
 }
 

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -362,7 +362,20 @@
                 <span>Version:&nbsp;{{version}}&nbsp;({{commit_hash}})</span>
                 <hr />
                 <pre>{% include 'license.html' %}</pre>
-                <hr />
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Whats New Modal -->
+<div class="modal fade" id="whatsNewModal" tabindex="-1" role="dialog" aria-labelledby="whatsNewModalTitle">
+    <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="whatsNewModalTitle">What's New</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
                 <pre>{% include 'versions.html' %}</pre>
             </div>
         </div>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -7,7 +7,7 @@
             EAGLE
             <sup>π</sup>
         </a>
-        <span>{{version}}</span>
+        <span data-bind="text: window.version">version</span>
     </div>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -240,6 +240,7 @@
                 </a>
                 <div class="dropdown-menu dropdown-menu-right dropdown-area" aria-labelledby="navbarDropdownHelp">
                     <a class="dropdown-item" id="about" href="#" data-bind="click: showAbout">About</a>
+                    <a class="dropdown-item" id="versions" href="#" data-bind="click: showWhatsNew">What's New</a>
                     <span class="dropdown-item dropDropDownParent" id="navTutorials" href="#"><img src="/static/assets/img/arrow_right_white_24dp.svg" alt="" id="navbarDropdownTutorials">Tutorials
                         <div class="dropDropDown">
                             <a class="dropdown-item" id="quickIntroTutBtn" href="#" data-bind="click: function(){TutorialSystem.initiateTutorial('Quick Start')}">Quick Introduction</a>


### PR DESCRIPTION
Move version information out of the "About" modal, into a new "What's New" modal.
Add "What's New" option to the "Help" menu in the navbar
Show "What's New" modal automatically at startup if user sees a new version of EAGLE for the first time.
Store last seen EAGLE version in localStorage as "lastSeenVersion"

## Summary by Sourcery

Introduce a dedicated What’s New modal for version release details, move version info out of the About modal, and automatically prompt users on first launch of each new version by tracking lastSeenVersion in localStorage and adding supporting UI and utility logic.

New Features:
- Add a dedicated "What’s New" modal to showcase version updates
- Introduce a "What’s New" item in the Help menu to trigger the new modal
- Automatically display the What’s New modal on startup when a new version is detected

Enhancements:
- Move version information out of the About modal into the What’s New modal
- Persist and compare last seen version in localStorage to control modal display
- Add compareVersions utility method and Eagle.showWhatsNew action
- Update modal styling and layout for About and What’s New dialogs