### PR TITLE
EAGLE-1643: Fix duplicate snapshot detection in Undo system

### DIFF
--- a/e2e/undoDuplicateDetection.spec.ts
+++ b/e2e/undoDuplicateDetection.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { TestHelpers } from './TestHelpers';
+
+test('Undo duplicate snapshot detection', async ({ page }) => {
+    await page.goto('http://localhost:8888/?tutorial=none');
+    await expect(page).toHaveTitle(/EAGLE/);
+
+    // set 'Expert' UI mode
+    await TestHelpers.setUIMode(page, 'Expert');
+
+    // expand the 'Builtin Components' palette and add a HelloWorldApp node
+    await page.locator('#palette0').click();
+    await page.waitForTimeout(250);
+    await page.locator('#palette_0_HelloWorldApp').scrollIntoViewIfNeeded();
+    await page.locator('#addPaletteNodeHelloWorldApp').click();
+
+    // agree to create a new graph
+    await page.waitForTimeout(500);
+    await page.getByRole('button', { name: 'OK' }).click();
+    await page.waitForTimeout(500);
+
+    // record the undo front pointer after adding the node
+    const frontAfterAdd = await page.evaluate(() => {
+        return (window as any).eagle.undo().front();
+    });
+
+    // push a snapshot with no graph change — should be a duplicate and aborted
+    await page.evaluate(() => {
+        const eagle = (window as any).eagle;
+        eagle.undo().pushSnapshot(eagle, 'duplicate push attempt');
+    });
+
+    const frontAfterDuplicatePush = await page.evaluate(() => {
+        return (window as any).eagle.undo().front();
+    });
+
+    // front pointer must not have advanced — duplicate was detected
+    await expect(frontAfterDuplicatePush).toBe(frontAfterAdd);
+
+    // now add a File node to genuinely change the graph
+    await page.locator('#palette_0_File').scrollIntoViewIfNeeded();
+    await page.locator('#addPaletteNodeFile').click();
+    await page.waitForTimeout(500);
+
+    const frontAfterFileAdd = await page.evaluate(() => {
+        return (window as any).eagle.undo().front();
+    });
+
+    // front pointer must have advanced — the change was real
+    await expect(frontAfterFileAdd).not.toBe(frontAfterAdd);
+
+    await page.close();
+});

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -34,11 +34,22 @@ import { Utils } from './Utils';
 
 class Snapshot {
     description: ko.Observable<string>;
-    data : ko.Observable<object>;
+    data: ko.Observable<object>;
+    hash: number;
 
     constructor(description: string, data: object){
         this.description = ko.observable(description);
         this.data = ko.observable(data);
+        this.hash = Snapshot.hashObject(data);
+    }
+
+    static hashObject(obj: object): number {
+        const str = JSON.stringify(obj);
+        let hash = 5381;
+        for (let i = 0; i < str.length; i++) {
+            hash = (((hash << 5) + hash) ^ str.charCodeAt(i)) | 0;
+        }
+        return hash;
     }
 }
 
@@ -75,15 +86,15 @@ export class Undo {
         const previousIndex = (this.current() + Undo.MEMORY_SIZE - 1) % Undo.MEMORY_SIZE;
         const previousSnapshot : Snapshot = this.memory()[previousIndex];
         const newContent: object = LogicalGraph.toOJSJson(eagle.logicalGraph(), false)
+        const newSnapshot: Snapshot = new Snapshot(description, newContent);
 
         // check if newContent matches old content, if so, no need to push
-        // TODO: maybe speed this up with checksums? or maybe not required
-        if (previousSnapshot !== null && previousSnapshot.data() === newContent){
+        if (previousSnapshot !== null && previousSnapshot.hash === newSnapshot.hash){
             console.log("Undo.pushSnapshot() : content hasn't changed, abort!");
             return;
         }
 
-        this.memory()[this.current()] = new Snapshot(description, newContent);
+        this.memory()[this.current()] = newSnapshot;
         this.memory.valueHasMutated();
         this.front((this.current() + 1) % Undo.MEMORY_SIZE);
         this.current(this.front());

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -43,6 +43,7 @@ class Snapshot {
         this.hash = Snapshot.hashObject(data);
     }
 
+    // djb2-style hash function, adapted for objects by hashing their JSON string representation
     static hashObject(obj: object): number {
         const str = JSON.stringify(obj);
         let hash = 5381;


### PR DESCRIPTION
Previously it was checking to see whether two newly created objects were identical, which could never be true.

Now we store a hash along with each Undo snapshot, and can check whether a newly created snapshot matches the snapshot already stored at the top of the Undo system.

## Summary by Sourcery

Improve Undo snapshot handling to avoid storing duplicate snapshots for unchanged graph content.

Bug Fixes:
- Fix Undo system duplicate detection so snapshots are considered identical based on a stored hash of their serialized content rather than object identity.

Tests:
- Add an end-to-end test that verifies the Undo system does not create duplicate snapshots when content has not changed.