### PR TITLE
EAGLE-1630: Pin Typescript version to 5.8.x

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Install python setuptools
         run: pip install setuptools==81.0.0
       - name: Compile Typescript
-        run: tsc
+        run: |
+          npx tsc --version
+          npx tsc
       - name: Start server
         run: python eagleServer/eagleServer.py -t /tmp &
       - name: Install Playwright

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "knockout": "^3.5.1",
         "material-symbols": "^0.32.0",
         "showdown": "^2.0.1",
-        "typescript": "^5.8.3"
+        "typescript": "5.8.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.56.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "knockout": "^3.5.1",
     "material-symbols": "^0.32.0",
     "showdown": "^2.0.1",
-    "typescript": "~5.8.3"
+    "typescript": "5.8.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "knockout": "^3.5.1",
     "material-symbols": "^0.32.0",
     "showdown": "^2.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "~5.8.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
     "compilerOptions": {
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,
-        "rootDir": "./src",
         "outDir": "./static/built",
-        "ignoreDeprecations": "6.0",
         "sourceMap": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
     "compilerOptions": {
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,
+        "rootDir": "./src",
         "outDir": "./static/built",
+        "ignoreDeprecations": "6.0",
         "sourceMap": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Typescript 6.0 has been released, and compiling EAGLE under that version raises warnings about features deprecated in version 7.0.

We'll have to update EAGLE to be ready for Typescript 7.0 at some stage, but for the moment, just stay with 5.8.x.

I've added one more commit since the initial work. The Typescript compile started to fail again. It seems the Typescript compiler was version 6.0.2 even though we pin the version to 5.8.3. I fixed this by running the compiler using "npx tsc" instead of "tsc". This makes sure the version of tsc installed by npm (5.8.3) is run, instead of some global version (6.0.2) that is somehow the default on the system.