### PR TITLE
EAGLE-1632: Fixed typo in GraphUpdater keysToIds function

### DIFF
--- a/src/GraphUpdater.ts
+++ b/src/GraphUpdater.ts
@@ -122,7 +122,7 @@ export class GraphUpdater {
             if (node.outputApplicationKey !== null){
                 const outputAppId = Utils.generateNodeId();
                 keyToId.set(node.outputApplicationKey, outputAppId);
-                node.inputApplicationId = outputAppId;
+                node.outputApplicationId = outputAppId;
             }
         }
 


### PR DESCRIPTION
Really only a problem for very old graphs that still use keys, and contain nodes that have output applications. So not very common.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect assignment of generated output application IDs to input application fields when processing nodes with output application keys in legacy graphs.