### PR TITLE
Eagle 1568 - new status bar entries and selection refinement

### DIFF
--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1054,13 +1054,13 @@ export class GraphRenderer {
 
         // select handlers
         if(node !== null && event.button != 1 && !event.shiftKey){
-            //double click has highest priority, select only this node if it is a contruct
-            if(GraphRenderer.dragSelectionDoubleClick) {
+            //double click and alt + clicking has highest priority
+            if(GraphRenderer.dragSelectionDoubleClick || event.altKey) {
                 eagle.setSelection(node, Eagle.FileType.Graph);
             }   
 
-            //check for alt clicking, if so, add the target node and its children to the selection
-            else if(event.button != 2 && !event.altKey&&node.isGroup() && !eagle.objectIsSelected(node)){
+            //check that we are not alt + clicking, add the target node and its children to the selection
+            else if(event.button != 2 && !event.altKey && node.isGroup() && !eagle.objectIsSelected(node)){
                 GraphRenderer.selectNodeAndChildren(node,GraphRenderer.shiftSelect)
             }
 

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1055,7 +1055,7 @@ export class GraphRenderer {
         // select handlers
         if(node !== null && event.button != 1 && !event.shiftKey){
             //double click has highest priority, select only this node if it is a contruct
-            if(GraphRenderer.dragSelectionDoubleClick && node.isGroup()) {
+            if(GraphRenderer.dragSelectionDoubleClick) {
                 eagle.setSelection(node, Eagle.FileType.Graph);
             }   
 

--- a/src/StatusEntry.ts
+++ b/src/StatusEntry.ts
@@ -25,6 +25,7 @@ export class StatusEntry {
     }
     
     static childOfConstructIsSelected():boolean {
+        // Check if at least one child of a construct is selected, but no construct without parent
         const selectedObjects = Eagle.getInstance().getOutermostSelectedNodes();
 
         if(selectedObjects.length > 0){
@@ -35,6 +36,7 @@ export class StatusEntry {
     }
 
     static multiSelectionNoConstructRelatives():boolean {
+        //check if more than one object is selected and no node is selected that is a construct or has a parent
         const selectedObjects = Eagle.getInstance().selectedObjects();
 
         if(selectedObjects.length > 1){

--- a/src/StatusEntry.ts
+++ b/src/StatusEntry.ts
@@ -1,6 +1,7 @@
 import { Eagle } from './Eagle';
 import { KeyboardShortcut } from './KeyboardShortcut';
 import { Setting } from './Setting';
+import { Node } from './Node';
 
 export class StatusEntry {
     action:string;
@@ -22,6 +23,16 @@ export class StatusEntry {
 
         return false;
     }
+    
+    static childOfConstructIsSelected():boolean {
+        const selectedObjects = Eagle.getInstance().selectedObjects();
+
+        if(selectedObjects.length > 0){
+            return selectedObjects.some(obj => obj instanceof Node && (obj as Node).hasParent());
+        }
+
+        return false;
+    }
 
     static getStatusEntries() : StatusEntry[] {
         return [
@@ -38,14 +49,16 @@ export class StatusEntry {
             new StatusEntry('[Right Click]',' on Objects in the graph for more options.', Eagle.getInstance().selectedObjects().length > 0),
             new StatusEntry(KeyboardShortcut.idToKeysText('duplicate_selection', true),' duplicate selection.', Eagle.getInstance().selectedObjects().length > 0),
             new StatusEntry(KeyboardShortcut.idToKeysText('delete_selection', true),' delete selection.', Eagle.getInstance().selectedObjects().length > 0),
-            //node is selected
+            //a node is selected
             new StatusEntry(KeyboardShortcut.idToKeysText('open_parameter_table', true),' open fields table.', Eagle.getInstance().selectedNode() != null && Setting.findValue(Setting.ALLOW_GRAPH_EDITING)),
             //more than one thing is selected
             new StatusEntry('[Shift + Drag]',' Box select objects.', Eagle.getInstance().selectedObjects().length >1),
             new StatusEntry('[Shift + Ctrl + Drag]',' Box deselect objects.', Eagle.getInstance().selectedObjects().length >1),
             new StatusEntry(KeyboardShortcut.idToKeysText('create_construct_from_selection', true),' Construct from selection.', Eagle.getInstance().selectedObjects().length >1),
             //construct is selected
-            new StatusEntry('[Alt + click]',' Select construct + children.', this.constructIsSelected()),
+            new StatusEntry('[Alt + Click]',' Select construct without children.', this.constructIsSelected()),
+            //at least one child of a construct is selected
+            new StatusEntry('[Ctrl + Drag]',' move selection without resizing constructs.', this.childOfConstructIsSelected()),
             //always
         ];
     }

--- a/src/StatusEntry.ts
+++ b/src/StatusEntry.ts
@@ -67,7 +67,7 @@ export class StatusEntry {
             new StatusEntry(KeyboardShortcut.idToKeysText('create_construct_from_selection', true),' Construct from selection.', Eagle.getInstance().selectedObjects().length >1),
             new StatusEntry('[Shift + Alt + Click]',' toggle selection of object', Eagle.getInstance().selectedObjects().length >1),
             //construct is selected
-            new StatusEntry('[Alt + Click]',' Select construct without children.', this.constructIsSelected()),
+            new StatusEntry('[Double Click] or [Alt + Click]',' Select specific object.', this.constructIsSelected()),
             //at least one child of a construct, but no construct without parent is selected
             new StatusEntry('[Ctrl + Drag]',' move selection without resizing constructs.', this.childOfConstructIsSelected()),
             //multi selection but no construct selected

--- a/src/StatusEntry.ts
+++ b/src/StatusEntry.ts
@@ -15,20 +15,30 @@ export class StatusEntry {
     }
 
     static constructIsSelected():boolean {
-        const selectedNode = Eagle.getInstance().selectedNode();
+        const selectedObjects = Eagle.getInstance().selectedObjects();
 
-        if(selectedNode != null){
-            return selectedNode.isConstruct();
+        if(selectedObjects.length > 0){
+            return selectedObjects.some(obj => obj instanceof Node && (obj as Node).isConstruct());
         }
 
         return false;
     }
     
     static childOfConstructIsSelected():boolean {
-        const selectedObjects = Eagle.getInstance().selectedObjects();
+        const selectedObjects = Eagle.getInstance().getOutermostSelectedNodes();
 
         if(selectedObjects.length > 0){
             return selectedObjects.some(obj => obj instanceof Node && (obj as Node).hasParent());
+        }
+
+        return false;
+    }
+
+    static multiSelectionNoConstructRelatives():boolean {
+        const selectedObjects = Eagle.getInstance().selectedObjects();
+
+        if(selectedObjects.length > 1){
+            return selectedObjects.every(obj => { if(obj instanceof Node){ return (!(obj as Node).isConstruct() && !(obj as Node).hasParent()); }else { return true; } });
         }
 
         return false;
@@ -46,19 +56,21 @@ export class StatusEntry {
             //No Graph loaded or created
             new StatusEntry(KeyboardShortcut.idToKeysText('new_graph', true),' new graph.', Eagle.getInstance().logicalGraph().fileInfo().name === ""),
             //something is selected
-            new StatusEntry('[Right Click]',' on Objects in the graph for more options.', Eagle.getInstance().selectedObjects().length > 0),
             new StatusEntry(KeyboardShortcut.idToKeysText('duplicate_selection', true),' duplicate selection.', Eagle.getInstance().selectedObjects().length > 0),
             new StatusEntry(KeyboardShortcut.idToKeysText('delete_selection', true),' delete selection.', Eagle.getInstance().selectedObjects().length > 0),
             //a node is selected
+            new StatusEntry('[Right Click]',' on Objects in the graph for more options.', Eagle.getInstance().selectedNode() != null),
             new StatusEntry(KeyboardShortcut.idToKeysText('open_parameter_table', true),' open fields table.', Eagle.getInstance().selectedNode() != null && Setting.findValue(Setting.ALLOW_GRAPH_EDITING)),
             //more than one thing is selected
-            new StatusEntry('[Shift + Drag]',' Box select objects.', Eagle.getInstance().selectedObjects().length >1),
-            new StatusEntry('[Shift + Ctrl + Drag]',' Box deselect objects.', Eagle.getInstance().selectedObjects().length >1),
             new StatusEntry(KeyboardShortcut.idToKeysText('create_construct_from_selection', true),' Construct from selection.', Eagle.getInstance().selectedObjects().length >1),
+            new StatusEntry('[Shift + Alt + Click]',' toggle selection of object', Eagle.getInstance().selectedObjects().length >1),
             //construct is selected
             new StatusEntry('[Alt + Click]',' Select construct without children.', this.constructIsSelected()),
-            //at least one child of a construct is selected
+            //at least one child of a construct, but no construct without parent is selected
             new StatusEntry('[Ctrl + Drag]',' move selection without resizing constructs.', this.childOfConstructIsSelected()),
+            //multi selection but no construct selected
+            new StatusEntry('[Shift + Drag]',' Box select objects.', this.multiSelectionNoConstructRelatives()),
+            new StatusEntry('[Shift + Ctrl + Drag]',' Box deselect objects.', this.multiSelectionNoConstructRelatives()),
             //always
         ];
     }


### PR DESCRIPTION
added info to status bar
ctrl + drag = move children without resizing constructs
shift + alt + click = toggle selection of object in multi selection
alt + click or double click = select specific object
changed double click behaviour to select any single node (previously only worked for constructs)
changed alt click behaviour to be the same as double click

multiple changes to when which status bar entry is visible

## Summary by Sourcery

Provide status bar guidance for new mouse shortcuts, unify selection behavior for alt+click and double-click, and refine when status entries appear based on selection context

New Features:
- Add ctrl+drag status bar hint for moving selection without resizing constructs
- Add shift+alt+click status bar hint to toggle selection in multi-selection
- Add alt+click status bar hint for selecting a specific object

Enhancements:
- Unify alt+click and double-click into a single-node selection action
- Refine status bar visibility logic by introducing childOfConstructIsSelected and multiSelectionNoConstructRelatives predicates