### PR TITLE
EAGLE-882: Add undo snapshot after component update

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4642,6 +4642,13 @@ export class Eagle {
 
             Utils.showNotification("Success", "Successfully updated " + updatedNodes.length + " component(s): " + nodeNames.join(", "), "success");
         }
+
+        // make undo snapshot, recheck graph, mark as modified etc
+        this.logicalGraph.valueHasMutated();
+        this.logicalGraph().fileInfo().modified = true;
+        this.logicalGraph().fileInfo.valueHasMutated();
+        this.checkGraph();
+        this.undo().pushSnapshot(this, "Check for Component Updates");
     }
 
     findPaletteContainingNode = (nodeId: string): Palette => {


### PR DESCRIPTION
After component update:
- flag graph as modified
- recheck for correctness
- create undo snapshot

## Summary by Sourcery

After updating components, flag the graph as modified, recheck its correctness, and create an undo snapshot to capture the state.

Enhancements:
- Record an undo snapshot after component updates
- Flag the logical graph as modified and trigger value mutation
- Revalidate the graph for correctness after component updates