### PR TITLE
EAGLE-1647: Updated versions of github actions in CICD workflows to the latest

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: PIP install
@@ -37,7 +37,7 @@ jobs:
         run: npm install @playwright/test@latest
       - name: Run Playwright tests
         run: npx playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
actions/checkout@v4 → @v6
actions/setup-node@v4 → @v6
actions/setup-python@v5 → @v6
actions/upload-artifact@v4 → @v7

## Summary by Sourcery

CI:
- Bump checkout, setup-node, setup-python, and upload-artifact actions to newer major versions in the Playwright workflow.