### PR TITLE
EAGLE-1641: Updates and consistency fixes for eagleServer

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Start server
-        run: python eagleServer/eagleServer.py -t /tmp &
+        run: python eagleServer/eagleServer.py -t /tmp --debug &
       - name: Install Playwright
         run: npm install @playwright/test@latest
       - name: Run Playwright tests

--- a/.github/workflows/testcafe-workflow.oldyml
+++ b/.github/workflows/testcafe-workflow.oldyml
@@ -37,7 +37,7 @@ jobs:
       - name: Compile Typescript
         run: tsc
       - name: Start server
-        run: python eagleServer/eagleServer.py -t /tmp &
+        run: python eagleServer/eagleServer.py -t /tmp --debug &
       #- name: Run tests
       #  uses: DevExpress/testcafe-action@latest
       #  env:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -126,9 +126,9 @@ Install EAGLE
 Start Server
 """"""""""""
 
-Simply start it using
+Simply start it (in debug mode) using
 
-    $ eagleServer -t /tmp
+    $ eagleServer -t /tmp --debug
 
 Tools
 -----

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -30,7 +30,6 @@ import json
 import logging
 import os
 import sys
-import tempfile
 import subprocess
 
 import ipaddress

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -24,14 +24,13 @@ This is the main module of the EAGLE server side code.
 """
 import argparse
 import base64
+import certifi
 import datetime
-from fileinput import filename
 import json
 import logging
 import os
 import sys
 import tempfile
-import six
 import subprocess
 
 import urllib.request
@@ -56,14 +55,7 @@ class GraphException(Exception):
     pass
 
 
-if sys.version_info[0] == 2:
-    import errno
-
-    class FileExistsError(OSError):
-        def __init__(self, msg):
-            super(FileExistsError, self).__init__(errno.EEXIST, msg)
-
-#NOTE: this global variable is copied rather than imported
+# NOTE: this global variable is copied rather than imported
 #      because it can be overwritten by the user's command line
 TEMP_FILE_FOLDER = config.config.TEMP_FILE_FOLDER
 
@@ -151,27 +143,8 @@ def save():
     Saves a file to local computer.
     """
     content = request.get_json(silent=True)
-    temp_file = tempfile.TemporaryFile()
-
-    try:
-        content["modelData"]["lastModifiedDatetime"] = datetime.datetime.now().timestamp()
-
-        json_string = json.dumps(content)
-        if sys.version_info < (3, 2, 0):
-            temp_file.write(json_string)
-        else:
-            temp_file = tempfile.TemporaryFile(mode="w+t")
-            temp_file.write(json.dumps(content, indent=4, sort_keys=True))
-
-        # Reset the seeker
-        temp_file.seek(0)
-        string = temp_file.read()
-        # Indent json for human readable formatting.
-        graph = json.loads(string)
-        json_data = json.dumps(graph, indent=4)
-        return json_data
-    finally:
-        temp_file.close()
+    content["modelData"]["lastModifiedDatetime"] = datetime.datetime.now().timestamp()
+    return json.dumps(content, indent=4, sort_keys=True)
 
 
 @app.route("/openRemoteFileLocalServer/<filetype>/<path:filename>", methods=["POST"])
@@ -179,18 +152,20 @@ def open_file(filetype, filename):
     """
     FLASK POST routing method for '/openRemoteFileLocalServer/<filetype>/<path:filename>'
 
-    Opens and retruns a JSON file on a local server
+    Opens and returns a JSON file on a local server
     """
     path = request.data.decode().strip("/")
     path = os.path.join(TEMP_FILE_FOLDER, path)
     norm_path = os.path.join(os.path.normpath(path), filename)
 
-    json_data = open(norm_path, "r+")
-    data = json.load(json_data)
-    response = app.response_class(
-        response=json.dumps(data), status=200, mimetype="application/json"
-    )
-    return response
+    # attempt to open and read the file as JSON
+    try:
+        with open(norm_path, "r") as json_data:
+            data = json.load(json_data)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    return jsonify(data)
 
 
 @app.route("/getGitHubRepositoryList", methods=["GET"])
@@ -254,7 +229,7 @@ def get_git_hub_files_all():
         repo_token = content["token"]
         repo_path = content["path"]
     except KeyError as ke:
-        print("KeyError {1}: {0}".format(str(ke), repo_name))
+        print("KeyError: {0}".format(str(ke)))
         return jsonify({"error":"Repository, Branch or Token not specified in request"})
 
     # Extracting the true repo name and repo folder.
@@ -301,7 +276,7 @@ def get_git_lab_files_all():
         repo_token = content["token"]
         repo_path = content["path"]
     except KeyError as ke:
