### PR TITLE
EAGLE-1635: Fixed bug when user specifies a commit message

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1933,14 +1933,7 @@ export class Utils {
     }
 
     static async userEnterCommitMessage(modalMessage: string) : Promise<string> {
-        // request commit message from the user
-        let userString;
-        try {
-            userString = await Utils.requestUserString("Saving to git", modalMessage, "", false);
-        } catch (error){
-            throw error;
-        }
-        return userString;
+        return Utils.requestUserString("Saving to git", modalMessage, "", false);
     }
 
     // TODO: could we return a list of KeyboardShortcut here?

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1933,17 +1933,14 @@ export class Utils {
     }
 
     static async userEnterCommitMessage(modalMessage: string) : Promise<string> {
-        return new Promise<string>(async (resolve, reject) => {
-            // request commit message from the user
-            let userString;
-            try {
-                userString = await Utils.requestUserString("Saving to git", modalMessage, "", false);
-            } catch (error){
-                reject(error);
-                return;
-            }
-            resolve(userString);
-        });
+        // request commit message from the user
+        let userString;
+        try {
+            userString = await Utils.requestUserString("Saving to git", modalMessage, "", false);
+        } catch (error){
+            throw error;
+        }
+        return userString;
     }
 
     // TODO: could we return a list of KeyboardShortcut here?

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1933,11 +1933,11 @@ export class Utils {
     }
 
     static async userEnterCommitMessage(modalMessage: string) : Promise<string> {
-        return new Promise<string>((resolve, reject) => {
+        return new Promise<string>(async (resolve, reject) => {
             // request commit message from the user
             let userString;
             try {
-                userString = Utils.requestUserString("Saving to git", modalMessage, "", false);
+                userString = await Utils.requestUserString("Saving to git", modalMessage, "", false);
             } catch (error){
                 reject(error);
                 return;


### PR DESCRIPTION
Actually, it seems that this doesn't always cause a bug, but the function call should use await anyway.

## Summary by Sourcery

Bug Fixes:
- Fix potential race condition or unhandled behavior when requesting a user-entered commit message by properly awaiting the asynchronous prompt call.