### PR TITLE
EAGLE-1628: Remove code using pkg_resources and remove dependency of setuptools version 81.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install .
       - name: Install python setuptools
-        run: pip install setuptools==81.0.0
+        run: pip install setuptools
       - name: Compile Typescript
         run: |
           npx tsc --version

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -66,9 +66,11 @@ if sys.version_info[0] == 2:
 #      because it can be overwritten by the user's command line
 TEMP_FILE_FOLDER = config.config.TEMP_FILE_FOLDER
 
-templdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../templates")
-staticdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../static")
-srcdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+templdir = os.path.normpath(os.path.join(BASE_DIR, "..", "templates"))
+staticdir = os.path.normpath(os.path.join(BASE_DIR, "..", "static"))
+srcdir = os.path.normpath(os.path.join(BASE_DIR, "..", "src"))
 
 app = Flask(__name__, template_folder=templdir, static_folder=staticdir)
 app.config.from_object("config")

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -39,7 +39,6 @@ import ssl
 
 import github
 import gitlab
-import pkg_resources
 from flask import Flask, request, render_template, jsonify, send_from_directory
 
 import config.config
@@ -67,9 +66,9 @@ if sys.version_info[0] == 2:
 #      because it can be overwritten by the user's command line
 TEMP_FILE_FOLDER = config.config.TEMP_FILE_FOLDER
 
-templdir = pkg_resources.resource_filename(__name__, "../templates")
-staticdir = pkg_resources.resource_filename(__name__, "../static")
-srcdir = pkg_resources.resource_filename(__name__, "../src")
+templdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../templates")
+staticdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../static")
+srcdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src")
 
 app = Flask(__name__, template_folder=templdir, static_folder=staticdir)
 app.config.from_object("config")


### PR DESCRIPTION
> The pkg_resources module, formerly part of the setuptools library, has been officially removed as of setuptools version 82.0.0 (released around February 2026)

This branch removes code using the pkg_resources module, and allows the unit tests to use the most recent version of setuptools, instead of pinning the version to 81.0.0.

Please make sure that pkg_resources is not required for the deployment on AWS.

## Summary by Sourcery

Remove reliance on pkg_resources for locating server templates/static/src directories and allow CI Playwright workflow to use the latest setuptools instead of pinning to version 81.

Enhancements:
- Replace pkg_resources-based resource path resolution with filesystem-based paths derived from the eagleServer module location.

CI:
- Update Playwright GitHub Actions workflow to install the latest setuptools rather than a fixed 81.0.0 version.