-        print("KeyError {1}: {0}".format(str(ke), repo_name))
+        print("KeyError: {0}".format(str(ke)))
         return jsonify({"error":"Repository, Branch or Token not specified in request"})
 
     if repo_token:
@@ -344,13 +319,9 @@ def get_docker_images():
 
     docker_url = "https://hub.docker.com/v2/repositories/" + user_name + "/"
 
-    # avoid ssl errors when fetching a URL using urllib.request
-    # https://stackoverflow.com/questions/50236117/scraping-ssl-certificate-verify-failed-error-for-http-en-wikipedia-org
-    ssl._create_default_https_context = ssl._create_unverified_context
-
-    with urllib.request.urlopen(docker_url) as url:
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    with urllib.request.urlopen(docker_url, context=ctx) as url:
         data = json.loads(url.read().decode())
-        #print(data)
 
     return jsonify(data)
 
@@ -372,13 +343,9 @@ def get_docker_image_tags():
 
     docker_url = "https://registry.hub.docker.com/v2/repositories/" + image_name + "/tags"
 
-    # avoid ssl errors when fetching a URL using urllib.request
-    # https://stackoverflow.com/questions/50236117/scraping-ssl-certificate-verify-failed-error-for-http-en-wikipedia-org
-    ssl._create_default_https_context = ssl._create_unverified_context
-
-    with urllib.request.urlopen(docker_url) as url:
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    with urllib.request.urlopen(docker_url, context=ctx) as url:
         data = json.loads(url.read().decode())
-        #print(data)
 
     return jsonify(data)
 
@@ -450,7 +417,7 @@ def save_git_hub_file():
     except github.GithubException as e:
         return github_exception_handler(e, "Error in edit", repo_name, repo_branch)
 
-    return "ok"
+    return jsonify({"success": True})
 
 
 # helper function to handle github exceptions consistently
@@ -527,7 +494,7 @@ def save_git_lab_file():
             return jsonify({"error": str(gce)}), 400
 
 
-    return "ok"
+    return jsonify({"success": True})
 
 
 def set_metadata_for_ingress(graph, repo_service, repo_name, repo_branch, filename):
@@ -600,7 +567,7 @@ def open_git_hub_file():
     try:
         repo = g.get_repo(repo_name)
     except Exception as e:
-        return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(e)}), 404
 
 
     # get commits
@@ -621,7 +588,7 @@ def open_git_hub_file():
         sha = [x.sha for x in tree if x.path == filename]
         if not sha:
             # well, not found..
-            return app.response_class(response=json.dumps({"error":"File not found"}), status=404, mimetype="application/json")
+            return jsonify({"error": "File not found"}), 404
 
         # use the sha to get the blob, then decode it
         blob = repo.get_git_blob(sha[0])
@@ -632,8 +599,6 @@ def open_git_hub_file():
         download_url = "https://raw.githubusercontent.com/" + repo_name + "/" + most_recent_commit.sha + "/" + filename
     except AssertionError as e:
         # download via http get
-        import certifi
-        import ssl
         raw_data = urllib.request.urlopen(download_url, context=ssl.create_default_context(cafile=certifi.where())).read()
 
     if extension != ".md":
@@ -641,7 +606,7 @@ def open_git_hub_file():
         graph = json.loads(raw_data)
 
         if isinstance(graph, list):
-            return app.response_class(response=json.dumps({"error":"File JSON data is a list, this file could be a Physical Graph instead of a Logical Graph."}), status=404, mimetype="application/json")
+            return jsonify({"error": "File JSON data is a list, this file could be a Physical Graph instead of a Logical Graph."}), 404
 
         if not "modelData" in graph:
             graph["modelData"] = {}
@@ -691,7 +656,7 @@ def delete_git_hub_file():
         repo = g.get_repo(repo_name)
     except Exception as e:
         print(e)
-        return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(e)}), 404
 
     # get commits
     commits = repo.get_commits(sha=repo_branch, path=filename)
@@ -702,9 +667,9 @@ def delete_git_hub_file():
         f = repo.get_contents(filename, ref=most_recent_commit.sha)
         repo.delete_file(f.path, "File removed by EAGLE", f.sha, branch=repo_branch)
     except github.GithubException as e:
-        return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(e)}), 404
 
-    return json.dumps({'success':True}), 200, {'ContentType':'application/json'}
+    return jsonify({"success": True})
 
 
 @app.route("/openRemoteGitlabFile", methods=["POST"])
@@ -738,7 +703,7 @@ def open_git_lab_file():
             gl.auth()
         except Exception as e:
             print(e)
