### PR TITLE
EAGLE-1555: Allow users to copy a url that represents a repository

### DIFF
--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -67,6 +67,16 @@ export class Repositories {
         return Repository.Service.Unknown;
     }
 
+    static generateUrl(repository: Repository): string {
+        let url = window.location.origin;
+
+        url += "/?service=" + repository.service;
+        url += "&repository=" + repository.name;
+        url += "&branch=" + repository.branch;
+
+        return url;
+    }
+
     // use a custom modal to ask user for repository service and url at the same time
     addCustomRepository = async () => {
         let customRepository: Repository;
@@ -78,7 +88,7 @@ export class Repositories {
         }
 
         if (customRepository.name.trim() == ""){
-            Utils.showUserMessage("Error", "Repository name is empty!");
+            console.log("Error", "Repository name is empty!");
             return;
         }
 
@@ -91,6 +101,13 @@ export class Repositories {
     };
 
     _addCustomRepository = async (repositoryService: Repository.Service, repositoryName: string, repositoryBranch: string) => {
+        // check if repository already exists
+        const existingRepo = Repositories.get(repositoryService, repositoryName, repositoryBranch);
+        if (existingRepo !== null) {
+            console.log("Repository already exists!");
+            return;
+        }
+
         // create repo
         const newRepo = new Repository(repositoryService, repositoryName, repositoryBranch, false);
 
@@ -121,6 +138,19 @@ export class Repositories {
 
         this._removeCustomRepository(repository);
     };
+
+    copyRepository = (repository: Repository): void => {
+        console.log("copyRepository()", repository.getNameAndBranch());
+
+        // build url
+        const url: string = Repositories.generateUrl(repository);
+ 
+        // copy to clipboard
+        navigator.clipboard.writeText(url);
+
+        // notification
+        Utils.showNotification("Repository URL", "Copied to clipboard", "success");
+    }
 
     private _removeCustomRepository = (repository : Repository) : void => {
 

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -117,6 +117,11 @@ export class Repository {
     // expand all the directories along a given path
     expandPath = async (path: string) : Promise<void> => {
         return new Promise(async(resolve, reject) => {
+            if (path === ""){
+                resolve();
+                return;
+            }
+
             let pointer: Repository | RepositoryFolder = this;
             const pathParts: string[] = path.split('/');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,8 +312,8 @@ async function autoLoad() {
     const serviceIsGit: boolean = [Repository.Service.GitHub, Repository.Service.GitLab].includes(realService);
 
     // skip empty strings
-    if (serviceIsGit && (repository === "" || branch === "" || filename === "")){
-        console.log("No auto load. Repository, branch or filename not specified");
+    if (serviceIsGit && (repository === "" || branch === "")){
+        console.log("No auto load. Repository or branch not specified");
         return;
     }
 
@@ -323,11 +323,17 @@ async function autoLoad() {
         return;
     }
 
-    // load
+    // decide what to do based on the url
     if (realService === Repository.Service.Url){
         Repositories.selectFile(new RepositoryFile(new Repository(realService, "", "", false), "", url));
     } else {
-        Repositories.selectFile(new RepositoryFile(new Repository(realService, repository, branch, false), path, filename));
+        if (filename === ""){
+            // add repository to repository list
+            await eagle.repositories()._addCustomRepository(realService, repository, branch);
+        } else {
+            // load file
+            Repositories.selectFile(new RepositoryFile(new Repository(realService, repository, branch, false), path, filename));
+        }
     }
 
     // if developer setting enabled, fetch the repository that this graph belongs to (if the repository is in the list of known repositories)

--- a/static/base.css
+++ b/static/base.css
@@ -1855,6 +1855,10 @@ select.form-control{
     visibility: visible;
 }
 
+#repositoryList ul.repositories .repoContainer:hover .repo-actions i.material-symbols-outlined.md-18 {
+    visibility: visible;
+}
+
 #nodeList ul.nodes {
     list-style-type: none;
     padding: 0px 20px;

--- a/templates/repository.html
+++ b/templates/repository.html
@@ -19,16 +19,19 @@
             <!-- /ko -->
             <!-- /ko -->
         </div>
-        <div class="col-10 col">
+        <div class="col-9 col">
             <a href="" data-bind="attr: {id: htmlId}, click: select, eagleTooltip: '|||' +  name + ' (' + branch + ') |||'" data-bs-placement="left">
                 <span data-bind="text: name + ' (' + branch + ')'"></span>
             </a>
         </div>
-        <!-- ko ifnot: isBuiltIn -->
-        <div class="col col-1">
-            <i class="material-symbols-outlined filled md-18 interactive iconHoverEffect" data-bind="click: $root.repositories().removeCustomRepository, attr: {id: htmlId() + '-eject'}">eject</i>
+        
+        <div class="col col-2 repo-actions">
+            <!-- ko ifnot: isBuiltIn -->
+                <i class="material-symbols-outlined filled md-18 interactive iconHoverEffect" data-bind="click: $root.repositories().removeCustomRepository, attr: {id: htmlId() + '-eject'}">eject</i>
+            <!-- /ko -->
+            <i class="material-symbols-outlined md-18 interactive iconHoverEffect" data-bind="click: $root.repositories().copyRepository, attr: {id: htmlId() + '-copy'}">content_copy</i>
         </div>
-        <!-- /ko -->
+        
         <!-- ko if: expanded -->
         <ul class="folders" data-bind="foreach: folders">
             <li>


### PR DESCRIPTION
Hid 'eject' buttons next to repos until hover.
Added new button for copy url.
Updated URL parser to add new repositories. URLs like this: http://localhost:8888/?service=GitHub&repository=james-strauss-uwa/eagle-test&branch=master will add a repository to EAGLE.