### PR TITLE
EAGLE-1596: 'Missing description' warning doesn't disappear after adding description

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -4661,6 +4661,9 @@ export class Eagle {
 
         fileInfo.shortDescription = description;
         fileInfo.modified = true;
+
+        // check graph (hopefully the 'missing short description' warning will go away)
+        this.checkGraph();
     }
 
     editDetailedDescription = async(fileInfo: FileInfo): Promise<void> => {
@@ -4676,6 +4679,9 @@ export class Eagle {
 
         fileInfo.detailedDescription = description;
         fileInfo.modified = true;
+
+        // check graph (hopefully the 'missing detailed description' warning will go away)
+        this.checkGraph();
     }
 
     editNodeDescription = async (node?: Node): Promise<void> => {


### PR DESCRIPTION
Re-check graph after editing short/detailed description

## Summary by Sourcery

Re-evaluate the graph immediately after editing file descriptions to clear stale 'missing description' warnings.

Bug Fixes:
- Invoke checkGraph() after updating short descriptions to remove 'missing description' warnings.
- Invoke checkGraph() after updating detailed descriptions to remove 'missing description' warnings.