-            return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+            return jsonify({"error": str(e)}), 404
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
 
@@ -748,7 +713,7 @@ def open_git_lab_file():
         f = project.files.get(file_path=filename, ref=repo_branch)
     except gitlab.exceptions.GitlabGetError as gle:
         print("GitLabGetError {0}/{1}/{2}: {3}".format(repo_name, repo_branch, filename, str(gle)))
-        return app.response_class(response=json.dumps({"error":str(gle)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(gle)}), 404
 
     # get the decoded content
     raw_data = f.decode().decode("utf-8")
@@ -810,7 +775,7 @@ def delete_git_lab_file():
         gl.auth()
     except Exception as e:
         print(e)
-        return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(e)}), 404
 
     project = gl.projects.get(repo_name)
 
@@ -818,9 +783,9 @@ def delete_git_lab_file():
         project.files.delete(file_path=filename, branch=repo_branch, commit_message="File removed by EAGLE")
     except gitlab.exceptions.GitlabDeleteError as gle:
         print("GitLabDeleteError {0}/{1}/{2}: {3}".format(repo_name, repo_branch, filename, str(gle)))
-        return app.response_class(response=json.dumps({"error":str(gle)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(gle)}), 404
 
-    return json.dumps({'success':True}), 200, {'ContentType':'application/json'}
+    return jsonify({"success": True})
 
 
 @app.route("/openRemoteUrlFile", methods=["POST"])
@@ -835,13 +800,11 @@ def open_url_file():
     extension = os.path.splitext(url)[1]
 
     # download via http get
-    import certifi
-    import ssl
     try:
         raw_data = urllib.request.urlopen(url, context=ssl.create_default_context(cafile=certifi.where())).read()
     except Exception as e:
         print(e)
-        return app.response_class(response=json.dumps({"error":str(e)}), status=404, mimetype="application/json")
+        return jsonify({"error": str(e)}), 404
 
     # parse JSON
     graph = json.loads(raw_data)
@@ -956,8 +919,6 @@ def save_to_temp(lg_name, logical_graph):
                 lg_name, str(exp)
             )
         ) from exp
-    finally:
-        pass
 
     return new_path
 
@@ -1001,7 +962,7 @@ def parse_args():
 
 def main():
     """
-    Main function of eagleServer, will run the APP indefinetly.
+    Main function of eagleServer, will run the APP indefinitely.
     """
     args = parse_args()
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -47,6 +47,7 @@ from config.config import GITLAB_DEFAULT_REPO_LIST
 from config.config import STUDENT_GITHUB_DEFAULT_REPO_LIST
 from config.config import SERVER_PORT
 
