### PR TITLE
code edit button for the bash - command field values

### DIFF
--- a/src/Daliuge.ts
+++ b/src/Daliuge.ts
@@ -84,7 +84,10 @@ export namespace Daliuge {
         // python
         FUNC_CODE = "func_code",
         FUNC_NAME = "func_name",
-        PYDATA = "pydata"
+        PYDATA = "pydata",
+
+        //bash
+        COMMAND = "command",
     }
 
     export enum DataType {

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -340,6 +340,11 @@ export class ParameterTable {
         }
     }
 
+    static isCodeField(field: Field) : boolean {
+        //func code is for python functions, command is for bash commands
+        return field.getDisplayText() === Daliuge.FieldName.FUNC_CODE || field.getDisplayText() === Daliuge.FieldName.COMMAND;
+    }
+
     static select(selection: string, selectionName: string, selectionParent: Field, selectionIndex: number) : void {
         ParameterTable.selectionName(selectionName);
         ParameterTable.selectionParent(selectionParent);

--- a/templates/config_parameter_table.html
+++ b/templates/config_parameter_table.html
@@ -97,7 +97,7 @@
                                                     <td class='columnCell column_Value'>
                                                         <!-- ko if: $data.getGraphConfigField() -->
                                                             <textarea  style="resize: none;" class="tableParameter inputNoArrows tableFieldStringValueInput" data-bind="css: {selectedTableParameter: ParameterTable.isSelected('value', $data) },disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: $data.getGraphConfigField().value, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.getGraphConfigField().value(), 'value', $data, $index())}}"></textarea>
-                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && $data.getDisplayText() === Daliuge.FieldName.FUNC_CODE -->
+                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && ParameterTable.isCodeField($data) -->
                                                                 <button class="parameterTableEditParam icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>
                                                             <!-- /ko -->
                                                         <!-- /ko -->

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -240,7 +240,7 @@
                                                             <!-- ko ifnot: $data.getGraphConfigField() -->
                                                                 <textarea style="resize: none;" class="tableParameter inputNoArrows tableFieldStringValueInput" data-bind="eagleTooltip: 'Graph Value', disabled: ParameterTable.getCurrentParamValueReadonly($data), valueUpdate: ['afterkeydown', 'input'], value: value, attr:{type: $data.getHtmlInputType()},  event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.value(), 'value', $data, $index())}, click: function(event, data){ParameterTable.select($data.value(), 'value', $data, $index())}}"></textarea>
                                                             <!-- /ko -->
-                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && $data.getDisplayText() === Daliuge.FieldName.FUNC_CODE -->
+                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && ParameterTable.isCodeField($data) -->
                                                                 <button class="parameterTableEditParam icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, false)}"></button>
                                                             <!-- /ko -->
                                                         <!-- /ko -->
@@ -304,7 +304,7 @@
                                                         <!-- string -->
                                                         <!-- ko ifnot: $data.getType() === 'Integer' || $data.getType() === 'Float' -->
                                                             <textarea  style="resize: none;" class="tableParameter inputNoArrows" data-bind="disabled: ParameterTable.getNodeLockedState($data), valueUpdate: ['afterkeydown', 'input'], value: defaultValue, attr:{type: $data.getHtmlInputType()}, event: {change: ParameterTable.fieldValueChanged, keyup: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}, click: function(event, data){ParameterTable.select($data.defaultValue(), 'defaultValue', $data, $index())}}"></textarea>
-                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && $data.getDisplayText() === Daliuge.FieldName.FUNC_CODE -->
+                                                            <!-- ko if: !ParameterTable.getNodeLockedState($data) && ParameterTable.isCodeField($data) -->
                                                                 <button class="parameterTableEditParam icon-pencil iconHoverEffect" data-bind="click:function(data,event){ParameterTable.requestEditValueCode($data, true)}"></button>
                                                             <!-- /ko -->
                                                         <!-- /ko -->


### PR DESCRIPTION
code edit - pen button for command field values on bash nodes in parameter table

## Summary by Sourcery

Add support for editing Bash command fields via the code editor button in node and config parameter tables

New Features:
- Display a code edit (pencil) button for Bash command fields alongside Python function code fields.

Enhancements:
- Introduce Daliuge.FieldName.COMMAND enum value and ParameterTable.isCodeField helper to unify code field detection.
- Replace direct FUNC_CODE checks with isCodeField to toggle the edit button for both Python and Bash fields.