### PR TITLE
EAGLE-1657: Set LogicalGraph fileInfo schemaVersion to V4 upon creation

### DIFF
--- a/src/LogicalGraph.ts
+++ b/src/LogicalGraph.ts
@@ -52,6 +52,7 @@ export class LogicalGraph {
     constructor(){
         this.fileInfo = ko.observable(new FileInfo());
         this.fileInfo().type = Eagle.FileType.Graph;
+        this.fileInfo().schemaVersion = Setting.SchemaVersion.V4;
         this.fileInfo().readonly = false;
         this.fileInfo().builtIn = false;
         this.nodes = ko.observable(new Map<NodeId, Node>());


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Default LogicalGraph fileInfo now explicitly sets schemaVersion to V4 on creation.