+URL_OPEN_TIMEOUT = 20
 
 class GraphException(Exception):
     """
@@ -162,8 +163,10 @@ def open_file(filetype, filename):
     try:
         with open(norm_path, "r") as json_data:
             data = json.load(json_data)
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except FileNotFoundError as fnfe:
+        return jsonify({"error": "File not found: " + norm_path}), 404
+    except json.JSONDecodeError as jde:
+        return jsonify({"error": "JSON decode error: " + str(jde)}), 400
 
     return jsonify(data)
 
@@ -320,7 +323,7 @@ def get_docker_images():
     docker_url = "https://hub.docker.com/v2/repositories/" + user_name + "/"
 
     ctx = ssl.create_default_context(cafile=certifi.where())
-    with urllib.request.urlopen(docker_url, context=ctx) as url:
+    with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
         data = json.loads(url.read().decode())
 
     return jsonify(data)
@@ -344,7 +347,7 @@ def get_docker_image_tags():
     docker_url = "https://registry.hub.docker.com/v2/repositories/" + image_name + "/tags"
 
     ctx = ssl.create_default_context(cafile=certifi.where())
-    with urllib.request.urlopen(docker_url, context=ctx) as url:
+    with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
         data = json.loads(url.read().decode())
 
     return jsonify(data)
@@ -599,7 +602,7 @@ def open_git_hub_file():
         download_url = "https://raw.githubusercontent.com/" + repo_name + "/" + most_recent_commit.sha + "/" + filename
     except AssertionError as e:
         # download via http get
-        raw_data = urllib.request.urlopen(download_url, context=ssl.create_default_context(cafile=certifi.where())).read()
+        raw_data = urllib.request.urlopen(download_url, context=ssl.create_default_context(cafile=certifi.where()), timeout=URL_OPEN_TIMEOUT).read()
 
     if extension != ".md":
         # parse JSON
@@ -801,7 +804,7 @@ def open_url_file():
 
     # download via http get
     try:
-        raw_data = urllib.request.urlopen(url, context=ssl.create_default_context(cafile=certifi.where())).read()
+        raw_data = urllib.request.urlopen(url, context=ssl.create_default_context(cafile=certifi.where()), timeout=URL_OPEN_TIMEOUT).read()
     except Exception as e:
         print(e)
         return jsonify({"error": str(e)}), 404

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -966,7 +966,13 @@ def parse_args():
         "--quiet",
         action="store_true",
         help="suppress info logging output from the server",
-
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        default=False,
+        help="enable Flask debug mode (binds to localhost only, for local development)",
     )
     args = parser.parse_args()
 
@@ -994,7 +1000,9 @@ def main():
         log = logging.getLogger('werkzeug')
         log.setLevel(logging.ERROR)
 
-    app.run(host="0.0.0.0", debug=True, port=args.port)
+    # If debug mode is enabled, bind to localhost only for security. Otherwise, bind to all interfaces.
+    host = "127.0.0.1" if args.debug else "0.0.0.0"
+    app.run(host=host, debug=args.debug, port=args.port)
 
 
 if __name__ == "__main__":

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -946,26 +946,6 @@ def find_github_palettes(repo, path, branch):
     return result
 
 
-def save_to_temp(lg_name, logical_graph):
-    """
-    Saves graph to temp folder.
-    """
-    try:
-        new_path = os.path.join(TEMP_FILE_FOLDER, lg_name)
-
-        # Overwrite file on disks.
-        with open(new_path, "w") as outfile:
-            json.dump(logical_graph, outfile, sort_keys=True, indent=4)
-    except Exception as exp:
-        raise GraphException(
-            "Failed to save a pre-translated graph {0}:{1}".format(
-                lg_name, str(exp)
-            )
-        ) from exp
-
-    return new_path
-
-
 def parse_args():
     """
     Parsing command line arguments and setting corresponding global variables.

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -148,29 +148,6 @@ def save():
     return json.dumps(content, indent=4, sort_keys=True)
 
 
