### PR TITLE
fields cell in configs table is now readonly

### DIFF
--- a/templates/graph_configurations_table.html
+++ b/templates/graph_configurations_table.html
@@ -45,24 +45,30 @@
                 <tbody>
                     <!-- ko foreach: logicalGraph().graphConfigs() -->
                         <tr data-bind="attr: {'id' : 'tableRow_'+$data.getName()}, css: {activeConfig: $data.id() === $root.logicalGraph().activeGraphConfigId()}">
+<!-- drag handle -->
                             <td class='columnCell column-sort'>
                                 <!-- kept for now as we will need the space for the row drag handle -->
                             </td>
+<!-- config name -->
                             <td class='columnCell column-name'>
                                 <input class="tableParameter" type="string" data-bind="value: $data.name, eagleTooltip: $data.getName()">
                             </td>
+<!-- config description -->
                             <td class='columnCell column-description'>
-                                <textarea  style="resize: none;" class="tableParameter" type="string" data-bind="value: $data.description, eagleTooltip: $data.getDescription()"></textarea>
+                                <textarea style="resize: none;" class="tableParameter" type="string" data-bind="value: $data.description, eagleTooltip: $data.getDescription()"></textarea>
                             </td>
+<!-- number of fields -->
                             <td class='columnCell column-fields'>
-                                <input class="tableParameter" type="string" data-bind="value: $data.numFields(), eagleTooltip: 'number of fields added to the graph configuration'">
+                                <input class="tableParameter" readonly type="string" data-bind="value: $data.numFields(), eagleTooltip: 'number of fields added to the graph configuration'">
                             </td>
+<!-- active config -->
                             <td class='columnCell column-active'>
                                 <button class="iconHoverEffect" type="button" data-bind="click: function(){$root.logicalGraph().setActiveGraphConfig($data.getId());}">
                                     <i class="material-symbols-outlined md-18" data-bind="visible: $data.id() === $root.logicalGraph().activeGraphConfigId()">radio_button_checked</i>
                                     <i class="material-symbols-outlined md-18" data-bind="hidden:  $data.id() === $root.logicalGraph().activeGraphConfigId()">radio_button_unchecked</i>
                                 </button>
                             </td>
+<!-- actions -->
                             <td class='columnCell column-actions'>
                                 <button class="btmWindowDuplicateBtn iconHoverEffect" data-bind="click: $root.logicalGraph().duplicateGraphConfig, eagleTooltip:'Duplicate'">
                                     <i class="material-symbols-outlined">content_copy</i>


### PR DESCRIPTION
fix bug in graph configurations table 
format the graph configurations table html file to make it more readable

## Summary by Sourcery

Make the "number of fields" input cell readonly and enhance the readability of the graph configurations table HTML by adding column annotations and reformatting the template.

Bug Fixes:
- Prevent editing of the number of fields cell by marking its input as readonly.

Enhancements:
- Add HTML comments above each table column for clarity.
- Reformat the graph_configurations_table.html file for improved readability.