### PR TITLE
EAGLE-1648: Allow LogicalGraphs to be checked from memory when not loaded as the Eagle active graph

### DIFF
--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -39,14 +39,14 @@ export class TestHelpers {
     static async setShortDescription(page: Page, description: string): Promise<void> {
         await page.evaluate( (description: string) => {
             (window as any).eagle.logicalGraph().fileInfo().shortDescription = description;
-            (window as any).eagle.checkGraph();
+            (window as any).eagle.checkEagle();
         }, description);
     }
 
     static async setDetailedDescription(page: Page, description: string): Promise<void> {
         await page.evaluate( (description: string) => {
             (window as any).eagle.logicalGraph().fileInfo().detailedDescription = description;
-            (window as any).eagle.checkGraph();
+            (window as any).eagle.checkEagle();
         }, description);
     }
 

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -927,7 +927,7 @@ export class Eagle {
     
                     // TODO: handle errors and warnings
     
-                    eagle.checkGraph();
+                    eagle.checkEagle();
                     eagle.undo().pushSnapshot(eagle, "Insert Logical Graph");
                     eagle.logicalGraph.valueHasMutated();
                 });
@@ -1057,7 +1057,7 @@ export class Eagle {
 
         // flag graph as changed
         this.flagActiveFileModified();
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Create Subgraph from Selection");
         this.logicalGraph.valueHasMutated();
     }
@@ -1113,7 +1113,7 @@ export class Eagle {
 
         // flag graph as changed
         this.flagActiveFileModified();
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Add Selection to Construct");
         this.logicalGraph.valueHasMutated();
     }
@@ -2520,7 +2520,7 @@ export class Eagle {
         }, EagleConfig.STANDARD_UI_SHORT_TIMEOUT);
 
         // check graph
-        this.checkGraph();
+        this.checkEagle();
         this.undo().clear();
         this.undo().pushSnapshot(this, "Loaded " + file.name);
 
