### PR TITLE
Eagle 1543 - check graph when opening issues window

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4283,6 +4283,10 @@ export class Eagle {
     };
 
     showGraphErrors = (): void => {
+        //recheck the graph for errors, this is because we cannot rely on the fact that the graph has been checked.
+        //this is to ensure that when the user requests to see the graph errors, the information is up to date
+        this.checkGraph();
+
         if (this.graphWarnings().length > 0 || this.graphErrors().length > 0){
 
             // switch to graph errors mode

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -1004,7 +1004,7 @@ export class LogicalGraph {
             }
             ids.push(node.getId());
 
-            // loop over fields within graphs to check that all node ids are unique
+            // loop over fields within graphs to check that all field ids are unique
             for (const field of node.getFields()){
                 if (ids.includes(field.getId())){
                     const issue: Errors.Issue = Errors.ShowFix(
@@ -1019,7 +1019,7 @@ export class LogicalGraph {
             }
         }
 
-        // loop over graph edges to check that all node ids are unique
+        // loop over graph edges to check that all graph ids are unique
         for (const edge of graph.getEdges()){
             if (ids.includes(edge.getId())){
                 const issue: Errors.Issue = Errors.ShowFix(
@@ -1033,7 +1033,7 @@ export class LogicalGraph {
             ids.push(edge.getId());
         }
 
-        // loop over the graph configs to check that all node ids are unique
+        // loop over the graph configs to check that all graph config ids are unique
         for (const graphConfig of graph.getGraphConfigs()){
             if (ids.includes(graphConfig.getId())){
                 const issue: Errors.Issue = Errors.ShowFix(

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -991,7 +991,7 @@ export class LogicalGraph {
         // check that all node, edge, field, and config ids are unique
         const ids : string[] = [];
 
-        // loop over graph nodes
+        // loop over graph nodes to check that all node ids are unique
         for (const node of graph.getNodes()){
             if (ids.includes(node.getId())){
                 const issue: Errors.Issue = Errors.ShowFix(
@@ -1004,7 +1004,7 @@ export class LogicalGraph {
             }
             ids.push(node.getId());
 
-            // loop over fields within graphs
+            // loop over fields within graphs to check that all node ids are unique
             for (const field of node.getFields()){
                 if (ids.includes(field.getId())){
                     const issue: Errors.Issue = Errors.ShowFix(
@@ -1019,7 +1019,7 @@ export class LogicalGraph {
             }
         }
 
-        // loop over graph edges
+        // loop over graph edges to check that all node ids are unique
         for (const edge of graph.getEdges()){
             if (ids.includes(edge.getId())){
                 const issue: Errors.Issue = Errors.ShowFix(
@@ -1033,7 +1033,7 @@ export class LogicalGraph {
             ids.push(edge.getId());
         }
 
-        // loop over the graph configs
+        // loop over the graph configs to check that all node ids are unique
         for (const graphConfig of graph.getGraphConfigs()){
             if (ids.includes(graphConfig.getId())){
                 const issue: Errors.Issue = Errors.ShowFix(

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -8,6 +8,7 @@ import { Palette } from "./Palette";
 import { Repository } from "./Repository";
 import { UiModeSystem } from './UiModes';
 import { Utils } from './Utils';
+import { EagleConfig } from "./EagleConfig";
 
 export class SettingsGroup {
     private name : string;
@@ -290,6 +291,7 @@ export class Setting {
             }
         }
     }
+
 
     static readonly GITHUB_ACCESS_TOKEN_KEY: string = "GitHubAccessToken";
     static readonly GITLAB_ACCESS_TOKEN_KEY: string = "GitLabAccessToken";

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -8,7 +8,6 @@ import { Palette } from "./Palette";
 import { Repository } from "./Repository";
 import { UiModeSystem } from './UiModes';
 import { Utils } from './Utils';
-import { EagleConfig } from "./EagleConfig";
 
 export class SettingsGroup {
     private name : string;
@@ -291,7 +290,6 @@ export class Setting {
             }
         }
     }
-
 
     static readonly GITHUB_ACCESS_TOKEN_KEY: string = "GitHubAccessToken";
     static readonly GITLAB_ACCESS_TOKEN_KEY: string = "GitLabAccessToken";

--- a/templates/base.html
+++ b/templates/base.html
@@ -209,7 +209,7 @@
                             <button id="bottomTabGraphConfigurationsSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphConfigsTable}, click: function(){GraphConfigurationsTable.openTable()}, eagleTooltip: KeyboardShortcut.idToFullText('open_graph_configurations_table')">
                                 <i class="md-20 icon-config_table clickable"></i>
                             </button>
-                            <button id="bottomTabGraphIssuesSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphErrors}, click: function(){Setting.find(Setting.BOTTOM_WINDOW_MODE).setValue(Eagle.BottomWindowMode.GraphErrors)}, eagleTooltip: `Display Graph Issues`">
+                            <button id="bottomTabGraphIssuesSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphErrors}, click: function(){eagle.showGraphErrors()}, eagleTooltip: `Display Graph Issues`">
                                 <i class="md-20 icon-question_mark clickable"></i>
                             </button>
                         </div>


### PR DESCRIPTION
call check graph when the user requests to view the issues window.
this is because we cannot rely on the current graph validation system to be up to date. This means that when users request to see the errors in the graph, the information is definitely up to date.

## Summary by Sourcery

Ensure the graph is freshly checked before displaying issues by invoking checkGraph on issues window open and updating the UI button handler

Enhancements:
- Revalidate the graph when opening the issues window to ensure error information is up to date
- Update the Graph Issues tab button to invoke showGraphErrors() instead of directly switching modes

Chores:
- Clarify comment descriptions in LogicalGraph validation loops