### PR TITLE
EAGLE-1637: More explicit deletion of elements from a Map

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1089,10 +1089,14 @@ export class Node {
     }
 
     removeAllComponentParameters = () : Node => {
+        const toDelete: FieldId[] = [];
         for (const [id, field] of this.fields()){
             if (field.getParameterType() === Daliuge.FieldType.Component){
-                this.fields().delete(id);
+                toDelete.push(id);
             }
+        }
+        for (const id of toDelete){
+            this.fields().delete(id);
         }
         this.fields.valueHasMutated();
 
@@ -1100,10 +1104,14 @@ export class Node {
     }
 
     removeAllApplicationArguments = () : Node => {
+        const toDelete: FieldId[] = [];
         for (const [id, field] of this.fields()){
             if (field.getParameterType() === Daliuge.FieldType.Application){
-                this.fields().delete(id);
+                toDelete.push(id);
             }
+        }
+        for (const id of toDelete){
+            this.fields().delete(id);
         }
         this.fields.valueHasMutated();
 
@@ -1112,13 +1120,17 @@ export class Node {
 
     // removes all InputPort ports, and changes all InputOutput ports to be OutputPort
     removeAllInputPorts = () : Node => {
+        const toDelete: FieldId[] = [];
         for (const [id, field] of this.fields()){
             if (field.getUsage() === Daliuge.FieldUsage.InputPort){
-                this.fields().delete(id);
+                toDelete.push(id);
             }
             if (field.getUsage() === Daliuge.FieldUsage.InputOutput){
                 field.setUsage(Daliuge.FieldUsage.OutputPort);
             }
+        }
+        for (const id of toDelete){
+            this.fields().delete(id);
         }
         this.fields.valueHasMutated();
 
@@ -1127,13 +1139,17 @@ export class Node {
 
     // removes all OutputPort ports, and changes all InputOutput ports to be InputPort
     removeAllOutputPorts = () : Node => {
+        const toDelete: FieldId[] = [];
         for (const [id, field] of this.fields()){
             if (field.getUsage() === Daliuge.FieldUsage.OutputPort){
-                this.fields().delete(id);
+                toDelete.push(id);
             }
             if (field.getUsage() === Daliuge.FieldUsage.InputOutput){
                 field.setUsage(Daliuge.FieldUsage.InputPort);
             }
+        }
+        for (const id of toDelete){
+            this.fields().delete(id);
         }
         this.fields.valueHasMutated();
 

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1088,72 +1088,47 @@ export class Node {
         return this;
     }
 
-    removeAllComponentParameters = () : Node => {
+    private removeFieldsWhere = (predicate: (field: Field) => boolean) : Node => {
+        const fields = this.fields();
         const toDelete: FieldId[] = [];
-        for (const [id, field] of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.Component){
+        for (const [id, field] of fields){
+            if (predicate(field)){
                 toDelete.push(id);
             }
         }
         for (const id of toDelete){
-            this.fields().delete(id);
+            fields.delete(id);
         }
         this.fields.valueHasMutated();
-
         return this;
     }
 
-    removeAllApplicationArguments = () : Node => {
-        const toDelete: FieldId[] = [];
-        for (const [id, field] of this.fields()){
-            if (field.getParameterType() === Daliuge.FieldType.Application){
-                toDelete.push(id);
-            }
-        }
-        for (const id of toDelete){
-            this.fields().delete(id);
-        }
-        this.fields.valueHasMutated();
+    removeAllComponentParameters = () : Node => {
+        return this.removeFieldsWhere((field) => field.getParameterType() === Daliuge.FieldType.Component);
+    }
 
-        return this;
+    removeAllApplicationArguments = () : Node => {
+        return this.removeFieldsWhere((field) => field.getParameterType() === Daliuge.FieldType.Application);
     }
 
     // removes all InputPort ports, and changes all InputOutput ports to be OutputPort
     removeAllInputPorts = () : Node => {
-        const toDelete: FieldId[] = [];
-        for (const [id, field] of this.fields()){
-            if (field.getUsage() === Daliuge.FieldUsage.InputPort){
-                toDelete.push(id);
-            }
+        for (const field of this.fields().values()){
             if (field.getUsage() === Daliuge.FieldUsage.InputOutput){
                 field.setUsage(Daliuge.FieldUsage.OutputPort);
             }
         }
-        for (const id of toDelete){
-            this.fields().delete(id);
-        }
-        this.fields.valueHasMutated();
-
-        return this;
+        return this.removeFieldsWhere((field) => field.getUsage() === Daliuge.FieldUsage.InputPort);
     }
 
     // removes all OutputPort ports, and changes all InputOutput ports to be InputPort
     removeAllOutputPorts = () : Node => {
-        const toDelete: FieldId[] = [];
-        for (const [id, field] of this.fields()){
-            if (field.getUsage() === Daliuge.FieldUsage.OutputPort){
-                toDelete.push(id);
-            }
+        for (const field of this.fields().values()){
             if (field.getUsage() === Daliuge.FieldUsage.InputOutput){
                 field.setUsage(Daliuge.FieldUsage.InputPort);
             }
         }
-        for (const id of toDelete){
-            this.fields().delete(id);
-        }
-        this.fields.valueHasMutated();
-
-        return this;
+        return this.removeFieldsWhere((field) => field.getUsage() === Daliuge.FieldUsage.OutputPort);
     }
 
     clone = () : Node => {


### PR DESCRIPTION
Switch to a more explicit way of deleting items from a Map, just to make sure the Map iteration doesn't skip values.

## Summary by Sourcery

Refactor Node field removal operations to avoid mutating Maps during iteration and ensure consistent behavior.

Enhancements:
- Introduce a reusable helper to remove fields from a Node based on a predicate without mutating the Map during iteration.
- Update component parameter, application argument, and port removal methods to delegate to the new helper while preserving their existing semantics.