@@ -2682,7 +2682,7 @@ export class Eagle {
         // trigger re-render
         this.logicalGraph.valueHasMutated();
         this.undo().pushSnapshot(this, "Inserted " + file.name);
-        this.checkGraph();
+        this.checkEagle();
 
         // show errors/warnings
         this._handleLoadingErrors(errorsWarnings, file.name, file.repository.service);
@@ -2774,7 +2774,7 @@ export class Eagle {
         this._handleLoadingErrors(errorsWarnings, file.name, file.repository.service);
 
         // check EAGLE
-        this.checkGraph();
+        this.checkEagle();
     }
 
     findPaletteByFile = (file : RepositoryFile) : Palette => {
@@ -3198,7 +3198,7 @@ export class Eagle {
         sourceNode.setGroupEnd(this.selectedEdge().isClosesLoop());
         destNode.setGroupStart(this.selectedEdge().isClosesLoop());
 
-        this.checkGraph();
+        this.checkEagle();
 
         const groupStartValue = destNode.getFieldByDisplayText(Daliuge.FieldName.GROUP_START).getValue();
         const groupEndValue = sourceNode.getFieldByDisplayText(Daliuge.FieldName.GROUP_END).getValue();
@@ -3339,7 +3339,7 @@ export class Eagle {
                     }
 
                     // re-check graph, set undo snapshot and trigger re-render
-                    this.checkGraph();
+                    this.checkEagle();
                     this.undo().pushSnapshot(this, "Duplicate selection");
                     this.logicalGraph.valueHasMutated();
                 }
@@ -3551,7 +3551,7 @@ export class Eagle {
         }
 
         // ensure changes are reflected in display
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Paste from Clipboard");
         this.logicalGraph.valueHasMutated();
     }
@@ -3648,7 +3648,7 @@ export class Eagle {
         }
 
         // check EAGLE
-        this.checkGraph();
+        this.checkEagle();
     }
 
     addSelectedNodesToPalette = (mode: "normal"|"contextMenuRequest") : void => {
@@ -3855,7 +3855,7 @@ export class Eagle {
                 // flag LG has changed
                 this.logicalGraph().fileInfo().modified = true;
 
-                this.checkGraph();
+                this.checkEagle();
                 this.undo().pushSnapshot(this, "Delete Selection");
                 break;
 
@@ -3919,7 +3919,7 @@ export class Eagle {
         }
 
         // check, undo, modified etc
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Add edge " + edge.getId());
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph.valueHasMutated();
@@ -4065,7 +4065,7 @@ export class Eagle {
             // select the new node
             this.setSelection(newNode, Eagle.FileType.Graph);
 
-            this.checkGraph();
+            this.checkEagle();
             this.undo().pushSnapshot(this, "Add node " + newNode.getName());
             this.logicalGraph.valueHasMutated();
 
@@ -4142,7 +4142,7 @@ export class Eagle {
         destinationPalette.fileInfo().modified = true;
 
         // check EAGLE
-        this.checkGraph();
+        this.checkEagle();
     }
 
     private buildWritablePaletteNamesList = () : string[] => {
@@ -4309,7 +4309,7 @@ export class Eagle {
         field.setType(newType);
 
         // re-check the graph
-        this.checkGraph();
+        this.checkEagle();
     }
 
     graphEditComment = (object:Node | Edge): void => {
@@ -4395,7 +4395,7 @@ export class Eagle {
         selectedNode.setParent(newParent);
 
         // refresh the display
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Change Node Parent");
         this.logicalGraph().fileInfo().modified = true;
         this.selectedObjects.valueHasMutated();
@@ -4537,7 +4537,7 @@ export class Eagle {
             return;
         }
 
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Edit Field");
 
         // now that we are done, re-open the params table
@@ -4631,18 +4631,18 @@ export class Eagle {
         Utils.showNotification("Graph URL", "Copied to clipboard", "success");
     }
 
-    checkGraph = (): void => {
-        Utils.checkGraph(this);//validate the graph
+    checkEagle = (): void => {
+        Utils.checkEagle(this);//validate the graph
         const graphErrors = Utils.gatherGraphErrors() //gather all the errors from all of the components
         
         this.graphWarnings(graphErrors.warnings);
         this.graphErrors(graphErrors.errors);
     };
 
-    showGraphErrors = (): void => {
+    showEagleErrors = (): void => {
         //recheck the graph for errors, this is because we cannot rely on the fact that the graph has been checked.
         //this is to ensure that when the user requests to see the graph errors, the information is up to date
-        this.checkGraph();
+        this.checkEagle();
 
         if (this.graphWarnings().length > 0 || this.graphErrors().length > 0){
 
@@ -4650,7 +4650,7 @@ export class Eagle {
             this.errorsMode(Errors.Mode.Graph);
 
             //switch bottom window mode
-            Setting.find(Setting.BOTTOM_WINDOW_MODE).setValue(Eagle.BottomWindowMode.GraphErrors)
+            Setting.find(Setting.BOTTOM_WINDOW_MODE).setValue(Eagle.BottomWindowMode.EagleErrors)
             //show bottom window
             SideWindow.setShown('bottom',true)
         } else {
@@ -4831,7 +4831,7 @@ export class Eagle {
             }
 
             this.logicalGraph().addVisual(visual);
-            this.checkGraph();
+            this.checkEagle();
             this.undo().pushSnapshot(this, "Add Visual");
             this.logicalGraph().fileInfo().modified = true;
             this.logicalGraph.valueHasMutated();
@@ -4854,7 +4854,7 @@ export class Eagle {
         fileInfo.modified = true;
 
         // check graph (hopefully the 'missing short description' warning will go away)
-        this.checkGraph();
+        this.checkEagle();
     }
 
     editDetailedDescription = async(fileInfo: FileInfo): Promise<void> => {
@@ -4872,7 +4872,7 @@ export class Eagle {
         fileInfo.modified = true;
 
         // check graph (hopefully the 'missing detailed description' warning will go away)
-        this.checkGraph();
+        this.checkEagle();
     }
 
     editNodeDescription = async (node?: Node): Promise<void> => {
@@ -5018,7 +5018,7 @@ export class Eagle {
         oldNode.setCategoryType(newNodeCategoryType);
 
         this.flagActiveFileModified();
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Edit Node Category");
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph.valueHasMutated();
@@ -5087,7 +5087,7 @@ export class Eagle {
         this.logicalGraph.valueHasMutated();
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph().fileInfo.valueHasMutated();
-        this.checkGraph();
+        this.checkEagle();
         this.undo().pushSnapshot(this, "Check for Component Updates");
     }
 
@@ -5138,7 +5138,7 @@ export class Eagle {
         this.logicalGraph.valueHasMutated();
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph().fileInfo.valueHasMutated();
-        this.checkGraph();
+        this.checkEagle();
         const updatedNodeNames = updatedNodes.map(n => n.getName()).join(", ");
         this.undo().pushSnapshot(this, "Update Component(s): " + updatedNodeNames);
     }
@@ -5202,7 +5202,7 @@ export class Eagle {
         this.logicalGraph.valueHasMutated();
         this.logicalGraph().fileInfo().modified = true;
         this.logicalGraph().fileInfo.valueHasMutated();
-        this.checkGraph();
+        this.checkEagle();
         const updatedNodeNames = updatedNodes.map(n => n.getName()).join(", ");
         this.undo().pushSnapshot(this, "Fix Component(s): " + updatedNodeNames);
     }
@@ -5291,7 +5291,7 @@ export namespace Eagle
         NodeParameterTable = "NodeParameterTable",
         GraphConfigsTable = "GraphConfigsTable",
         ConfigParameterTable = "ConfigParameterTable",
-        GraphErrors = "GraphErrors"
+        EagleErrors = "EagleErrors"
     }
 
     export enum AddNodeMode {

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -48,7 +48,7 @@ export class Errors {
                 }
             }
 
-            eagle.checkGraph();
+            eagle.checkEagle();
         }
 
         // show notification

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -195,7 +195,7 @@ export class Field {
         this.readonly(!this.readonly())
 
         // trigger graph check
-        Eagle.getInstance().checkGraph();
+        Eagle.getInstance().checkEagle();
 
         return this;
     }
@@ -245,7 +245,7 @@ export class Field {
         this.precious(!this.precious());
 
         // trigger graph check
-        Eagle.getInstance().checkGraph();
+        Eagle.getInstance().checkEagle();
 
         return this;
     }
@@ -267,7 +267,7 @@ export class Field {
         this.changeable(!this.changeable());
 
         // trigger graph check
-        Eagle.getInstance().checkGraph();
+        Eagle.getInstance().checkEagle();
 
         return this;
     }
@@ -358,7 +358,7 @@ export class Field {
         this.positional(!this.positional());
 
         // trigger graph check
-        Eagle.getInstance().checkGraph();
+        Eagle.getInstance().checkEagle();
 
         return this;
     }

--- a/src/GraphConfig.ts
+++ b/src/GraphConfig.ts
@@ -102,7 +102,7 @@ export class GraphConfig {
         }
 
         // re-check graph
-        Eagle.getInstance().checkGraph();
+        Eagle.getInstance().checkEagle();
     }
 
     addValue = (node: Node, field: Field, value: string) => {

--- a/src/GraphRenderer.ts
+++ b/src/GraphRenderer.ts
@@ -1798,7 +1798,7 @@ export class GraphRenderer {
     static updateNodeParent(node: Node, parent: Node, allowGraphEditing: boolean): void {
         if (node.getParent() === null || parent === null || (node.getParent().getId() !== parent.getId()) && allowGraphEditing){
             node.setParent(parent);
-            Eagle.getInstance().checkGraph()   
+            Eagle.getInstance().checkEagle()   
         }
     }
 
@@ -2507,7 +2507,7 @@ export class GraphRenderer {
         }
 
         await eagle.addEdge(srcNode, srcPort, destNode, destPort, loopAware, closesLoop);
-        eagle.checkGraph();
+        eagle.checkEagle();
         eagle.undo().pushSnapshot(eagle, "Added edge from " + srcNode.getName() + " to " + destNode.getName());
         eagle.logicalGraph().fileInfo().modified = true;
         eagle.logicalGraph.valueHasMutated();

--- a/src/GraphUpdater.ts
+++ b/src/GraphUpdater.ts
@@ -275,7 +275,7 @@ export class GraphUpdater {
                         row.lastModified = date.toLocaleDateString() + " " + date.toLocaleTimeString()
 
                         // check the graph once loaded
-                        Utils.checkGraph(eagle);
+                        Utils.checkEagle(eagle);
                         const results: Errors.ErrorsWarnings = Utils.gatherGraphErrors();
                         row.numCheckWarnings = results.warnings.length;
                         row.numCheckErrors = results.errors.length;

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -600,7 +600,7 @@ export class KeyboardShortcut {
         // checking and fixing
         new KeyboardShortcut({
             id: "check_eagle",
-            text: "Check Graph",
+            text: "Check Eagle",
             keys: [new Key("!", Modifier.Shift)],
             tags: ['error','errors','fix'],
             run: (eagle): void => {eagle.showEagleErrors();}

--- a/src/KeyboardShortcut.ts
+++ b/src/KeyboardShortcut.ts
@@ -599,11 +599,11 @@ export class KeyboardShortcut {
 
         // checking and fixing
         new KeyboardShortcut({
-            id: "check_graph",
+            id: "check_eagle",
             text: "Check Graph",
             keys: [new Key("!", Modifier.Shift)],
             tags: ['error','errors','fix'],
-            run: (eagle): void => {eagle.showGraphErrors();}
+            run: (eagle): void => {eagle.showEagleErrors();}
         }),
         new KeyboardShortcut({
             id: "fix_all",

--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -672,7 +672,7 @@ export class LogicalGraph {
 
         const eagle: Eagle = Eagle.getInstance();
         eagle.undo().pushSnapshot(eagle, "Added a new graph configuration (" + config.fileInfo().name + ")");
-        eagle.checkGraph();
+        eagle.checkEagle();
     }
 
     removeGraphConfig = (config: GraphConfig): void => {
@@ -689,7 +689,7 @@ export class LogicalGraph {
         eagle.undo().pushSnapshot(eagle, "Removed graph configuration " + name);
 
         // check graph
-        eagle.checkGraph();
+        eagle.checkEagle();
     }
 
     getActiveGraphConfig = (): GraphConfig | undefined => {
@@ -1076,7 +1076,7 @@ export class LogicalGraph {
         // get reference to EAGLE
         const eagle: Eagle = Eagle.getInstance();
 
-        eagle.checkGraph();
+        eagle.checkEagle();
         eagle.undo().pushSnapshot(eagle, "Remove port from node");
         eagle.flagActiveFileModified();
         eagle.selectedObjects.valueHasMutated();
@@ -1303,10 +1303,12 @@ export class LogicalGraph {
         return radius;
     }
 
-    static isValid () : void {
+    private static withEagle(eagle: Eagle | null, fn: (e: Eagle) => void): () => void {
+        return eagle !== null ? () => fn(eagle) : () => {};
+    }
+
+    static isValid (graph: LogicalGraph, eagle: Eagle | null) : void {
         //here should be the higher level graph wide checks for graph validity
-        const eagle = Eagle.getInstance()
-        const graph = eagle.logicalGraph()
 
         // clear old issues
         graph.issues([]);
@@ -1315,7 +1317,7 @@ export class LogicalGraph {
         if (graph.fileInfo().isInitiated() && graph.fileInfo().shortDescription === ''){
             const issue: Errors.Issue = Errors.Show(
                 "Graph does not have a short description.",
-                function(){eagle.editShortDescription(graph.fileInfo())}
+                LogicalGraph.withEagle(eagle, e => e.editShortDescription(graph.fileInfo()))
             );
             graph.issues.push({issue : issue, validity : Errors.Validity.Warning})
         }
@@ -1324,7 +1326,7 @@ export class LogicalGraph {
         if (graph.fileInfo().isInitiated() && graph.fileInfo().detailedDescription === ''){
             const issue: Errors.Issue = Errors.Show(
                 "Graph does not have a detailed description.",
-                function(){eagle.editDetailedDescription(graph.fileInfo())}
+                LogicalGraph.withEagle(eagle, e => e.editDetailedDescription(graph.fileInfo()))
             );
             graph.issues.push({issue : issue, validity : Errors.Validity.Warning})
         }
@@ -1334,7 +1336,7 @@ export class LogicalGraph {
             if (node.getId() !== id){
                 const issue: Errors.Issue = Errors.ShowFix(
                     "Node (" + id + ") id does not match the key in the nodes dictionary",
-                    function(){Utils.showNode(eagle, Eagle.FileType.Graph, node)},
+                    LogicalGraph.withEagle(eagle, e => Utils.showNode(e, Eagle.FileType.Graph, node)),
                     function(){node.setId(id)},
                     "Set node id to match key in nodes dictionary"
                 );
@@ -1347,7 +1349,7 @@ export class LogicalGraph {
             if (!FileLocation.match(graphConfig.fileInfo().graphLocation, graph.fileInfo().location)){
                 const issue: Errors.Issue = Errors.ShowFix(
                     "Graph Config (" + graphConfig.fileInfo().name + ") graph location does not match the location of the parent graph",
-                    function(){Utils.showGraphConfig(eagle, graphConfig.getId())},
+                    LogicalGraph.withEagle(eagle, e => Utils.showGraphConfig(e, graphConfig.getId())),
                     function(){graphConfig.fileInfo().graphLocation = graph.fileInfo().location.clone()},
                     "Set graph config's graph location to match that of the graph"
                 );
@@ -1358,20 +1360,20 @@ export class LogicalGraph {
         // check all edges in the edges dict are also present in the srcPort or destPort edges dict
         for (const [id, edge] of graph.edges()){
             if (typeof edge.getSrcPort() === 'undefined' || typeof edge.getDestPort() === 'undefined'){
-                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") has undefined srcPort or undefined destPort", function(){Utils.showEdge(eagle, edge)});
+                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") has undefined srcPort or undefined destPort", LogicalGraph.withEagle(eagle, e => Utils.showEdge(e, edge)));
                 graph.issues.push({issue:issue, validity: Errors.Validity.Error});
                 continue;
             }
 
             // check source port
             if (typeof edge.getSrcPort().getEdgeById(id) === 'undefined'){
-                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") is not present in source port edges list", function(){Utils.showEdge(eagle, edge)});
+                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") is not present in source port edges list", LogicalGraph.withEagle(eagle, e => Utils.showEdge(e, edge)));
                 graph.issues.push({issue:issue, validity: Errors.Validity.Error});
             }
 
             // check destination port
             if (typeof edge.getDestPort().getEdgeById(id) === 'undefined'){
-                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") is not present in destination port edges list", function(){Utils.showEdge(eagle, edge)});
+                const issue: Errors.Issue = Errors.Show("Edge (" + id + ") is not present in destination port edges list", LogicalGraph.withEagle(eagle, e => Utils.showEdge(e, edge)));
                 graph.issues.push({issue:issue, validity: Errors.Validity.Error});
             }
         }
@@ -1381,7 +1383,7 @@ export class LogicalGraph {
             if (edge.getId() !== id){
                 const issue: Errors.Issue = Errors.ShowFix(
                     "Edge (" + id + ") id does not match the key in the edges dictionary",
-                    function(){Utils.showEdge(eagle, edge)},
+                    LogicalGraph.withEagle(eagle, e => Utils.showEdge(e, edge)),
                     function(){edge.setId(id)},
                     "Set edge id to match key in edges dictionary"
                 );
@@ -1395,7 +1397,7 @@ export class LogicalGraph {
             if (visual.getId() !== id){
                 const issue: Errors.Issue = Errors.ShowFix(
                     "Visual (" + id + ") id does not match the key in the visuals dictionary",
-                    function(){Utils.showVisual(eagle, visual)},
+                    LogicalGraph.withEagle(eagle, e => Utils.showVisual(e, visual)),
                     function(){visual.setId(id)},
                     "Set visual id to match key in visuals dictionary"
                 );
@@ -1423,7 +1425,7 @@ export class LogicalGraph {
                 if (!targetExists){
                     const issue: Errors.Issue = Errors.ShowFix(
                         "Visual (" + id + ") target does not exist in the graph",
-                        function(){Utils.showVisual(eagle, visual)},
+                        LogicalGraph.withEagle(eagle, e => Utils.showVisual(e, visual)),
                         function(){visual.setTarget(null)},
                         "Reset visual target to empty state"
                     );

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -477,7 +477,7 @@ export class Modals {
         });
 
         $('.parameterTable').on('hidden.bs.modal', function(){
-            eagle.checkGraph();
+            eagle.checkEagle();
         });
 
         $('.eagleTableDisplay').on('shown.bs.modal', function(){

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -316,7 +316,7 @@ export class ParameterTable {
         }
 
         // trigger graph check, since changing the usage of a field may break some rules
-        eagle.checkGraph();
+        eagle.checkEagle();
     }
 
     // when a field value is modified in the parameter table, we need to flag the containing palette or logical graph as modified
@@ -336,7 +336,7 @@ export class ParameterTable {
             case Eagle.FileType.Graph:
                 eagle.logicalGraph().fileInfo().modified = true;
 
-                eagle.checkGraph();
+                eagle.checkEagle();
                 break;
         }
     }

--- a/src/Undo.ts
+++ b/src/Undo.ts
@@ -141,7 +141,7 @@ export class Undo {
             Undo.printTable();
         }
 
-        eagle.checkGraph();
+        eagle.checkEagle();
 
         this._updateSelection();
 
@@ -171,7 +171,7 @@ export class Undo {
             Undo.printTable();
         }
 
-        eagle.checkGraph();
+        eagle.checkEagle();
 
         this._updateSelection();
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1580,11 +1580,10 @@ export class Utils {
         return errorsWarnings;
     }
 
-    // TODO: maybe re-name, since this checks everything now, not just the graph. And maybe move to Eagle class?
-    static checkGraph(eagle: Eagle): void {
+    static checkEagle(eagle: Eagle): void {
         const graph: LogicalGraph = eagle.logicalGraph();
 
-        LogicalGraph.isValid();
+        LogicalGraph.isValid(graph, eagle);
 
         // check all nodes are valid
         for (const node of graph.getNodes()){
@@ -2402,7 +2401,7 @@ export class Utils {
         eagle.selectedObjects.valueHasMutated();
         eagle.logicalGraph().fileInfo().modified = true;
 
-        eagle.checkGraph();
+        eagle.checkEagle();
         eagle.undo().pushSnapshot(eagle, "Fix");
     }
 
@@ -3105,7 +3104,7 @@ export class Utils {
                 graphConfig.fileInfo().name = Daliuge.DEFAULT_GRAPH_CONFIGURATION_NAME;
                 logicalGraph.addGraphConfig(graphConfig, false);
 
-                eagle.checkGraph();
+                eagle.checkEagle();
                 eagle.undo().pushSnapshot(eagle, "Specify Logical Graph name");
                 eagle.logicalGraph.valueHasMutated();
                 Utils.showNotification("Graph named", filename, "success");

--- a/src/tutorials/graphBuilding.ts
+++ b/src/tutorials/graphBuilding.ts
@@ -126,7 +126,7 @@ newTut.newTutStep("Connecting nodes", "<em>Click and hold the output Port of the
 .setAlternateHighlightTargetFunc(function(){return $("#logicalGraphParent")})
 .setConditionFunction(function(eagle:Eagle){if(eagle.logicalGraph().getNumEdges() != 0){return true}else{return false}}) //check if there are any edges present in the graph
 
-newTut.newTutStep("Graph Errors and warnings", "This is the error checking system, it is showing a check mark, so we did everything correctly. If there are errors in the graph you are able to troubleshoot them by clicking here.", function(){return $("#checkGraphWarnings")})
+newTut.newTutStep("Graph Errors and warnings", "This is the error checking system, it is showing a check mark, so we did everything correctly. If there are errors in the graph you are able to troubleshoot them by clicking here.", function(){return $("#checkEagleWarnings")})
 
 newTut.newTutStep("Saving a Graph", "Options to save your graph are available in the graph menu <em>Click on 'Graph' to continue.</em>", function(){return $("#navbarDropdownGraph")})
 .setType(TutorialStep.Type.Press)

--- a/static/base.css
+++ b/static/base.css
@@ -81,7 +81,7 @@ body {
     top: 10px;
 }
 
-#checkGraphWarnings span{
+#checkEagleWarnings span{
     top: -3px;
 }
 
@@ -208,7 +208,7 @@ body {
     font-size: 20px;
 }
 
-#checkGraphDone i{
+#checkEagleDone i{
 color: #00bb00;}
 
 #navBarToolBar .navbarGroup button:first-of-type{

--- a/templates/Errors.html
+++ b/templates/Errors.html
@@ -13,10 +13,10 @@
         <div class='accordion' id='issuesDisplayAccordion'>
 
             <div class="accordion-item" id="issuesDisplayErrorsAccordionItem">
-                <h2 class="accordion-header" id="checkGraphAccordionHeadingOne">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors&nbsp;<span id="issuesDisplayErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
+                <h2 class="accordion-header" id="checkEagleAccordionHeadingOne">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkEagleAccordionCollapseOne" aria-expanded="true" aria-controls="checkEagleAccordionCollapseOne"> Errors&nbsp;<span id="issuesDisplayErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
                 </h2>
-                <div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">
+                <div id="checkEagleAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkEagleAccordionHeadingOne">
                     <div class="accordion-body" id="issuesDisplayErrorsAccordionBody">
                         <ul class="list-group">
                         <!-- ko foreach: Errors.getErrors -->
@@ -38,10 +38,10 @@
             </div>
 
             <div class="accordion-item" id="issuesDisplayWarningsAccordionItem">
-                <h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings&nbsp;<span id="issuesDisplayWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
+                <h2 class="accordion-header" id="checkEagleAccordionHeadingTwo">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkEagleAccordionCollapseTwo" aria-expanded="true" aria-controls="checkEagleAccordionCollapseTwo"> Warnings&nbsp;<span id="issuesDisplayWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
                 </h2>
-                <div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">
+                <div id="checkEagleAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkEagleAccordionHeadingTwo">
                     <div class="accordion-body" id="issuesDisplayWarningsAccordionBody">
                         <ul class="list-group">
                         <!-- ko foreach: Errors.getWarnings -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -230,7 +230,7 @@
                             <button id="bottomTabGraphConfigurationsSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphConfigsTable}, click: function(){GraphConfigurationsTable.openTable()}, eagleTooltip: KeyboardShortcut.idToFullText('open_graph_configurations_table')">
                                 <i class="md-20 icon-config_table clickable"></i>
                             </button>
-                            <button id="bottomTabGraphIssuesSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphErrors}, click: function(){eagle.showGraphErrors()}, eagleTooltip: `Display Graph Issues`">
+                            <button id="bottomTabGraphIssuesSwitcher" class="btn btn-secondary btn-sm iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="css:{activeTab:Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.EagleErrors}, click: function(){eagle.showEagleErrors()}, eagleTooltip: `Display Graph Issues`">
                                 <i class="md-20 icon-question_mark clickable"></i>
                             </button>
                         </div>
@@ -249,7 +249,7 @@
                             <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphConfigsTable -->
                                 {% include 'graph_configurations_table.html' %}
                             <!-- /ko -->
-                            <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.GraphErrors -->
+                            <!-- ko if: Setting.findValue(Setting.BOTTOM_WINDOW_MODE) === Eagle.BottomWindowMode.EagleErrors -->
                                 {% include 'Errors.html' %}
                             <!-- /ko -->
                         <!-- /ko -->

--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -25,7 +25,7 @@
                                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getInspectorDescriptionHTML(), click: $root.editNodeDescription" data-bs-toggle="tooltip" data-html="true">library_books</i>
                                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getInspectorCommentHTML(), click: function(){$root.editNodeComment($data)}" data-bs-toggle="tooltip" data-html="true">chat</i>
                                     <!-- ko if: $data.getAllErrorsWarnings().errors.length > 0 || $data.getAllErrorsWarnings().warnings.length > 0 -->
-                                        <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}, click: $root.showGraphErrors" data-bs-toggle="tooltip" data-html="true">error</i>
+                                        <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}, click: $root.showEagleErrors" data-bs-toggle="tooltip" data-html="true">error</i>
                                     <!-- /ko -->
                                 </div>
                                 <div class="col-7 col text-right">
@@ -181,7 +181,7 @@
                                 <div class="col-4 col">
                                     <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getInspectorCommentHTML(), click: $root.editEdgeComment" data-bs-toggle="tooltip" data-html="true">chat</i>
                                     <!-- ko if: $data.getErrorsWarnings().errors.length > 0 || $data.getErrorsWarnings().warnings.length > 0 -->
-                                        <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}, click: $root.showGraphErrors" data-bs-toggle="tooltip" data-html="true">error</i>
+                                        <i class="material-symbols-outlined filled interactive clickable iconHoverEffect" data-bs-placement="right" data-bind="eagleTooltip: $data.getNodeIssuesHtml(), style:{'color': $data.getIconColor()}, click: $root.showEagleErrors" data-bs-toggle="tooltip" data-html="true">error</i>
                                     <!-- /ko -->
                                 </div>
                                 <div class="col-8 col text-right">

--- a/templates/modals/errors.html
+++ b/templates/modals/errors.html
@@ -10,10 +10,10 @@
                 <div class='accordion' id='issuesModalAccordion'>
 
                     <div class="accordion-item" id="issuesModalErrorsAccordionItem">
-                        <h2 class="accordion-header" id="checkGraphAccordionHeadingOne">
-                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseOne" aria-expanded="true" aria-controls="checkGraphAccordionCollapseOne"> Errors&nbsp;<span id="issuesModalErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
+                        <h2 class="accordion-header" id="checkEagleAccordionHeadingOne">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkEagleAccordionCollapseOne" aria-expanded="true" aria-controls="checkEagleAccordionCollapseOne"> Errors&nbsp;<span id="issuesModalErrorCount" data-bind="text: '[' + Errors.getErrors().length + ']'"></span></button>
                         </h2>
-                        <div id="checkGraphAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingOne">
+                        <div id="checkEagleAccordionCollapseOne" class="accordion-collapse collapse show" aria-labelledby="checkEagleAccordionHeadingOne">
                             <div class="accordion-body" id="issuesModalErrorsAccordionBody">
                                 <ul class="list-group">
                                 <!-- ko foreach: Errors.getErrors -->
@@ -35,10 +35,10 @@
                     </div>
 
                     <div class="accordion-item" id="issuesModalWarningsAccordionItem">
-                        <h2 class="accordion-header" id="checkGraphAccordionHeadingTwo">
-                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkGraphAccordionCollapseTwo" aria-expanded="true" aria-controls="checkGraphAccordionCollapseTwo"> Warnings&nbsp;<span id="issuesModalWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
+                        <h2 class="accordion-header" id="checkEagleAccordionHeadingTwo">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#checkEagleAccordionCollapseTwo" aria-expanded="true" aria-controls="checkEagleAccordionCollapseTwo"> Warnings&nbsp;<span id="issuesModalWarningCount" data-bind="text: '[' + Errors.getWarnings().length + ']'"></span></button>
                         </h2>
-                        <div id="checkGraphAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkGraphAccordionHeadingTwo">
+                        <div id="checkEagleAccordionCollapseTwo" class="accordion-collapse collapse show" aria-labelledby="checkEagleAccordionHeadingTwo">
                             <div class="accordion-body" id="issuesModalWarningsAccordionBody">
                                 <ul class="list-group">
                                 <!-- ko foreach: Errors.getWarnings -->

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -95,12 +95,12 @@
                 <div class="btn-group ms-4 navbarGroup" role="group" aria-label="Basic example" data-bind="css: {'navbarGroupWarning': graphWarnings().length > 0, 'navbarGroupError': graphErrors().length > 0,'navbarGroupSuccess':graphWarnings().length === 0 && graphErrors().length === 0}">
                     <span class="navBarToolBarTitle">Issues</span>
                     <!-- ko if: graphWarnings().length === 0 && graphErrors().length === 0 -->
-                        <button id="checkGraphDone" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: showGraphErrors, eagleTooltip: 'Check Graph for Errors'">
+                        <button id="checkEagleDone" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: showEagleErrors, eagleTooltip: 'Check Graph for Errors'">
                             <i class="material-symbols-outlined md-18">done_all</i>
                         </button>
                     <!-- /ko -->
                     <!-- ko if: graphWarnings().length > 0 || graphErrors().length > 0 -->
-                        <button id="checkGraphWarnings" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" style="display:none;" data-bind="click: showGraphErrors, visible:$root.logicalGraph()!=null, css: {'btn-outline-warning': graphWarnings().length > 0, 'btn-outline-danger': graphErrors().length > 0}, eagleTooltip: KeyboardShortcut.idToFullText('check_graph')">
+                        <button id="checkEagleWarnings" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" style="display:none;" data-bind="click: showEagleErrors, visible:$root.logicalGraph()!=null, css: {'btn-outline-warning': graphWarnings().length > 0, 'btn-outline-danger': graphErrors().length > 0}, eagleTooltip: KeyboardShortcut.idToFullText('check_eagle')">
                             <span class="badge bg-warning" data-bind="text: graphWarnings().length, visible: graphWarnings().length > 0"></span>
                             <span class="badge bg-danger" data-bind="text: graphErrors().length, visible: graphErrors().length > 0"></span>
                         </button>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -95,7 +95,7 @@
                 <div class="btn-group ms-4 navbarGroup" role="group" aria-label="Basic example" data-bind="css: {'navbarGroupWarning': graphWarnings().length > 0, 'navbarGroupError': graphErrors().length > 0,'navbarGroupSuccess':graphWarnings().length === 0 && graphErrors().length === 0}">
                     <span class="navBarToolBarTitle">Issues</span>
                     <!-- ko if: graphWarnings().length === 0 && graphErrors().length === 0 -->
-                        <button id="checkEagleDone" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: showEagleErrors, eagleTooltip: 'Check Graph for Errors'">
+                        <button id="checkEagleDone" class="btn navbar-btn iconHoverEffect" type="button" data-bs-placement="bottom" data-bind="click: showEagleErrors, eagleTooltip: KeyboardShortcut.idToFullText('check_eagle')">
                             <i class="material-symbols-outlined md-18">done_all</i>
                         </button>
                     <!-- /ko -->


### PR DESCRIPTION
Preparatory work for EAGLE-1556 (Update old graphs script) which needs to test graphs after updating, to notify the user of errors in the resulting graph.

Renaming checkGraph functions/ids to make their purpose clearer, since it is actually more like 'checkEagle'.

Refactor of LogicalGraph.isValid to make it possible to check graphs even when they are not loaded into Eagle as the currently edited graph.

## Summary by Sourcery

Refactor graph validation to support checking logical graphs independently of the active Eagle instance and rename related APIs and UI bindings from graph-specific to Eagle-wide terminology.

Enhancements:
- Rename graph validation APIs, keyboard shortcut IDs, UI bindings, and CSS hooks from graph-focused (checkGraph/GraphErrors) to Eagle-focused (checkEagle/EagleErrors) terminology for clarity.
- Update LogicalGraph validity checks to accept an explicit graph and optional Eagle instance so graphs can be validated even when not loaded as the active graph.
- Adjust error display flows, inspectors, tutorials, and modals to use the new Eagle-wide validation entry points and bottom-window mode.