### PR TITLE
EAGLE-1551: Graph loading fixes

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1089,8 +1089,10 @@ export class GraphRenderer {
             //checking if the node is inside of a construct, if so, fetching it's parent
             if(node.getParentId() != null){
                 const parentNode = eagle.logicalGraph().findNodeByIdQuiet(node.getParentId())
-                $('#'+parentNode.getId()).removeClass('transition')
-                GraphRenderer.NodeParentRadiusPreDrag = parentNode.getRadius()
+                if (parentNode !== null){
+                    $('#'+parentNode.getId()).removeClass('transition')
+                    GraphRenderer.NodeParentRadiusPreDrag = parentNode.getRadius()
+                }
             }
         }
 

--- a/src/GraphUpdater.ts
+++ b/src/GraphUpdater.ts
@@ -106,6 +106,7 @@ export class GraphUpdater {
 
             keyToId.set(node.key, newId);
             node.id = newId;
+            delete node.key; // remove key attribute
 
             // input app
             if (node.inputApplicationKey !== null){
@@ -128,11 +129,12 @@ export class GraphUpdater {
             } else {
                 node.parentId = null;
             }
+            delete node.group; // remove group attribute
         }
 
         // use map to update subject
         for (const node of graphObject["nodeDataArray"]){
-            if (typeof node.subject !== "undefined"){
+            if (typeof node.subject !== "undefined" && node.subject !== null){
                 node.subject = keyToId.get(node.subject);
             } else {
                 node.subjectId = null;
@@ -141,7 +143,6 @@ export class GraphUpdater {
 
         // use map to update edges
         for (const edge of graphObject["linkDataArray"]){
-
             if (!keyToId.has(edge.from)){
                 console.warn("GraphUpdater.updateKeysToIds() : Can't find Id for from key", edge.from, edge);
             }

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -837,7 +837,6 @@ export class LogicalGraph {
     findDepthById = (id: NodeId) : number => {
         const node = this.findNodeById(id);
         let parentId: NodeId = node.getParentId();
-        console.log("findDepthById(): nodeId = ", id, " parentId = ", parentId);
         let depth = 0;
         let iterations = 0;
 

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -837,6 +837,7 @@ export class LogicalGraph {
     findDepthById = (id: NodeId) : number => {
         const node = this.findNodeById(id);
         let parentId: NodeId = node.getParentId();
+        console.log("findDepthById(): nodeId = ", id, " parentId = ", parentId);
         let depth = 0;
         let iterations = 0;
 
@@ -848,7 +849,12 @@ export class LogicalGraph {
 
             iterations += 1;
             depth += 1;
-            parentId = this.findNodeById(parentId).getParentId();
+            const parent = this.findNodeById(parentId);
+            if (parent === null){
+                console.warn("findDepthById(): could not find parent node with id (", parentId, ")");
+                break;
+            }
+            parentId = parent.getParentId();
         }
 
         return depth;


### PR DESCRIPTION
I think I found the main issue. There were actually a few different errors.

There is a helper function that examines node JSON to try to determine the parent of the node. It looks at the "group", "parent" and "parentId" attributes in that order, exiting as soon as it sees the first one.

At some stage I changed the graph loading code from always depending on the "parentId" attribute, to instead re-use this helper function. Hoping to support older graphs.

However, the updateKeysToIds function I mentioned when we spoke updates the "parentId" attribute of all nodes, but crucially it did NOT remove the "group" attribute. So the "group" attribute was still being used as the parent in some situations. This caused all sorts of problems.

## Summary by Sourcery

Fix graph loading errors by removing legacy attributes and adding null checks for missing parent nodes.

Bug Fixes:
- Guard against null parent nodes in findDepthById and GraphRenderer to avoid runtime errors when a parent is missing
- Ensure subject IDs are only updated when the subject field is defined and non-null

Enhancements:
- Remove obsolete node.key and node.group properties in GraphUpdater to prevent stale group attributes from affecting parent resolution