### PR TITLE
reducing scroll sensitivity of types dropdown in parameter table

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -62,7 +62,6 @@ import { Utils } from './Utils';
 import { GraphUpdater } from "./GraphUpdater";
 import { GraphConfigurationsTable } from "./GraphConfigurationsTable";
 import { versions } from "./Versions";
-import { event } from "jquery";
 
 
 export class Eagle {

--- a/templates/node_parameter_table.html
+++ b/templates/node_parameter_table.html
@@ -370,7 +370,7 @@
                                                                         arrow_drop_down
                                                                     </span>
                                                                 </button>
-                                                                <ul class="dropdown-menu dropdown-menu-end dropdown-area" data-bind="event:{mousewheel: $root.slowScroll},attr:{id:'typeFor_'+$data.getId()},clickBubble:false">
+                                                                <ul class="dropdown-menu dropdown-menu-end dropdown-area" data-bind="event:{mousewheel: $root.slowScroll}, attr:{id:'typeFor_'+$data.getId()}">
                                                                     <!-- ko foreach:$root.types() -->
                                                                         <a class="dropdown-item" data-bind="text:$data, click:function(){$root.tableDropdownClick($data, $parent);}"></a>
                                                                     <!-- /ko -->


### PR DESCRIPTION
created a function which we can trigger on scrollable elements that need to scroll slower.

## Summary by Sourcery

Add reduced-scroll sensitivity to type-selection dropdowns in the node parameter table by introducing a slowScroll handler and binding it to mousewheel events; refine modal event handler signatures and prevent unwanted click propagation in dropdown menus.

Enhancements:
- Introduce slowScroll method in Eagle to halve mousewheel scroll delta on scrollable elements
- Bind slowScroll to mousewheel events on parameter table type dropdown menus for smoother vertical scrolling
- Disable click event bubbling on type dropdown menus to avoid unintended interactions
- Add explicit event parameter typings to Bootstrap modal shown and header mousedown handlers