-@app.route("/openRemoteFileLocalServer/<filetype>/<path:filename>", methods=["POST"])
-def open_file(filetype, filename):
-    """
-    FLASK POST routing method for '/openRemoteFileLocalServer/<filetype>/<path:filename>'
-
-    Opens and returns a JSON file on a local server
-    """
-    path = request.data.decode().strip("/")
-    path = os.path.join(TEMP_FILE_FOLDER, path)
-    norm_path = os.path.join(os.path.normpath(path), filename)
-
-    # attempt to open and read the file as JSON
-    try:
-        with open(norm_path, "r") as json_data:
-            data = json.load(json_data)
-    except FileNotFoundError as fnfe:
-        return jsonify({"error": "File not found: " + norm_path}), 404
-    except json.JSONDecodeError as jde:
-        return jsonify({"error": "JSON decode error: " + str(jde)}), 400
-
-    return jsonify(data)
-
-
 @app.route("/getGitHubRepositoryList", methods=["GET"])
 def get_git_hub_repository_list():
     """

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -33,7 +33,10 @@ import sys
 import tempfile
 import subprocess
 
+import ipaddress
+import socket
 import urllib.request
+import urllib.parse
 import ssl
 
 import github
@@ -48,6 +51,60 @@ from config.config import STUDENT_GITHUB_DEFAULT_REPO_LIST
 from config.config import SERVER_PORT
 
 URL_OPEN_TIMEOUT = 20
+
+ALLOWED_URL_SCHEMES = {"http", "https"}
+ALLOWED_URL_EXTENSIONS = {".graph", ".palette"}
+
+
+def validate_remote_url(url: str) -> None:
+    """
+    Validate a user-supplied URL before fetching it server-side.
+
+    Raises ValueError if the URL is not permitted, blocking SSRF attacks
+    that target cloud metadata endpoints (169.254.169.254), loopback,
+    RFC-1918 private ranges, or unexpected URI schemes.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        raise ValueError("URL could not be parsed")
+
+    # 1. Scheme must be http or https
+    if parsed.scheme not in ALLOWED_URL_SCHEMES:
+        raise ValueError("URL scheme not permitted")
+
+    # 2. Hostname must be present
+    host = parsed.hostname
+    if not host:
+        raise ValueError("URL has no host")
+
+    # 3. File extension must be .graph or .palette
+    ext = os.path.splitext(parsed.path)[1].lower()
+    if ext not in ALLOWED_URL_EXTENSIONS:
+        raise ValueError("URL file extension not permitted")
+
+    # 4. Resolve the hostname and check every returned address
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        addr_infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ValueError("URL host could not be resolved")
+
+    if not addr_infos:
+        raise ValueError("URL host resolved to no addresses")
+
+    for *_, sockaddr in addr_infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_unspecified
+            or ip.is_multicast
+        ):
+            raise ValueError("URL resolves to a non-public address")
+
 
 class GraphException(Exception):
     """
@@ -778,6 +835,13 @@ def open_url_file():
     content = request.get_json(silent=True)
     url = content["url"]
     extension = os.path.splitext(url)[1]
+
+    # validate the URL before fetching to prevent SSRF
+    try:
+        validate_remote_url(url)
+    except ValueError as e:
+        app.logger.warning("SSRF attempt blocked for URL %r: %s", url, e)
+        return jsonify({"error": "Invalid URL"}), 400
 
     # download via http get
     try:

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -363,16 +363,16 @@ def get_docker_images():
     except urllib.error.HTTPError as e:
         app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
         status = 404 if e.code == 404 else 502
-        return jsonify({"error": str(e)}), status
+        return jsonify({"error": "Failed to retrieve Docker images"}), status
     except urllib.error.URLError as e:
         if isinstance(e.reason, (socket.timeout, TimeoutError)):
             app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
-            return jsonify({"error": str(e)}), 504
+            return jsonify({"error": "Docker Hub request timed out"}), 504
         app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": str(e)}), 502
+        return jsonify({"error": "Failed to reach Docker Hub"}), 502
     except Exception as e:
         app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An unexpected error occurred"}), 500
 
     return jsonify(data)
 
@@ -401,16 +401,16 @@ def get_docker_image_tags():
     except urllib.error.HTTPError as e:
         app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
         status = 404 if e.code == 404 else 502
-        return jsonify({"error": str(e)}), status
+        return jsonify({"error": "Failed to retrieve Docker image tags"}), status
     except urllib.error.URLError as e:
         if isinstance(e.reason, (socket.timeout, TimeoutError)):
             app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
-            return jsonify({"error": str(e)}), 504
+            return jsonify({"error": "Docker Hub request timed out"}), 504
         app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": str(e)}), 502
+        return jsonify({"error": "Failed to reach Docker Hub"}), 502
     except Exception as e:
         app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An unexpected error occurred"}), 500
 
     return jsonify(data)
 
@@ -877,16 +877,16 @@ def open_url_file():
     except urllib.error.HTTPError as e:
         app.logger.exception("Remote URL returned HTTP %s: %s", e.code, url)
         status = 404 if e.code == 404 else 502
-        return jsonify({"error": str(e)}), status
+        return jsonify({"error": "Failed to fetch remote file"}), status
     except urllib.error.URLError as e:
         if isinstance(e.reason, (socket.timeout, TimeoutError)):
             app.logger.exception("Timeout fetching remote URL: %s", url)
-            return jsonify({"error": str(e)}), 504
+            return jsonify({"error": "Remote URL request timed out"}), 504
         app.logger.exception("Network error fetching remote URL: %s", url)
-        return jsonify({"error": str(e)}), 502
+        return jsonify({"error": "Failed to reach remote URL"}), 502
     except Exception as e:
         app.logger.exception("Unexpected error fetching remote URL: %s", url)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An unexpected error occurred"}), 500
 
     # parse JSON
     graph = json.loads(raw_data)

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -56,6 +56,41 @@ ALLOWED_URL_SCHEMES = {"http", "https"}
 ALLOWED_URL_EXTENSIONS = {".graph", ".palette"}
 
 
+class RemoteFetchError(Exception):
+    """Raised by fetch_json_url when a remote HTTP fetch fails."""
+    def __init__(self, message: str, status: int):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def fetch_json_url(url: str, label: str) -> dict:
+    """
+    Fetch a URL, decode the response, and parse it as JSON.
+
+    Raises RemoteFetchError with an appropriate HTTP status code on any
+    network, HTTP, or parse failure.  All exceptions are logged via the
+    Flask application logger before being re-raised as RemoteFetchError.
+    """
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    try:
+        with urllib.request.urlopen(url, context=ctx, timeout=URL_OPEN_TIMEOUT) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as e:
+        app.logger.exception("%s HTTP %s for %s", label, e.code, url)
+        status = 404 if e.code == 404 else 502
+        raise RemoteFetchError("Failed to fetch remote resource", status) from e
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, (socket.timeout, TimeoutError)):
+            app.logger.exception("Timeout fetching %s: %s", label, url)
+            raise RemoteFetchError("Request timed out", 504) from e
+        app.logger.exception("Network error fetching %s: %s", label, url)
+        raise RemoteFetchError("Failed to reach remote host", 502) from e
+    except Exception as e:
+        app.logger.exception("Unexpected error fetching %s: %s", label, url)
+        raise RemoteFetchError("An unexpected error occurred", 500) from e
+
+
 def validate_remote_url(url: str) -> None:
     """
     Validate a user-supplied URL before fetching it server-side.
