### PR TITLE
EAGLE-1572: Obey SHOW_GRAPH_WARNINGS setting when colouring graph edges

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -2298,6 +2298,7 @@ export class GraphRenderer {
 
     static edgeGetStrokeColor(edge: Edge) : string {
         const eagle = Eagle.getInstance();
+        const showGraphWarnings = Setting.findValue(Setting.SHOW_GRAPH_WARNINGS);
 
         let normalColor: string = EagleConfig.getColor('edgeDefault');
         let selectedColor: string = EagleConfig.getColor('edgeDefaultSelected');
@@ -2318,12 +2319,12 @@ export class GraphRenderer {
         // const linkValid : Errors.Validity = Edge.isValid(eagle,false, edge.getId(), edge.getSrcNodeId(), edge.getSrcPortId(), edge.getDestNodeId(), edge.getDestPortId(), edge.isLoopAware(), edge.isClosesLoop(), false, false, {errors:[], warnings:[]});
         const linkValid : Errors.Validity = Utils.worstEdgeError(edge.getErrorsWarnings());
 
-        if (linkValid === Errors.Validity.Error || linkValid === Errors.Validity.Impossible){
+        if ((linkValid === Errors.Validity.Error || linkValid === Errors.Validity.Impossible) && showGraphWarnings !== Setting.ShowErrorsMode.None){
             normalColor = EagleConfig.getColor('edgeInvalid');
             selectedColor = EagleConfig.getColor('edgeInvalidSelected');
         }
 
-        if (linkValid === Errors.Validity.Warning){
+        if (linkValid === Errors.Validity.Warning && showGraphWarnings === Setting.ShowErrorsMode.Warnings){
             normalColor = EagleConfig.getColor('edgeWarning');
             selectedColor = EagleConfig.getColor('edgeWarningSelected');
         }


### PR DESCRIPTION
Fixed bug where edge warnings and errors would be shown even when the setting to show them was disabled.