### PR TITLE
EAGLE-1593: Restructure Utils.requestUserConfirm

### DIFF
--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -38,6 +38,7 @@ test('Adding and Removing Repositories', async ({ page }) => {
   //removing the repo
   await page.locator('.repoContainer').filter({has:page.locator(repoHTMLId)}).hover()
   await page.locator(repoHTMLId + "-eject").click()
+  await page.waitForTimeout(500);
   await page.locator('button#confirmModalAffirmativeButton').click()
 
   //wait for the repo to be removed

--- a/e2e/creatingASimpleGraph.spec.ts
+++ b/e2e/creatingASimpleGraph.spec.ts
@@ -71,9 +71,11 @@ test('Creating a Simple Graph', async ({ page }) => {
 
   // delete the second file node
   await page.keyboard.press('Delete');
+  await page.waitForTimeout(500);
 
   // confirm the deletion in the modal
   await page.locator('#confirmModalAffirmativeAnswer').click();
+  await page.waitForTimeout(500);
 
   // check that the graph has the expected number of nodes
   const numNodesPostDelete = await page.evaluate(() => {

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2304,13 +2304,7 @@ export class Eagle {
 
                 // warn user if file newer than EAGLE
                 if (Utils.newerEagleVersion(eagleVersion, (<any>window).version)){
-                    let confirmed: boolean = false;
-                    try {
-                        confirmed = await Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", null);
-                    } catch (error){
-                        console.error(error);
-                        return;
-                    }
+                    const confirmed = await Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", null);
                     if (confirmed){
                         this._loadGraph(dataObject, file);
                     }
@@ -2453,14 +2447,8 @@ export class Eagle {
 
     deleteRemoteFile = async (file : RepositoryFile): Promise<void> => {
         // request confirmation from user
-        let confirmed: boolean = false;
-        try {
-            confirmed = await Utils.requestUserConfirm("Delete?", "Are you sure you wish to delete '" + file.name + "' from this repository?", "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_FILES));
-        } catch (error) {
-            console.error(error);
-            return;
-        }
-        if (confirmed) {
+        const confirmed = await Utils.requestUserConfirm("Delete?", "Are you sure you wish to delete '" + file.name + "' from this repository?", "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_FILES));
+        if (confirmed){
             this._deleteRemoteFile(file);
         }
     }
@@ -2505,13 +2493,7 @@ export class Eagle {
 
         // if dictated by settings, reload the palette immediately
         if (alreadyLoadedPalette !== null && Setting.findValue(Setting.CONFIRM_RELOAD_PALETTES)){
-            let confirmed: boolean = false;
-            try {
-                confirmed = await Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No", Setting.find(Setting.CONFIRM_RELOAD_PALETTES));
-            } catch (error){
-                console.error(error);
-                return;
-            }
+            const confirmed = await Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No", Setting.find(Setting.CONFIRM_RELOAD_PALETTES));
             if (confirmed){
                 this._reloadPalette(file, data, alreadyLoadedPalette);
             }
@@ -2584,13 +2566,7 @@ export class Eagle {
 
                 // check if the palette is modified, and if so, ask the user to confirm they wish to close
                 if (p.fileInfo().modified && Setting.findValue(Setting.CONFIRM_DISCARD_CHANGES)){
-                    let confirmed: boolean = false;
-                    try {
-                        confirmed = await Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel", null);
-                    } catch (error){
-                        console.error(error);
-                        return;
-                    }
+                    const confirmed = await Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel", null);
                     if (confirmed){
                         this.palettes.splice(i, 1);
                     }
@@ -3543,14 +3519,7 @@ export class Eagle {
         }
 
         // request confirmation from user
-        let confirmed: boolean = false;
-        try {
-            confirmed = await Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_OBJECTS));
-        } catch (error) {
-            console.error(error);
-            return;
-        }
-
+        const confirmed = await Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_OBJECTS));
         if (confirmed){
             this._deleteSelection(deleteChildren, data, location);
         }
@@ -4585,14 +4554,7 @@ export class Eagle {
         // request confirmation from user
         // old request if 'confirm' setting is true AND we're not going to keep the old fields
         if (confirmNodeCategoryChanges && !keepOldFields){
-            let confirmed: boolean = false;
-            try {
-                confirmed = await Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES));
-            } catch (error){
-                //we need to reset the input select to the previous value
-                $(event.target).val(this.selectedNode().getCategory())
-                return;
-            }
+            const confirmed = await Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES));
             if (confirmed){
                 this.inspectorChangeNodeCategory(event)
             }

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2304,13 +2304,16 @@ export class Eagle {
 
                 // warn user if file newer than EAGLE
                 if (Utils.newerEagleVersion(eagleVersion, (<any>window).version)){
+                    let confirmed: boolean = false;
                     try {
-                        await Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", null);
+                        confirmed = await Utils.requestUserConfirm("Newer EAGLE Version", "File " + file.name + " was written with EAGLE version " + eagleVersion + ", whereas the current EAGLE version is " + (<any>window).version + ". Do you wish to load the file anyway?", "Yes", "No", null);
                     } catch (error){
                         console.error(error);
                         return;
                     }
-                    this._loadGraph(dataObject, file);
+                    if (confirmed){
+                        this._loadGraph(dataObject, file);
+                    }
                 } else {
                     this._loadGraph(dataObject, file);
                 }
@@ -2450,13 +2453,16 @@ export class Eagle {
 
     deleteRemoteFile = async (file : RepositoryFile): Promise<void> => {
         // request confirmation from user
+        let confirmed: boolean = false;
         try {
-            await Utils.requestUserConfirm("Delete?", "Are you sure you wish to delete '" + file.name + "' from this repository?", "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_FILES));
+            confirmed = await Utils.requestUserConfirm("Delete?", "Are you sure you wish to delete '" + file.name + "' from this repository?", "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_FILES));
         } catch (error) {
             console.error(error);
             return;
         }
-        this._deleteRemoteFile(file);
+        if (confirmed) {
+            this._deleteRemoteFile(file);
+        }
     }
 
     private _deleteRemoteFile = async (file: RepositoryFile): Promise<void> => {
@@ -2499,13 +2505,16 @@ export class Eagle {
 
         // if dictated by settings, reload the palette immediately
         if (alreadyLoadedPalette !== null && Setting.findValue(Setting.CONFIRM_RELOAD_PALETTES)){
+            let confirmed: boolean = false;
             try {
-                await Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No", Setting.find(Setting.CONFIRM_RELOAD_PALETTES));
+                confirmed = await Utils.requestUserConfirm("Reload Palette?", "This palette (" + file.name + ") is already loaded, do you wish to load it again?", "Yes", "No", Setting.find(Setting.CONFIRM_RELOAD_PALETTES));
             } catch (error){
                 console.error(error);
                 return;
             }
-            this._reloadPalette(file, data, alreadyLoadedPalette);
+            if (confirmed){
+                this._reloadPalette(file, data, alreadyLoadedPalette);
+            }
         } else {
             this._reloadPalette(file, data, alreadyLoadedPalette);
         }
@@ -2575,13 +2584,16 @@ export class Eagle {
 
                 // check if the palette is modified, and if so, ask the user to confirm they wish to close
                 if (p.fileInfo().modified && Setting.findValue(Setting.CONFIRM_DISCARD_CHANGES)){
+                    let confirmed: boolean = false;
                     try {
-                        await Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel", null);
+                        confirmed = await Utils.requestUserConfirm("Close Modified Palette", "Are you sure you wish to close this modified palette?", "Close", "Cancel", null);
                     } catch (error){
                         console.error(error);
                         return;
                     }
-                    this.palettes.splice(i, 1);
+                    if (confirmed){
+                        this.palettes.splice(i, 1);
+                    }
                 } else {
                     this.palettes.splice(i, 1);
                 }
@@ -3531,14 +3543,17 @@ export class Eagle {
         }
 
         // request confirmation from user
+        let confirmed: boolean = false;
         try {
-            await Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_OBJECTS));
+            confirmed = await Utils.requestUserConfirm("Delete?", confirmMessage, "Yes", "No", Setting.find(Setting.CONFIRM_DELETE_OBJECTS));
         } catch (error) {
             console.error(error);
             return;
         }
 
-        this._deleteSelection(deleteChildren, data, location);
+        if (confirmed){
+            this._deleteSelection(deleteChildren, data, location);
+        }
 
         // if we're NOT in rightClick mode, empty the selected objects, should have all been deleted
         if(!rightClick){
@@ -4570,14 +4585,17 @@ export class Eagle {
         // request confirmation from user
         // old request if 'confirm' setting is true AND we're not going to keep the old fields
         if (confirmNodeCategoryChanges && !keepOldFields){
+            let confirmed: boolean = false;
             try {
-                await Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES));
+                confirmed = await Utils.requestUserConfirm("Change Category?", 'Changing a nodes category could destroy some data (parameters, ports, etc) that are not appropriate for a node with the selected category', "Yes", "No", Setting.find(Setting.CONFIRM_NODE_CATEGORY_CHANGES));
             } catch (error){
                 //we need to reset the input select to the previous value
                 $(event.target).val(this.selectedNode().getCategory())
                 return;
             }
-            this.inspectorChangeNodeCategory(event)
+            if (confirmed){
+                this.inspectorChangeNodeCategory(event)
+            }
         }else{
             this.inspectorChangeNodeCategory(event)
         }

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -244,29 +244,29 @@ export class Modals {
 
         // #confirmModal - requestUserConfirm()
         $('#confirmModalAffirmativeButton').on('click', function(){
-            const callback : (confirmed : boolean) => void = $('#confirmModal').data('callback');
-            if (callback){
-                callback(true);
-            } else {
-                console.error("No 'callback' data attribute found on modal");
-            }
-
-            // remove data stored on the modal
-            $('#confirmModal').removeData('callback');
+            $('#confirmModal').data('completed', true);
+            $('#confirmModal').data('confirmed', true);
         });
         $('#confirmModalNegativeButton').on('click', function(){
-            const callback : (confirmed : boolean) => void = $('#confirmModal').data('callback');
-            if (callback){
-                callback(false);
-            } else {
-                console.error("No 'callback' data attribute found on modal");
-            }
-
-            // remove data stored on the modal
-            $('#confirmModal').removeData('callback');
+            $('#confirmModal').data('completed', true);
+            $('#confirmModal').data('confirmed', false);
         });
         $('#confirmModal').on('shown.bs.modal', function(){
             $('#confirmModalAffirmativeButton').trigger("focus");
+        });
+        $('#confirmModal').on('hidden.bs.modal', function(){
+            const callback : (completed: boolean, confirmed: boolean) => void = $('#confirmModal').data('callback');
+            if (!callback){
+                console.error("No 'callback' data attribute found on modal");
+            } else {
+                const completed: boolean = $('#confirmModal').data('completed');
+                const confirmed: boolean = $('#confirmModal').data('confirmed');
+
+                callback(completed, confirmed);
+            }
+
+            // remove data stored on the modal
+            $('#choiceModal').removeData(['callback', 'completed', 'confirmed']);
         });
 
         // #gitCommitModal - requestUserGitCommit()

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -266,7 +266,7 @@ export class Modals {
             }
 
             // remove data stored on the modal
-            $('#choiceModal').removeData(['callback', 'completed', 'confirmed']);
+            $('#confirmModal').removeData(['callback', 'completed', 'confirmed']);
         });
 
         // #gitCommitModal - requestUserGitCommit()

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -43,15 +43,17 @@ export class Repositories {
         // if the file is modified, get the user to confirm they want to overwrite changes
         const confirmDiscardChanges: Setting = Setting.find(Setting.CONFIRM_DISCARD_CHANGES);
         if (isModified && confirmDiscardChanges.value()){
+            let confirmed: boolean = false;
             try {
-                await Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges);
+                confirmed = await Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges);
             } catch (error) {
                 console.error(error);
                 eagle.hideEagleIsLoading();
                 return;
             }
-
-            eagle.openRemoteFile(file);
+            if (confirmed){
+                eagle.openRemoteFile(file);
+            }
         } else {
             eagle.openRemoteFile(file);
         }
@@ -122,14 +124,17 @@ export class Repositories {
         }
 
         // otherwise, check with user
+        let confirmed: boolean = false;
         try {
-            await Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel", confirmRemoveRepositories);
+            confirmed = await Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel", confirmRemoveRepositories);
         } catch (error) {
             console.error(error);
             return;
         }
 
-        this._removeCustomRepository(repository);
+        if (confirmed){
+            this._removeCustomRepository(repository);
+        }
     };
 
     copyRepository = async (repository: Repository): Promise<void> => {

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -43,14 +43,7 @@ export class Repositories {
         // if the file is modified, get the user to confirm they want to overwrite changes
         const confirmDiscardChanges: Setting = Setting.find(Setting.CONFIRM_DISCARD_CHANGES);
         if (isModified && confirmDiscardChanges.value()){
-            let confirmed: boolean = false;
-            try {
-                confirmed = await Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges);
-            } catch (error) {
-                console.error(error);
-                eagle.hideEagleIsLoading();
-                return;
-            }
+            const confirmed = await Utils.requestUserConfirm("Discard changes?", "Opening a new file will discard changes. Continue?", "OK", "Cancel", confirmDiscardChanges);
             if (confirmed){
                 eagle.openRemoteFile(file);
             }
@@ -124,14 +117,7 @@ export class Repositories {
         }
 
         // otherwise, check with user
-        let confirmed: boolean = false;
-        try {
-            confirmed = await Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel", confirmRemoveRepositories);
-        } catch (error) {
-            console.error(error);
-            return;
-        }
-
+        const confirmed = await Utils.requestUserConfirm("Remove Custom Repository", "Remove this repository from the list?", "OK", "Cancel", confirmRemoveRepositories);
         if (confirmed){
             this._removeCustomRepository(repository);
         }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -718,7 +718,7 @@ export class Utils {
         });
     }
 
-    static async requestUserConfirm(title : string, message : string, affirmativeAnswer : string, negativeAnswer : string, confirmSetting: Setting): Promise<void> {
+    static async requestUserConfirm(title : string, message : string, affirmativeAnswer : string, negativeAnswer : string, confirmSetting: Setting): Promise<boolean> {
         return new Promise(async(resolve, reject) => {
             $('#confirmModalTitle').text(title);
             $('#confirmModalMessage').html(message);
@@ -741,10 +741,12 @@ export class Utils {
                 })
             }
 
-            $('#confirmModal').data('callback', function(completed: boolean){
+            $('#confirmModal').data('callback', function(completed: boolean, confirmed: boolean): void {
                 if (completed){
-                    resolve();
+                    // if the user confirmed the action, resolve the promise
+                    resolve(confirmed);
                 } else {
+                    // if the user did not confirm, reject the promise
                     reject("Utils.requestUserConfirm() aborted by user");
                 }
             });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -742,13 +742,7 @@ export class Utils {
             }
 
             $('#confirmModal').data('callback', function(completed: boolean, confirmed: boolean): void {
-                if (completed){
-                    // if the user confirmed the action, resolve the promise
-                    resolve(confirmed);
-                } else {
-                    // if the user did not confirm, reject the promise
-                    reject("Utils.requestUserConfirm() aborted by user");
-                }
+                resolve(completed && confirmed);
             });
 
             $('#confirmModal').modal("show");


### PR DESCRIPTION
Improved the handing of this modal to prevent an error from being thrown when the user answered negative to the confirmation dialog.

The behaviour has slightly changed. Processing of the user's response is no longer triggered by pressing the affirmative button, but instead when the dialog is hidden. So a slightly longer delay is required in the unit tests (to account for the length of time taken for the modal dialog to animate to its hidden state).

## Summary by Sourcery

Restructure the user confirmation flow so Utils.requestUserConfirm returns a boolean and only executes actions when the user affirms, preventing errors on negative responses and deferring callbacks until the modal hides.

Enhancements:
- Change Utils.requestUserConfirm signature to return a boolean and reject only on user cancellation
- Refactor confirmation modal to set completion and confirmation flags on button clicks and invoke callbacks on hidden event
- Update Eagle and Repositories code to capture the confirmed flag and conditionally execute load, delete, reload, close, and category-change operations
- Maintain focus on the affirmative button when the modal is shown

Tests:
- Add waitForTimeout delays in e2e tests to account for modal hide animation