@@ -356,23 +391,10 @@ def get_docker_images():
 
     docker_url = "https://hub.docker.com/v2/repositories/" + user_name + "/"
 
-    ctx = ssl.create_default_context(cafile=certifi.where())
     try:
-        with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
-            data = json.loads(url.read().decode())
-    except urllib.error.HTTPError as e:
-        app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
-        status = 404 if e.code == 404 else 502
-        return jsonify({"error": "Failed to retrieve Docker images"}), status
-    except urllib.error.URLError as e:
-        if isinstance(e.reason, (socket.timeout, TimeoutError)):
-            app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
-            return jsonify({"error": "Docker Hub request timed out"}), 504
-        app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": "Failed to reach Docker Hub"}), 502
-    except Exception as e:
-        app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": "An unexpected error occurred"}), 500
+        data = fetch_json_url(docker_url, label="Docker Hub")
+    except RemoteFetchError as e:
+        return jsonify({"error": e.message}), e.status
 
     return jsonify(data)
 
@@ -394,23 +416,10 @@ def get_docker_image_tags():
 
     docker_url = "https://registry.hub.docker.com/v2/repositories/" + image_name + "/tags"
 
-    ctx = ssl.create_default_context(cafile=certifi.where())
     try:
-        with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
-            data = json.loads(url.read().decode())
-    except urllib.error.HTTPError as e:
-        app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
-        status = 404 if e.code == 404 else 502
-        return jsonify({"error": "Failed to retrieve Docker image tags"}), status
-    except urllib.error.URLError as e:
-        if isinstance(e.reason, (socket.timeout, TimeoutError)):
-            app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
-            return jsonify({"error": "Docker Hub request timed out"}), 504
-        app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": "Failed to reach Docker Hub"}), 502
-    except Exception as e:
-        app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
-        return jsonify({"error": "An unexpected error occurred"}), 500
+        data = fetch_json_url(docker_url, label="Docker Hub")
+    except RemoteFetchError as e:
+        return jsonify({"error": e.message}), e.status
 
     return jsonify(data)
 
@@ -873,23 +882,9 @@ def open_url_file():
 
     # download via http get
     try:
-        raw_data = urllib.request.urlopen(url, context=ssl.create_default_context(cafile=certifi.where()), timeout=URL_OPEN_TIMEOUT).read()
-    except urllib.error.HTTPError as e:
-        app.logger.exception("Remote URL returned HTTP %s: %s", e.code, url)
-        status = 404 if e.code == 404 else 502
-        return jsonify({"error": "Failed to fetch remote file"}), status
-    except urllib.error.URLError as e:
-        if isinstance(e.reason, (socket.timeout, TimeoutError)):
-            app.logger.exception("Timeout fetching remote URL: %s", url)
-            return jsonify({"error": "Remote URL request timed out"}), 504
-        app.logger.exception("Network error fetching remote URL: %s", url)
-        return jsonify({"error": "Failed to reach remote URL"}), 502
-    except Exception as e:
-        app.logger.exception("Unexpected error fetching remote URL: %s", url)
-        return jsonify({"error": "An unexpected error occurred"}), 500
-
-    # parse JSON
-    graph = json.loads(raw_data)
+        graph = fetch_json_url(url, label="remote URL")
+    except RemoteFetchError as e:
+        return jsonify({"error": e.message}), e.status
 
     if not "modelData" in graph:
         graph["modelData"] = {}

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -34,6 +34,7 @@ import subprocess
 
 import ipaddress
 import socket
+import urllib.error
 import urllib.request
 import urllib.parse
 import ssl
@@ -265,8 +266,8 @@ def get_git_hub_files_all():
         repo_token = content["token"]
         repo_path = content["path"]
     except KeyError as ke:
-        print("KeyError: {0}".format(str(ke)))
-        return jsonify({"error":"Repository, Branch or Token not specified in request"})
+        app.logger.error("KeyError in getGitHubFilesAll: %s", ke)
+        return jsonify({"error":"Repository, Branch or Token not specified in request"}), 400
 
     # Extracting the true repo name and repo folder.
     folder_name, repo_name = extract_folder_and_repo_names(repo_name)
