### PR TITLE
Eagle 1550 - Hide Data Node Names In Graph

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1298,6 +1298,10 @@ export class Node {
         return CategoryData.getCategoryData(this.category()).icon;
     }
 
+    graphNodeTitleIsVisible = () : boolean => {
+        return this.isData() && Setting.findValue(Setting.SHOW_DATA_NODE_TITLES);
+    }
+
     //get icon color
     getGraphIconAttr = () : string => {
         const attr = "font-size: 44px; color:" + CategoryData.getCategoryData(this.category()).color

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1298,8 +1298,8 @@ export class Node {
         return CategoryData.getCategoryData(this.category()).icon;
     }
 
-    graphNodeTitleIsVisible = () : boolean => {
-        return this.isData() && Setting.findValue(Setting.SHOW_DATA_NODE_TITLES);
+    graphNodeTitleIsHidden = () : boolean => {
+        return this.isData() && Setting.findValue(Setting.HIDE_DATA_NODE_TITLES);
     }
 
     //get icon color

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -354,6 +354,7 @@ export class Setting {
     static readonly SNAP_TO_GRID_SIZE: string = "SnapToGridSize";
     static readonly SHOW_GRAPH_WARNINGS: string = "ShowInspectorWarnings";
     static readonly SHOW_ALL_CATEGORY_OPTIONS: string = "ShowAllCategoryOptions";
+    static readonly SHOW_DATA_NODE_TITLES: string = "ShowDataNodeTitles";
 
     static readonly ALLOW_MODIFIED_GRAPH_TRANSLATION: string = "AllowModifiedGraphTranslation";
     static readonly FETCH_REPOSITORY_FOR_URLS: string = "FetchRepositoryForUrls";
@@ -439,6 +440,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Bottom Window Visibility", Setting.BOTTOM_WINDOW_VISIBLE, "saving the visibility state of the bottom window", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(false, "Bottom Window Mode/Tab", Setting.BOTTOM_WINDOW_MODE, "saving the mode/tab of the bottom window", true, Setting.Type.Number, 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable'),
             new Setting(false, "Graph and Object Inspector", Setting.INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph object inspector", true, Setting.Type.Boolean, false, false, false, false, false),
+            new Setting(false, "Visibility of data node titles", Setting.SHOW_DATA_NODE_TITLES, "saving the visibility of the data node titles", true, Setting.Type.Boolean, true, true, true, true, true),
         ]
     ),
     new SettingsGroup(

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -354,7 +354,7 @@ export class Setting {
     static readonly SNAP_TO_GRID_SIZE: string = "SnapToGridSize";
     static readonly SHOW_GRAPH_WARNINGS: string = "ShowInspectorWarnings";
     static readonly SHOW_ALL_CATEGORY_OPTIONS: string = "ShowAllCategoryOptions";
-    static readonly HIDE_DATA_NODE_TITLES: string = "ShowDataNodeTitles";
+    static readonly HIDE_DATA_NODE_TITLES: string = "HideDataNodeTitles";
 
     static readonly ALLOW_MODIFIED_GRAPH_TRANSLATION: string = "AllowModifiedGraphTranslation";
     static readonly FETCH_REPOSITORY_FOR_URLS: string = "FetchRepositoryForUrls";
@@ -440,7 +440,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Bottom Window Visibility", Setting.BOTTOM_WINDOW_VISIBLE, "saving the visibility state of the bottom window", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(false, "Bottom Window Mode/Tab", Setting.BOTTOM_WINDOW_MODE, "saving the mode/tab of the bottom window", true, Setting.Type.Number, 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable'),
             new Setting(false, "Graph and Object Inspector", Setting.INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph object inspector", true, Setting.Type.Boolean, false, false, false, false, false),
-            new Setting(false, "Visibility of data node titles", Setting.HIDE_DATA_NODE_TITLES, "saving the visibility of the data node titles", true, Setting.Type.Boolean, true, true, true, true, true),
+            new Setting(false, "Visibility of data node titles", Setting.HIDE_DATA_NODE_TITLES, "saving the visibility of the data node titles", true, Setting.Type.Boolean, false, false, false, false, false),
         ]
     ),
     new SettingsGroup(

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -354,7 +354,7 @@ export class Setting {
     static readonly SNAP_TO_GRID_SIZE: string = "SnapToGridSize";
     static readonly SHOW_GRAPH_WARNINGS: string = "ShowInspectorWarnings";
     static readonly SHOW_ALL_CATEGORY_OPTIONS: string = "ShowAllCategoryOptions";
-    static readonly SHOW_DATA_NODE_TITLES: string = "ShowDataNodeTitles";
+    static readonly HIDE_DATA_NODE_TITLES: string = "ShowDataNodeTitles";
 
     static readonly ALLOW_MODIFIED_GRAPH_TRANSLATION: string = "AllowModifiedGraphTranslation";
     static readonly FETCH_REPOSITORY_FOR_URLS: string = "FetchRepositoryForUrls";
@@ -440,7 +440,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Bottom Window Visibility", Setting.BOTTOM_WINDOW_VISIBLE, "saving the visibility state of the bottom window", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(false, "Bottom Window Mode/Tab", Setting.BOTTOM_WINDOW_MODE, "saving the mode/tab of the bottom window", true, Setting.Type.Number, 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable', 'ParameterTable'),
             new Setting(false, "Graph and Object Inspector", Setting.INSPECTOR_COLLAPSED_STATE, "saving the collapsed state of the graph object inspector", true, Setting.Type.Boolean, false, false, false, false, false),
-            new Setting(false, "Visibility of data node titles", Setting.SHOW_DATA_NODE_TITLES, "saving the visibility of the data node titles", true, Setting.Type.Boolean, true, true, true, true, true),
+            new Setting(false, "Visibility of data node titles", Setting.HIDE_DATA_NODE_TITLES, "saving the visibility of the data node titles", true, Setting.Type.Boolean, true, true, true, true, true),
         ]
     ),
     new SettingsGroup(

--- a/static/base.css
+++ b/static/base.css
@@ -178,6 +178,14 @@ body {
     color: white;
 }
 
+#navBarToolBar .navbarGroup button:last-child{
+    margin-right: 2px;
+}
+
+#navBarToolBar .navbarGroup button:first-child{
+    margin-left: 2px;
+}
+
 #navBarToolBar .navbarGroup i{
     font-size: 20px;
 }
@@ -1653,8 +1661,8 @@ select.form-control{
     font-size: 20px;
 }
 
-.navbar-center .navbar-btn.navbar-btn-active{
-    color: #002349 !important;
+#navBarToolBar .navbar-btn.navbar-btn-active{
+    color: #002349;
     background: rgb(211, 211, 211);
 }
 

--- a/static/graph.css
+++ b/static/graph.css
@@ -192,6 +192,17 @@
     display: none;
 }
 
