### PR TITLE
EAGLE-1638: Removed duplicate case in switch

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1345,8 +1345,6 @@ export class Utils {
         }else if (node.isBranch()){
             return EagleConfig.BRANCH_NODE_RADIUS;
         }else if (node.isConstruct()){
-            return EagleConfig.NORMAL_NODE_RADIUS;
-        }else if (node.isConstruct()){
             return EagleConfig.MINIMUM_CONSTRUCT_RADIUS;
         }else if (node.isComment()){
             return EagleConfig.COMMENT_NODE_WIDTH;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Eliminate a duplicated switch branch for construct nodes so only the minimum construct radius value is used.