### PR TITLE
EAGLE-1035: Added 'Display as JSON' option to each palette triple-dot menu

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1492,12 +1492,15 @@ export class Eagle {
         }
     }
 
-    displayObjectAsJson = (fileType: Eagle.FileType) : void => {
+    displayObjectAsJson = (fileType: Eagle.FileType, object: LogicalGraph | Palette) : void => {
         let jsonString: string;
         
         switch(fileType){
             case Eagle.FileType.Graph:
-                jsonString = LogicalGraph.toOJSJsonString(this.logicalGraph(), false);
+                jsonString = LogicalGraph.toOJSJsonString(object as LogicalGraph, false);
+                break;
+            case Eagle.FileType.Palette:
+                jsonString = Palette.toOJSJsonString(object as Palette);
                 break;
             default:
                 console.error("displayObjectAsJson(): Un-handled fileType", fileType);

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -245,7 +245,7 @@ export class KeyboardShortcut {
         new KeyboardShortcut({
             id: "display_graph_as_json",
             text: "Display Graph As Json",
-            run: (eagle): void => {eagle.displayObjectAsJson(Eagle.FileType.Graph);}
+            run: (eagle): void => {eagle.displayObjectAsJson(Eagle.FileType.Graph, eagle.logicalGraph());}
         }),
         // load/save
         // TODO: this one (open_graph_from_repo) does almost nothing! we should have a real modal

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -163,7 +163,7 @@
                         </span>
                         <a class="dropdown-item" id="createNewGraphFromUrl" href="#" data-bind="click: function(){loadFileFromUrl(Eagle.FileType.Graph)}">Open from URL</a>
                         <div class="dropdown-divider"></div>
-                        <a class="dropdown-item" id="displayGraphAsJson" href="#" data-bind="click: function(){displayObjectAsJson(Eagle.FileType.Graph);}">Display As Json</a>
+                        <a class="dropdown-item" id="displayGraphAsJson" href="#" data-bind="click: function(){displayObjectAsJson(Eagle.FileType.Graph, eagle.logicalGraph());}">Display As Json</a>
                         <a class="dropdown-item" id="screenshotGraph" href="#" data-bind="click: saveGraphScreenshot">Screenshot</a>
                         <a class="dropdown-item" id="validateGraph" href="#" data-bind="click: validateGraph">Validate</a>
                     <!-- /ko -->

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -59,6 +59,7 @@
                     <!-- /ko -->
                     <a href="#" data-bind="click: $data.copyUrl"><span>Copy URL</span></a>
                     <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show ModelData</span></a>
+                    <a href="#" data-bind="click: function(){eagle.displayObjectAsJson(Eagle.FileType.Palette, $data);}"><span>Display as JSON</span></a>
                 </div>
                 <div class="accordion-item paletteWrapper" data-bind="attr: {'data-palette-index': $index}, event: { dragover: SideWindow.nodeDragOver, drop: $root.nodeDropPalette }">
                     <div class="accordion-header">


### PR DESCRIPTION
## Summary by Sourcery

Unify the JSON display functionality by updating displayObjectAsJson to handle both graphs and palettes, and add a “Display as JSON” option to the palette menu with corresponding UI and shortcut updates.

New Features:
- Add “Display as JSON” option to each palette menu item
- Enable displaying palette data as JSON alongside existing graph JSON display

Enhancements:
- Refactor displayObjectAsJson method to accept a generic LogicalGraph or Palette object
- Update keyboard shortcut and navbar bindings to pass the appropriate object to displayObjectAsJson