### PR TITLE
palette descriptions more utilised

### DIFF
--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -366,7 +366,7 @@ export class FileInfo {
             text = "<p>" + this._repositoryService() + " : " + this._repositoryName() + ((this._repositoryBranch() == "") ? "" : ("(" + this._repositoryBranch() + ")")) + " : " + this._path() + "/" + this._name() + "</p>";
         }
 
-        return "<p><h5>" + title + "<h5><p><p>" + text + "</p>";
+        return "<p><h5>" + title + "<h5><p><p>" + text + "</p><p>"+this.renderedShortDescription() + "</p><p>" + this.renderedDetailedDescription() + "</p></p>";
     }
 
     getText = () : string => {

--- a/templates/palettes.html
+++ b/templates/palettes.html
@@ -20,6 +20,7 @@
             <div class="paletteCardWrapper">
                 <button type="button" class="material-symbols-outlined md-18 dropdown-toggle dropdown-control paletteTripleDot iconHoverEffect" data-bs-toggle="dropdown" >more_vert</button>
                 <div class="dropdown-menu dropdown-area">
+                    <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show Palette Info</span></a>
                     <a href="#" data-bind="click: $root.selectAllInPalette" data-html="true"><span>Select All</span></a>
                     <!-- ko ifnot: $data.fileInfo().builtIn -->
                     <a href="#" data-bind="click: $root.closePalette" data-html="true"><span>Remove</span></a>
@@ -38,7 +39,6 @@
                     <a href="#" data-bind="click: function(){$data.setSearchExclude(true)}"><span>Exclude From Search Filter</span></a>
                     <!-- /ko -->
                     <a href="#" data-bind="click: $data.copyUrl"><span>Copy URL</span></a>
-                    <a href="#" data-bind="click: function(){Utils.showModelDataModal('Palette Info', fileInfo());}"><span>Show ModelData</span></a>
                     <a href="#" data-bind="click: function(){eagle.displayObjectAsJson(Eagle.FileType.Palette, $data);}"><span>Display as JSON</span></a>
                 </div>
                 <div class="accordion-item paletteWrapper" data-bind="attr: {'data-palette-index': $index}, event: { dragover: SideWindow.nodeDragOver, drop: $root.nodeDropPalette }">


### PR DESCRIPTION
edited the "show modeldata" option to instead be "show palette info" and moved it to the top of the triple dot menu.
also showing both the rendered short and long description in the palettes' eagle tooltips.

## Summary by Sourcery

Enhance palette UI by enriching the info modal with palette descriptions and improving the context menu entry

Enhancements:
- Include both short and detailed rendered descriptions in the palette info popup
- Rename "Show ModelData" to "Show Palette Info" and move it to the top of the palette card context menu