### PR TITLE
EAGLE-1657: Fixed bug where LG num nodes was not shown in the Graph Inspector

### DIFF
--- a/templates/inspector.html
+++ b/templates/inspector.html
@@ -358,7 +358,15 @@
                                 <h5>Num Nodes: </h5>
                             </div>  
                             <div class="col-6 col contentObjectValue">
-                                <span data-bind="text:$root.logicalGraph().getNodes().length"></span>
+                                <span data-bind="text:$root.logicalGraph().nodes().size"></span>
+                            </div>
+                        </div>
+                        <div class="row inspectorEdgeSrcNodeId contentObject">
+                            <div class="col-6 col contentObjectTitle">
+                                <h5>Num Edges: </h5>
+                            </div>  
+                            <div class="col-6 col contentObjectValue">
+                                <span data-bind="text:$root.logicalGraph().edges().size"></span>
                             </div>
                         </div>
                         <div class="row inspectorEdgeSrcNodeId contentObject">


### PR DESCRIPTION
Added num edges to the Graph Inspector.

## Summary by Sourcery

Update graph inspector to correctly display logical graph node count and include edge count.

New Features:
- Display the number of edges in the logical graph within the Graph Inspector.

Bug Fixes:
- Fix the Graph Inspector so that the logical graph node count is retrieved from the nodes collection size instead of the previous method.