### PR TITLE
EAGLE-1636: Improved Node.getPorts()

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -402,18 +402,14 @@ export class Node {
         return result;
     }
 
-    // TODO: check what this is doing, isn't this too complicated? just loop through all fields, adding everything with usage !== NoPort to the results array
     getPorts = () : Field[] => {
-        const results: Field[] = this.getInputPorts()
-        this.getOutputPorts().forEach(function(outputPort){
-            for (const result of results){
-                if(result.getId() === outputPort.getId()){
-                    continue
-                }else{
-                    results.push(outputPort)
-                }
+        const results: Field[] = [];
+
+        for (const field of this.fields().values()){
+            if (field.getUsage() !== Daliuge.FieldUsage.NoPort){
+                results.push(field);
             }
-        })
+        }
 
         return results;
     }


### PR DESCRIPTION
Just simplified the code to remove the duplicate ports in the results.

@M-Wicenec just wanted you to check that the previous behaviour wasn't required for the renderer (or anything else). Thanks.

## Summary by Sourcery

Enhancements:
- Refactor Node.getPorts() to iterate over all fields and return only those with a port usage, eliminating previous duplicate-handling logic.