@@ -312,8 +313,8 @@ def get_git_lab_files_all():
         repo_token = content["token"]
         repo_path = content["path"]
     except KeyError as ke:
-        print("KeyError: {0}".format(str(ke)))
-        return jsonify({"error":"Repository, Branch or Token not specified in request"})
+        app.logger.error("KeyError in getGitLabFilesAll: %s", ke)
+        return jsonify({"error":"Repository, Branch or Token not specified in request"}), 400
 
     if repo_token:
         gl = gitlab.Gitlab('https://gitlab.com', private_token=repo_token, api_version=4)
@@ -350,14 +351,28 @@ def get_docker_images():
     try:
         user_name = content["username"]
     except KeyError as ke:
-        print("KeyError: {0}".format(str(ke)))
-        return jsonify({"error":"Username not specified in request"})
+        app.logger.error("KeyError in getDockerImages: %s", ke)
+        return jsonify({"error":"Username not specified in request"}), 400
 
     docker_url = "https://hub.docker.com/v2/repositories/" + user_name + "/"
 
     ctx = ssl.create_default_context(cafile=certifi.where())
-    with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
-        data = json.loads(url.read().decode())
+    try:
+        with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
+            data = json.loads(url.read().decode())
+    except urllib.error.HTTPError as e:
+        app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
+        status = 404 if e.code == 404 else 502
+        return jsonify({"error": str(e)}), status
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, (socket.timeout, TimeoutError)):
+            app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
+            return jsonify({"error": str(e)}), 504
+        app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
+        return jsonify({"error": str(e)}), 502
+    except Exception as e:
+        app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
+        return jsonify({"error": str(e)}), 500
 
     return jsonify(data)
 
@@ -374,14 +389,28 @@ def get_docker_image_tags():
     try:
         image_name = content["imagename"]
     except KeyError as ke:
-        print("KeyError: {0}".format(str(ke)))
-        return jsonify({"error":"Imagename not specified in request"})
+        app.logger.error("KeyError in getDockerImageTags: %s", ke)
+        return jsonify({"error":"Imagename not specified in request"}), 400
 
     docker_url = "https://registry.hub.docker.com/v2/repositories/" + image_name + "/tags"
 
     ctx = ssl.create_default_context(cafile=certifi.where())
-    with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
-        data = json.loads(url.read().decode())
+    try:
+        with urllib.request.urlopen(docker_url, context=ctx, timeout=URL_OPEN_TIMEOUT) as url:
+            data = json.loads(url.read().decode())
+    except urllib.error.HTTPError as e:
+        app.logger.exception("Docker Hub HTTP %s for %s", e.code, docker_url)
+        status = 404 if e.code == 404 else 502
+        return jsonify({"error": str(e)}), status
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, (socket.timeout, TimeoutError)):
+            app.logger.exception("Timeout fetching Docker Hub: %s", docker_url)
+            return jsonify({"error": str(e)}), 504
+        app.logger.exception("Network error fetching Docker Hub: %s", docker_url)
+        return jsonify({"error": str(e)}), 502
+    except Exception as e:
+        app.logger.exception("Unexpected error fetching Docker Hub: %s", docker_url)
+        return jsonify({"error": str(e)}), 500
 
     return jsonify(data)
 
@@ -691,7 +720,7 @@ def delete_git_hub_file():
     try:
         repo = g.get_repo(repo_name)
     except Exception as e:
-        print(e)
+        app.logger.exception("GitHub get_repo failed for %s", repo_name)
         return jsonify({"error": str(e)}), 404
 
     # get commits
@@ -738,7 +767,7 @@ def open_git_lab_file():
         try:
             gl.auth()
         except Exception as e:
-            print(e)
+            app.logger.exception("GitLab auth failed for %s", repo_name)
             return jsonify({"error": str(e)}), 404
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
@@ -748,7 +777,7 @@ def open_git_lab_file():
     try:
         f = project.files.get(file_path=filename, ref=repo_branch)
     except gitlab.exceptions.GitlabGetError as gle:
-        print("GitLabGetError {0}/{1}/{2}: {3}".format(repo_name, repo_branch, filename, str(gle)))
+        app.logger.error("GitLabGetError %s/%s/%s: %s", repo_name, repo_branch, filename, gle)
         return jsonify({"error": str(gle)}), 404
 
     # get the decoded content
@@ -810,7 +839,7 @@ def delete_git_lab_file():
     try:
         gl.auth()
     except Exception as e:
-        print(e)
+        app.logger.exception("GitLab auth failed for %s", repo_name)
         return jsonify({"error": str(e)}), 404
 
     project = gl.projects.get(repo_name)