+/* node headers with class hiddenDataName will be hidden when the node is not selected */
+.node .container:not(.selected) .header .hiddenDataName{
+    visibility: hidden;
+}
+
+/* node header containers that have a child div with class hiddenDataName will not react to pointer events when the node is not selected */
+/* this is the prevent hover tooltips on hidden nodes' titles */
+.node .container:not(.selected) .header > div:has(.hiddenDataName){
+    pointer-events: none;
+}
+
 .node .body{
     position: relative;
     background-color: var(--nodeBackground);

--- a/static/graph.css
+++ b/static/graph.css
@@ -495,6 +495,7 @@
     transform: scaleY(-1);
 }
 
+/* if the node is not selected and the node title is hidden, move the comment icon closer to the node body */
 .node .container:not(.selected) .header.graphDataNode:has(.hiddenDataName) i{
     bottom: 10px;
     pointer-events: all;
@@ -502,7 +503,6 @@
 
 .node.transition{
     transition: width .2s cubic-bezier(0.68, 2.15, 0.5, 0.75), height .2s cubic-bezier(0.68, 2.15, 0.5, 0.75);
-    
 }
 
 .node .graphDataNode{    

--- a/static/graph.css
+++ b/static/graph.css
@@ -188,6 +188,10 @@
     color: rgb(46 49 146);
 }
 
+.node .header input{
+    display: none;
+}
+
 .node .body{
     position: relative;
     background-color: var(--nodeBackground);

--- a/static/graph.css
+++ b/static/graph.css
@@ -491,9 +491,13 @@
 
 .node .header.graphDataNode i{
     top: auto;
-    bottom: -5px;
+    bottom: -7px;
     transform: scaleY(-1);
+}
 
+.node .container:not(.selected) .header.graphDataNode:has(.hiddenDataName) i{
+    bottom: 10px;
+    pointer-events: all;
 }
 
 .node.transition{

--- a/templates/basic_node.html
+++ b/templates/basic_node.html
@@ -2,8 +2,8 @@
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)},attr:{id:$data.getId()}">
         <div class="header" data-bind=" css:{'graphDataNode':$data.isData()}">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
-                <div class="header-name" data-bind="html: $data.name, event: {click: GraphRenderer.editNodeTitleInGraph}, style:{visibility: $data.graphNodeTitleIsHidden() ? 'hidden' : 'visible'}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked,event:{keyup:GraphRenderer.nodeNameEditorKeybinds}, style:{visibility: $data.graphNodeTitleIsHidden() ? 'hidden' : 'visible'}" class="header-input">
+                <div class="header-name" data-bind="html: $data.name, event: {click: GraphRenderer.editNodeTitleInGraph},css:{hiddenDataName: $data.graphNodeTitleIsHidden()}"></div>
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked,event:{keyup:GraphRenderer.nodeNameEditorKeybinds},,css:{hiddenDataName: $data.graphNodeTitleIsHidden()}" class="header-input">
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/basic_node.html
+++ b/templates/basic_node.html
@@ -2,8 +2,8 @@
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)},attr:{id:$data.getId()}">
         <div class="header" data-bind=" css:{'graphDataNode':$data.isData()}">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
