### PR TITLE
EAGLE-1649: Improve reliability of cloneLogicalGraph.spec.ts unit test

### DIFF
--- a/e2e/cloneLogicalGraph.spec.ts
+++ b/e2e/cloneLogicalGraph.spec.ts
@@ -24,7 +24,6 @@ test('LogicalGraph.clone() does not share references with original', async ({ pa
 
     // center the graph
     await page.getByRole('button', { name: 'filter_center_focus' }).click();
-    await page.waitForTimeout(200);
 
     // draw an edge from HelloWorldApp output to File input
     await page.waitForTimeout(250);

--- a/e2e/cloneLogicalGraph.spec.ts
+++ b/e2e/cloneLogicalGraph.spec.ts
@@ -26,16 +26,21 @@ test('LogicalGraph.clone() does not share references with original', async ({ pa
     await page.getByRole('button', { name: 'filter_center_focus' }).click();
 
     // draw an edge from HelloWorldApp output to File input
-    await page.waitForTimeout(250);
-    const srcPortBox = await page.locator('#HelloWorldApp .outputPort').boundingBox();
-    const destPortBox = await page.locator('#File .inputPort').boundingBox();
+    const srcPort = page.locator('#HelloWorldApp .outputPort');
+    const destPort = page.locator('#File .inputPort');
 
-    expect(srcPortBox).not.toBeNull();
-    expect(destPortBox).not.toBeNull();
+    await expect(srcPort, 'source port should be visible before dragging').toBeVisible();
+    await expect(destPort, 'destination port should be visible before dragging').toBeVisible();
 
-    if (!srcPortBox || !destPortBox) {
-        throw new Error('Could not locate source or destination port for drag operation');
-    }
+    const requireBox = (box: { width: number; height: number } | null, message: string) => {
+        expect(box, message).not.toBeNull();
+        return box as { width: number; height: number };
+    };
+
+    const [srcPortBox, destPortBox] = [
+        requireBox(await srcPort.boundingBox(), 'source port should have a bounding box before dragging'),
+        requireBox(await destPort.boundingBox(), 'destination port should have a bounding box before dragging')
+    ];
 
     await page.dragAndDrop('#HelloWorldApp .outputPort', '#File .inputPort', {
         sourcePosition: { x: srcPortBox.width / 2, y: srcPortBox.height / 2 },

--- a/e2e/cloneLogicalGraph.spec.ts
+++ b/e2e/cloneLogicalGraph.spec.ts
@@ -27,9 +27,20 @@ test('LogicalGraph.clone() does not share references with original', async ({ pa
     await page.waitForTimeout(200);
 
     // draw an edge from HelloWorldApp output to File input
+    await page.waitForTimeout(250);
+    const srcPortBox = await page.locator('#HelloWorldApp .outputPort').boundingBox();
+    const destPortBox = await page.locator('#File .inputPort').boundingBox();
+
+    expect(srcPortBox).not.toBeNull();
+    expect(destPortBox).not.toBeNull();
+
+    if (!srcPortBox || !destPortBox) {
+        throw new Error('Could not locate source or destination port for drag operation');
+    }
+
     await page.dragAndDrop('#HelloWorldApp .outputPort', '#File .inputPort', {
-        sourcePosition: { x: 2, y: 2 },
-        targetPosition: { x: 2, y: 2 }
+        sourcePosition: { x: srcPortBox.width / 2, y: srcPortBox.height / 2 },
+        targetPosition: { x: destPortBox.width / 2, y: destPortBox.height / 2 }
     });
     await page.waitForTimeout(500);
 


### PR DESCRIPTION
At the moment, this test is failing more often than it succeeds in Github CI.

This AI suggested change finds the boundingBox for each port, and makes sure to drag from and to the middle of the bounding boxes. It seems to be more reliable.

It also adds a clear Error if it could not locate either the source or destination ports.

## Summary by Sourcery

Improve reliability of the LogicalGraph.clone end-to-end test when creating edges between nodes.

Bug Fixes:
- Prevent flaky failures in the cloneLogicalGraph end-to-end test by making the drag operation more robust and explicit when connecting ports.

Tests:
- Update the cloneLogicalGraph end-to-end test to drag from the center of computed port bounding boxes and surface a clear error when ports cannot be located.