### PR TITLE
EAGLE-1590: "edgeIds" array in field JSON empty in files saved to disk

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -363,6 +363,10 @@ export class Field {
         return this.edges().get(id);
     }
 
+    getNumEdges = () : number => {
+        return this.edges().size;
+    }
+
     getErrorsWarnings : ko.PureComputed<Errors.ErrorsWarnings> = ko.pureComputed(() => {
         const errorsWarnings : Errors.ErrorsWarnings = {warnings: [], errors: []};
         
@@ -447,6 +451,8 @@ export class Field {
         this.id(null);
         this.isEvent(false);
         this.node(null);
+        this.edges().clear();
+
         return this;
     }
 
@@ -460,6 +466,10 @@ export class Field {
         f.encoding(this.encoding());
         f.isEvent(this.isEvent());
         f.node(this.node());
+        f.edges(new Map<EdgeId, Edge>());
+        for (const edge of this.edges().values()) {
+            f.edges().set(edge.getId(), edge.clone());
+        }
         return f;
     }
 
@@ -482,6 +492,7 @@ export class Field {
         f.encoding = this.encoding;
         f.isEvent = this.isEvent;
         f.node = this.node;
+        f.edges = this.edges;
 
         return f;
     }

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -506,6 +506,16 @@ export class LogicalGraph {
         return this.nodes().get(id);
     }
 
+    // NOTE: only returns the first node found with the given name, names are not unique
+    getNodeByName = (name: string): Node | undefined => {
+        for (const node of this.nodes().values()){
+            if (node.getName() === name){
+                return node;
+            }
+        }
+        return undefined;
+    }
+
     addEdgeComplete = (edge : Edge) => {
         this.edges().set(edge.getId(), edge);
         this.edges.valueHasMutated();


### PR DESCRIPTION
Fixed bug in Field.clone() which meant the 'edgeIds' array in Field JSON was empty when LGs written to file.