### PR TITLE
added correct and updated imports for jqueryUI and jqueryMigrate and …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@types/bootstrap": "^5.1.4",
         "@types/bootstrap-notify": "^3.1.34",
         "@types/jquery": "^3.3.38",
+        "@types/jquery-migrate": "^3.3.3",
+        "@types/jqueryui": "^1.12.24",
         "@types/node": "^14.0.11",
         "@types/showdown": "^1.9.4",
         "ajv": "^6.14.0",
@@ -74,6 +76,24 @@
       "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
       "dependencies": {
         "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/jquery-migrate": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/jquery-migrate/-/jquery-migrate-3.3.3.tgz",
+      "integrity": "sha512-0CRPTHKGaK831+bxIbRerQpyLHwkNr/vSYZD5JAYpWw/TL2RUGiyWdwR8dAoGC4MpoyH5S+ato3+SyQDBmrZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*"
+      }
+    },
+    "node_modules/@types/jqueryui": {
+      "version": "1.12.24",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.24.tgz",
+      "integrity": "sha512-E2sGULwzMhg4kAeOV+gYcXjg988RuPkviWCt09jLe6GGK9sHM7dTqS8H7JMuUWoZQBucIBzBAgM5o/ezKUFkeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*"
       }
     },
     "node_modules/@types/node": {
@@ -296,6 +316,22 @@
       "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
       "requires": {
         "@types/sizzle": "*"
+      }
+    },
+    "@types/jquery-migrate": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/jquery-migrate/-/jquery-migrate-3.3.3.tgz",
+      "integrity": "sha512-0CRPTHKGaK831+bxIbRerQpyLHwkNr/vSYZD5JAYpWw/TL2RUGiyWdwR8dAoGC4MpoyH5S+ato3+SyQDBmrZNQ==",
+      "requires": {
+        "@types/jquery": "*"
+      }
+    },
+    "@types/jqueryui": {
+      "version": "1.12.24",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.24.tgz",
+      "integrity": "sha512-E2sGULwzMhg4kAeOV+gYcXjg988RuPkviWCt09jLe6GGK9sHM7dTqS8H7JMuUWoZQBucIBzBAgM5o/ezKUFkeg==",
+      "requires": {
+        "@types/jquery": "*"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@types/bootstrap": "^5.1.4",
     "@types/bootstrap-notify": "^3.1.34",
     "@types/jquery": "^3.3.38",
+    "@types/jquery-migrate": "^3.3.3",
+    "@types/jqueryui": "^1.12.24",
     "@types/node": "^14.0.11",
     "@types/showdown": "^1.9.4",
     "ajv": "^6.14.0",

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -5244,8 +5244,8 @@ $( document ).ready(function() {
         const modal = $(this);
 
         // modal draggable
-        (<any>$('.modal-dialog')).draggable({
-            handle: ".modal-header"
+        ($('.modal-dialog') as JQuery<HTMLElement>).draggable({
+            handle: '.modal-header'
         });
 
         //this is a system that allows graph interaction with a modal open, it triggers when the user clicks and drags the modal header

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -5244,7 +5244,6 @@ $( document ).ready(function() {
         const modal = $(this);
 
         // modal draggable
-        // the any type is required so we don't have an error when building. at runtime on eagle this actually functions without it.
         (<any>$('.modal-dialog')).draggable({
             handle: ".modal-header"
         });

--- a/src/bindingHandlers/eagleTooltip.ts
+++ b/src/bindingHandlers/eagleTooltip.ts
@@ -104,7 +104,7 @@ ko.bindingHandlers.eagleTooltip = {
 
             //fire the tooltip
             jQueryElement.attr("data-bs-original-title", result);
-            jQueryElement.tooltip({
+            (<any>jQueryElement).tooltip({
                 html : true,
                 boundary: document.body,
                 trigger : 'manual',

--- a/src/bindingHandlers/eagleTooltip.ts
+++ b/src/bindingHandlers/eagleTooltip.ts
@@ -1,4 +1,5 @@
 import * as ko from "knockout";
+import { Tooltip } from "bootstrap";
 import {Utils} from '../Utils';
 import { GraphRenderer } from "../GraphRenderer";
 import {Eagle} from '../Eagle';
@@ -84,8 +85,6 @@ ko.bindingHandlers.eagleTooltip = {
                 result = Utils.markdown2html(content)
             }
 
-
-
             let buttonRequirements : boolean = false
 
             //if a button is requested and all necessary info is supplied we will insert it here.
@@ -102,12 +101,14 @@ ko.bindingHandlers.eagleTooltip = {
                 }
             }
 
-            //fire the tooltip
+            // fire the tooltip
             jQueryElement.attr("data-bs-original-title", result);
-            (<any>jQueryElement).tooltip({
-                html : true,
+
+            // get a reference to the tooltip, if it already exists, and update its content, if not create a new tooltip
+            const bootstrapTooltip = Tooltip.getOrCreateInstance(element, {
+                html: true,
                 boundary: document.body,
-                trigger : 'manual',
+                trigger: 'manual',
             });
 
             if(buttonRequirements){
@@ -128,21 +129,21 @@ ko.bindingHandlers.eagleTooltip = {
                 if(stillHovering && !GraphRenderer.draggingPort && !GraphRenderer.draggingPaletteNode){
                     // make sure there is never more than one tooltip open
                     $(".tooltip").remove();
-                    jQueryElement.tooltip('show');
+                    bootstrapTooltip.show();
 
                     //adding our custom size if provided
                     $('.tooltip-inner').css('max-width',size)
 
                     //leave listener on the tooltip itself, we attach this when the tooltip is shown
                     $('.tooltip').on('mouseleave', function () {
-                        jQueryElement.tooltip('hide');
+                        bootstrapTooltip.hide();
                         stillHovering = false
                     });
                     
                     //enter listener on the tooltip itself, we attach this when the tooltip is shown
                     $('.tooltip').on('mouseenter', function () {
                         if(GraphRenderer.draggingPort || GraphRenderer.draggingPaletteNode){
-                            jQueryElement.tooltip('hide');
+                            bootstrapTooltip.hide();
                         }
                         stillHovering = true
                     });
@@ -153,10 +154,12 @@ ko.bindingHandlers.eagleTooltip = {
         jQueryElement.on('mouseleave', function(){
             stillHovering = false
 
+            const bootstrapTooltip = Tooltip.getOrCreateInstance(element);
+
             //we need to give the user a little bit of time to move from the element to to tooltip
             setTimeout(function(){
                 if(!stillHovering){
-                    jQueryElement.tooltip('hide');
+                    bootstrapTooltip.hide();
                     stillHovering = false
                 }
             },100)

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,8 @@
 
 import * as ko from "knockout";
 import $ from "jquery";
-// Note: jqueryMigrate and jqueryui are included as dependencies in the HTML template
+import "jquery-migrate";
+import "jqueryui";
 import * as bootstrap from 'bootstrap';
 
 import { Category } from './Category';
@@ -186,14 +187,6 @@ $(function(){
         //reset parameter table selection
         ParameterTable.resetSelection()
     });
-
-    $('.modal').on('shown.bs.modal',function(){
-        // modal draggables
-        //the any type is required so we don't have an error when building. at runtime on eagle this actually functions without it.
-        (<any>$('.modal-dialog')).draggable({
-            handle: ".modal-header"
-        });
-    })
 
     //increased click bubble for edit modal flag booleans
     $(".componentCheckbox").on("click",function(event: JQuery.TriggeredEvent){

--- a/src/require-config.ts
+++ b/src/require-config.ts
@@ -6,7 +6,7 @@ require.config({
         "text": "./static/externals/text",
         "knockout": "./static/externals/knockout-min",
         "jquery": "./static/externals/jquery-3.6.0.min",
-        "jqueryMigrate": "/static/externals/jquery-migrate-3.0.0.min",
+        "jquery-migrate": "/static/externals/jquery-migrate-3.0.0.min",
         "jqueryui": "./static/externals/jquery-ui.min",
         "bootstrap": "./static/externals/bootstrap.bundle.min",
         "bootstrap-notify": "./static/externals/bootstrap-notify.min",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
         "target": "es2015",
         "lib": ["es2021", "dom"],
         "allowJs": false,
-        "types": ["node", "jquery", "bootstrap", "bootstrap-notify"]
+        "types": ["node", "jquery", "jqueryui", "jquery-migrate", "bootstrap", "bootstrap-notify"]
     },
     "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
…their types

## Summary by Sourcery

Align jQuery-related module names and type definitions across the project and clean up redundant modal draggable setup.

Bug Fixes:
- Correct jQuery Migrate RequireJS path alias to match the actual script name.

Enhancements:
- Add TypeScript type definitions for jQuery UI and jQuery Migrate and register them in the compiler configuration.
- Remove a duplicated modal draggable initialization handler from the main entry script while retaining it in the central Eagle initialization.