-                <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">
+                <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}, visible: $data.graphNodeTitleIsVisible()"></div>
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{keyup:GraphRenderer.nodeNameEditorKeybinds}, visible: $data.graphNodeTitleIsVisible()" class="header-input">
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/basic_node.html
+++ b/templates/basic_node.html
@@ -2,8 +2,8 @@
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)},attr:{id:$data.getId()}">
         <div class="header" data-bind=" css:{'graphDataNode':$data.isData()}">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
-                <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}, visible: $data.graphNodeTitleIsVisible()"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{keyup:GraphRenderer.nodeNameEditorKeybinds}, visible: $data.graphNodeTitleIsVisible()" class="header-input">
+                <div class="header-name" data-bind="html: $data.name, event: {click: GraphRenderer.editNodeTitleInGraph}, style:{visibility: $data.graphNodeTitleIsHidden() ? 'hidden' : 'visible'}"></div>
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked,event:{keyup:GraphRenderer.nodeNameEditorKeybinds}, style:{visibility: $data.graphNodeTitleIsHidden() ? 'hidden' : 'visible'}" class="header-input">
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/basic_node.html
+++ b/templates/basic_node.html
@@ -2,8 +2,8 @@
     <div class="container" data-bind="css: {selected: $root.objectIsSelected($data)},attr:{id:$data.getId()}">
         <div class="header" data-bind=" css:{'graphDataNode':$data.isData()}">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
-                <div class="header-name" data-bind="html: $data.name, event: {click: GraphRenderer.editNodeTitleInGraph},css:{hiddenDataName: $data.graphNodeTitleIsHidden()}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked,event:{keyup:GraphRenderer.nodeNameEditorKeybinds},,css:{hiddenDataName: $data.graphNodeTitleIsHidden()}" class="header-input">
+                <div class="header-name" data-bind="html: $data.name, event: {click: GraphRenderer.editNodeTitleInGraph}, css:{hiddenDataName: $data.graphNodeTitleIsHidden()}"></div>
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, event:{click:function(){$(event.target).focus()}, keyup:GraphRenderer.nodeNameEditorKeybinds}, css:{hiddenDataName: $data.graphNodeTitleIsHidden()}" class="header-input">
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/branch_node.html
+++ b/templates/branch_node.html
@@ -3,7 +3,7 @@
         <div class="header">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/construct_node.html
+++ b/templates/construct_node.html
@@ -3,7 +3,7 @@
         <div class="header">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, event:{click:function(){$(event.target).focus()}, keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/construct_node.html
+++ b/templates/construct_node.html
@@ -3,7 +3,7 @@
         <div class="header">
             <div data-bind="eagleTooltip: {content: $data.getHelpHTML(),size: '500px'}, style: {transform: 'scale('+$root.getGraphTextScale()+')'}">
                 <div class="header-name" data-bind="html: $data.name,event: {click: GraphRenderer.editNodeTitleInGraph}"></div>
-                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, style:{display:'none'},event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
+                <input type="text" onmousedown="GraphRenderer.preventBubbling()" onmousemove="GraphRenderer.preventBubbling()" onmouseup="GraphRenderer.preventBubbling()" data-bind="value:$data.name, readonly: $data.isLocked, event:{click:function(){$(event.target).focus()},keyup:GraphRenderer.nodeNameEditorKeybinds}" class="header-input">    
                 <!-- ko if: $data.getComment() != '' -->
                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect graphComment" data-bs-placement="right" data-bind="eagleTooltip: $data.getComment(), click: $root.graphEditComment">chat</i>
                 <!-- /ko -->

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -38,6 +38,9 @@
                 <button id="centerGraph" class="btn btn-outline-secondary navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: centerGraph, eagleTooltip: KeyboardShortcut.idToFullText('center_graph')">
                     <i class="material-symbols-outlined md-18">filter_center_focus</i>
                 </button>
+                <button id="hideDataNodeNames" class="btn btn-outline-secondary navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: function(){Setting.find(Setting.HIDE_DATA_NODE_TITLES).toggle()}, css: { 'navbar-btn-active': Setting.findValue(Setting.HIDE_DATA_NODE_TITLES)}, eagleTooltip: 'Hide Data Node Names in the graph editor'">
+                    <i class="material-symbols-outlined md-18">visibility_off</i>
+                </button>
             </div>
 
             <!-- navbar category -->


### PR DESCRIPTION
added a new button to the center toolbar in the navbar that allows users to hide Data node names in the graph

## Summary by Sourcery

Enable users to hide data node titles in the graph editor via a new toolbar toggle, backed by a user setting and corresponding UI and CSS updates

New Features:
- Add a toolbar button to toggle hiding of data node names in the graph editor

Enhancements:
- Introduce a new setting (HIDE_DATA_NODE_TITLES) to control data node title visibility
- Update CSS and node templates to hide data node headers and disable their tooltips when hidden

Chores:
- Adjust navbar toolbar button margins for consistent spacing