### PR TITLE
EAGLE-1573: Removed the pencil icon to edit edges in the inspector

### DIFF
--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -322,7 +322,6 @@ export class Setting {
     static readonly ALLOW_INVALID_EDGES : string = "AllowInvalidEdges";
     static readonly ALLOW_COMPONENT_EDITING : string = "AllowComponentEditing";
     static readonly ALLOW_READONLY_PALETTE_EDITING : string = "AllowReadonlyPaletteEditing";
-    static readonly ALLOW_EDGE_EDITING : string = "AllowEdgeEditing";
     static readonly SHOW_NON_CONFIG_PARAMETERS : string = "ShowNonConfigParameters";
     static readonly FILTER_NODE_SUGGESTIONS : string = "AutoSuggestDestinationNodes";
 
@@ -453,7 +452,6 @@ const settings : SettingsGroup[] = [
             new Setting(true, "Allow Graph Editing", Setting.ALLOW_GRAPH_EDITING, "Allow the user to edit and create graphs.", false, Setting.Type.Boolean, false, false, true, true, true),
             new Setting(true, "Allow Palette Editing", Setting.ALLOW_PALETTE_EDITING, "Allow the user to edit palettes.", false, Setting.Type.Boolean, false, false, false, true, true),
             new Setting(true, "Allow Readonly Palette Editing", Setting.ALLOW_READONLY_PALETTE_EDITING, "Allow the user to modify palettes that would otherwise be readonly.", false, Setting.Type.Boolean,false,false,false,false,true),
-            new Setting(true, "Allow Edge Editing", Setting.ALLOW_EDGE_EDITING, "Allow the user to edit edge attributes.", false, Setting.Type.Boolean, false, false,false, false, true),
             new Setting(true, "Filter Node Suggestions", Setting.FILTER_NODE_SUGGESTIONS, "Filter Node Options When Drawing Edges Into Empty Space", false, Setting.Type.Boolean,true,true,true,true,false),
             new Setting(false, "STUDENT_SETTINGS_MODE", Setting.STUDENT_SETTINGS_MODE, "Mode disabling setting editing for students.", false, Setting.Type.Boolean, true, false,false, false, false),
             new Setting(true, "Value Editing", Setting.VALUE_EDITING_PERMS, "Set which values are allowed to be edited.", false, Setting.Type.Select, Setting.ValueEditingPermission.ConfigOnly,Setting.ValueEditingPermission.Normal,Setting.ValueEditingPermission.Normal,Setting.ValueEditingPermission.ReadOnly,Setting.ValueEditingPermission.ReadOnly, Object.values(Setting.ValueEditingPermission)),

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -183,11 +183,6 @@
                                     <!-- /ko -->
                                 </div>
                                 <div class="col-8 col text-right">
-                                    <!-- ko if: Setting.findValue(Setting.ALLOW_EDGE_EDITING) -->
-                                        <button type="button" class="btn btn-secondary btn-sm" data-bind="click: $root.editSelectedEdge, eagleTooltip: KeyboardShortcut.idToFullText('modify_selected_edge')">
-                                            <i class="material-symbols-outlined md-24 clickable iconHoverEffect">edit</i>
-                                        </button>
-                                    <!-- /ko -->
                                     <!-- ko if: Setting.findValue(Setting.ALLOW_GRAPH_EDITING) -->
                                         <button  type="button" class="btn btn-secondary btn-sm" data-bind="click: function(){$root.deleteSelection(false,false,false);}, eagleTooltip: KeyboardShortcut.idToFullText('delete_selection')">
                                             <i class="material-symbols-outlined md-24 clickable iconHoverEffect">delete</i>


### PR DESCRIPTION
Removed the pencil icon to edit edges in the inspector.
Removed now unused 'allow_edge_editing' setting.

## Summary by Sourcery

Remove edge editing UI and clean up obsolete edge editing setting

Enhancements:
- Remove the pencil icon for editing edges in the inspector
- Delete the now-unused ALLOW_EDGE_EDITING setting and its configuration entry