### PR TITLE
eagle-1591 - fixed edit config button, active config issue

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -628,6 +628,10 @@ export class LogicalGraph {
     }
 
     setActiveGraphConfig = (configId: GraphConfigId): void => {
+        this.activeGraphConfigId(configId)
+    }
+
+    toggleActiveGraphConfig = (configId: GraphConfigId): void => {
         if(this.activeGraphConfigId() === configId){
             this.activeGraphConfigId(null)
         }else{

--- a/templates/graph_configurations_table.html
+++ b/templates/graph_configurations_table.html
@@ -63,7 +63,7 @@
                             </td>
 <!-- active config -->
                             <td class='columnCell column-active'>
-                                <button class="iconHoverEffect" type="button" data-bind="click: function(){$root.logicalGraph().setActiveGraphConfig($data.getId());}">
+                                <button class="iconHoverEffect" type="button" data-bind="click: function(){$root.logicalGraph().toggleActiveGraphConfig($data.getId());}">
                                     <i class="material-symbols-outlined md-18" data-bind="visible: $data.id() === $root.logicalGraph().activeGraphConfigId()">radio_button_checked</i>
                                     <i class="material-symbols-outlined md-18" data-bind="hidden:  $data.id() === $root.logicalGraph().activeGraphConfigId()">radio_button_unchecked</i>
                                 </button>


### PR DESCRIPTION
this was caused by me editing the 'setActiveGraphConfig' function to support toggling. ive broken out the toggling of active configs into its own function.

## Summary by Sourcery

Separate active config toggling into its own method and update the template to use it, restoring correct edit config button functionality.

Bug Fixes:
- Fix active config button behavior by using toggleActiveGraphConfig in the template

Enhancements:
- Extract toggleActiveGraphConfig from setActiveGraphConfig to isolate toggling logic