### PR TITLE
EAGLE-1653: Readthedocs publishing cancelled unless commit has a tag

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,14 @@ build:
     python: "3.10"
   jobs:
     post_checkout:
-      # Only publish documentation for exact Git tags.
+      # Only publish documentation for tag builds on Read the Docs.
+      # Use RTD build metadata as the primary signal to avoid relying on git tags
+      # being available in the checkout (e.g., shallow clones).
       # Exit code 183 tells Read the Docs to cancel the build cleanly.
       - |
-        git describe --exact-match --tags HEAD >/dev/null 2>&1 || exit 183
+        if [ "${READTHEDOCS_VERSION_TYPE:-}" != "tag" ]; then
+          exit 183
+        fi
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      # Only publish documentation for exact Git tags.
+      # Exit code 183 tells Read the Docs to cancel the build cleanly.
+      - |
+        git describe --exact-match --tags HEAD >/dev/null 2>&1 || exit 183
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
Only publish to readthedocs if the commit is tagged. This will prevent issues like we have at the moment, where the features in master, but not released, are already documented on readthedocs.

## Summary by Sourcery

Build:
- Add a post-checkout job in the Read the Docs configuration that cancels documentation builds when the current commit is not an exact Git tag.