@@ -818,7 +847,7 @@ def delete_git_lab_file():
     try:
         project.files.delete(file_path=filename, branch=repo_branch, commit_message="File removed by EAGLE")
     except gitlab.exceptions.GitlabDeleteError as gle:
-        print("GitLabDeleteError {0}/{1}/{2}: {3}".format(repo_name, repo_branch, filename, str(gle)))
+        app.logger.error("GitLabDeleteError %s/%s/%s: %s", repo_name, repo_branch, filename, gle)
         return jsonify({"error": str(gle)}), 404
 
     return jsonify({"success": True})
@@ -845,9 +874,19 @@ def open_url_file():
     # download via http get
     try:
         raw_data = urllib.request.urlopen(url, context=ssl.create_default_context(cafile=certifi.where()), timeout=URL_OPEN_TIMEOUT).read()
+    except urllib.error.HTTPError as e:
+        app.logger.exception("Remote URL returned HTTP %s: %s", e.code, url)
+        status = 404 if e.code == 404 else 502
+        return jsonify({"error": str(e)}), status
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, (socket.timeout, TimeoutError)):
+            app.logger.exception("Timeout fetching remote URL: %s", url)
+            return jsonify({"error": str(e)}), 504
+        app.logger.exception("Network error fetching remote URL: %s", url)
+        return jsonify({"error": str(e)}), 502
     except Exception as e:
-        print(e)
-        return jsonify({"error": str(e)}), 404
+        app.logger.exception("Unexpected error fetching remote URL: %s", url)
+        return jsonify({"error": str(e)}), 500
 
     # parse JSON
     graph = json.loads(raw_data)

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -130,14 +130,7 @@ def validate_remote_url(url: str) -> None:
 
     for *_, sockaddr in addr_infos:
         ip = ipaddress.ip_address(sockaddr[0])
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_unspecified
-            or ip.is_multicast
-        ):
+        if not ip.is_global:
             raise ValueError("URL resolves to a non-public address")
 
 


### PR DESCRIPTION
- Consistency pass
- Dead code removal
- Remove Python2 and Python3.2 compatibility shims
- Various bugs fixes, typos

Touches the Docker image info fetching system, and error reporting when interacting with git repos

**IMPORTANT**: For security reasons eagleServer.py now default to running with debug OFF. If you want it to behave the same as previously (debug enabled), then run with:

> python eagleServer/eagleServer.py --debug [-t /tmp]

## Summary by Sourcery

Improve eagleServer API responses and remote integration robustness while cleaning up legacy compatibility code.

Bug Fixes:
- Fix error handling when opening local JSON files by returning structured JSON errors instead of failing silently or crashing.
- Correct incorrect logging of KeyErrors when parsing repository request payloads for GitHub and GitLab operations.
- Ensure GitHub/GitLab and remote URL operations consistently return JSON error responses with appropriate HTTP status codes instead of raw strings or custom response construction.

Enhancements:
- Remove obsolete Python 2 and early Python 3 compatibility shims and simplify JSON save logic for local files.
- Use a verified SSL context with certifi when fetching Docker image metadata and tags instead of globally disabling SSL verification.
- Standardize successful GitHub/GitLab file save and delete responses to return JSON objects.
- Tidy up comments, typos, and redundant code paths for improved readability and maintainability.

## Summary by Sourcery

Harden eagleServer’s remote integrations and debug behavior while cleaning up legacy code and standardizing API responses.

New Features:
- Add URL validation for remote file fetching to restrict schemes, file types, and non-public IP ranges before server-side download.
- Introduce a command-line --debug flag that controls Flask debug mode and binds the server to localhost only when enabled.

Bug Fixes:
- Return structured JSON error responses with appropriate HTTP status codes for Docker Hub, GitHub, GitLab, and generic remote URL failures instead of raw strings or 200 responses on error.
- Improve logging for GitHub and GitLab operations by replacing print statements with structured app logger calls.
- Ensure timeouts are applied when fetching remote resources such as Docker metadata, GitHub raw files, and arbitrary URLs to avoid hanging requests.

Enhancements:
- Remove obsolete Python 2 and early Python 3 compatibility shims and simplify local JSON save behavior.
- Standardize success responses from GitHub and GitLab file save and delete operations to JSON objects for consistent API behavior.
- Tighten SSL usage for outbound HTTP requests by using a verified certifi-backed SSL context instead of disabling certificate verification.
- Remove unused local temp-file helpers and endpoints and tidy comments and typos for improved maintainability.

CI:
- Update the Playwright GitHub Actions workflow to start eagleServer in debug mode for end-to-end tests.