### PR TITLE
EAGLE-1631: Anonymous file loading from public git repos if credentials are missing/incorrect

### DIFF
--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -302,6 +302,7 @@ def get_git_hub_files_all():
     folder_name, repo_name = extract_folder_and_repo_names(repo_name)
 
     # authenticate or not
+    credentials_ignored = False
     g = github.Github(repo_token) if repo_token else github.Github()
 
     try:
@@ -310,8 +311,20 @@ def get_git_hub_files_all():
         print("UnknownObjectException {1}: {0}".format(str(uoe), repo_name))
         return jsonify({"error":uoe.message})
     except github.GithubException as ge:
-        print("GithubException {1}: {0}".format(str(ge), repo_name))
-        return jsonify({"error":ge.data.get("message", str(ge))})
+        if ge.status == 401 and repo_token:
+            # bad credentials - fall back to anonymous access for public repos
+            print("GithubException 401 for {0}, retrying anonymously".format(repo_name))
+            credentials_ignored = True
+            g = github.Github()
+            try:
+                repo = g.get_repo(repo_name)
+            except github.UnknownObjectException as uoe:
+                return jsonify({"error":uoe.message})
+            except github.GithubException as ge2:
+                return jsonify({"error":ge2.data.get("message", str(ge2))})
+        else:
+            print("GithubException {1}: {0}".format(str(ge), repo_name))
+            return jsonify({"error":ge.data.get("message", str(ge))})
 
     # get results
     d = parse_github_folder(repo, repo_path, repo_branch)
@@ -323,7 +336,7 @@ def get_git_hub_files_all():
         return jsonify({"error":str(d)})
 
     # return correct result
-    return jsonify(d)
+    return jsonify({"files": d, "credentialsIgnored": credentials_ignored})
 
 
 @app.route("/getGitLabFilesAll", methods=["POST"])
@@ -345,13 +358,16 @@ def get_git_lab_files_all():
         app.logger.error("KeyError in getGitLabFilesAll: %s", ke)
         return jsonify({"error":"Repository, Branch or Token not specified in request"}), 400
 
+    credentials_ignored = False
     if repo_token:
         gl = gitlab.Gitlab('https://gitlab.com', private_token=repo_token, api_version=4)
         try:
             gl.auth()
         except gitlab.exceptions.GitlabAuthenticationError as gae:
-            print("GitlabAuthenticationError {1}: {0}".format(str(gae), repo_name))
-            return jsonify({"error": "Gitlab Authentication Error. Access token may be invalid." + "\n" + str(gae)})
+            # bad credentials - fall back to anonymous access for public repos
+            print("GitlabAuthenticationError {1}: {0}, retrying anonymously".format(str(gae), repo_name))
+            credentials_ignored = True
+            gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
 
@@ -365,7 +381,7 @@ def get_git_lab_files_all():
     d = parse_gitlab_folder(items, repo_path)
 
     # return correct result
-    return jsonify(d)
+    return jsonify({"files": d, "credentialsIgnored": credentials_ignored})
 
 
 @app.route("/getDockerImages", methods=["POST"])
@@ -630,10 +646,23 @@ def open_git_hub_file():
         filename = folder_name + "/" + filename
 
     # use authentication or not
+    credentials_ignored = False
     g = github.Github(repo_token) if repo_token else github.Github()
 
     try:
         repo = g.get_repo(repo_name)
+    except github.GithubException as ge:
+        if ge.status == 401 and repo_token:
+            # bad credentials - fall back to anonymous access for public repos
+            print("GithubException 401 for {0}, retrying anonymously".format(repo_name))
+            credentials_ignored = True
+            g = github.Github()
+            try:
+                repo = g.get_repo(repo_name)
+            except Exception as e:
+                return jsonify({"error": str(e)}), 404
+        else:
+            return jsonify({"error": ge.data.get("message", str(ge))}), 404
     except Exception as e:
         return jsonify({"error": str(e)}), 404
 
@@ -690,15 +719,10 @@ def open_git_hub_file():
 
         json_data = json.dumps(graph, indent=4)
 
-        response = app.response_class(
-            response=json.dumps(json_data), status=200, mimetype="application/json"
-        )
+        return jsonify({"data": json_data, "credentialsIgnored": credentials_ignored})
     else:
-        response = app.response_class(
-            response=raw_data, status=200, mimetype="text/plain"
-        )
-    
-    return response
+        raw_str = raw_data if isinstance(raw_data, str) else raw_data.decode("utf-8")
+        return jsonify({"data": raw_str, "credentialsIgnored": credentials_ignored})
 
 
 @app.route("/deleteRemoteGithubFile", methods=["POST"])
@@ -765,13 +789,16 @@ def open_git_lab_file():
     #print("folder_name", folder_name, "repo_name", repo_name, "filename", filename)
 
     # get the data from gitlab
+    credentials_ignored = False
     if repo_token:
         gl = gitlab.Gitlab('https://gitlab.com', private_token=repo_token, api_version=4)
         try:
             gl.auth()
-        except Exception as e:
-            app.logger.exception("GitLab auth failed for %s", repo_name)
-            return jsonify({"error": str(e)}), 404
+        except gitlab.exceptions.GitlabAuthenticationError:
+            # bad credentials - fall back to anonymous access for public repos
+            print("GitLab auth failed for {0}, retrying anonymously".format(repo_name))
+            credentials_ignored = True
+            gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
 
@@ -803,15 +830,9 @@ def open_git_lab_file():
 
         json_data = json.dumps(graph, indent=4)
 
-        response = app.response_class(
-            response=json.dumps(json_data), status=200, mimetype="application/json"
-        )
+        return jsonify({"data": json_data, "credentialsIgnored": credentials_ignored})
     else:
-        response = app.response_class(
-            response=raw_data, status=200, mimetype="text/plain"
-        )
-        
-    return response
+        return jsonify({"data": raw_data, "credentialsIgnored": credentials_ignored})
 
 
 @app.route("/deleteRemoteGitlabFile", methods=["POST"])

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -368,6 +368,9 @@ def get_git_lab_files_all():
             print("GitlabAuthenticationError {1}: {0}, retrying anonymously".format(str(gae), repo_name))
             credentials_ignored = True
             gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
+        except gitlab.exceptions.GitlabError as ge:
+            print("GitlabError during auth {1}: {0}".format(str(ge), repo_name))
+            return jsonify({"error": "GitLab error during authentication: " + str(ge)})
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
 
@@ -799,6 +802,9 @@ def open_git_lab_file():
             print("GitLab auth failed for {0}, retrying anonymously".format(repo_name))
             credentials_ignored = True
             gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
+        except gitlab.exceptions.GitlabError as ge:
+            app.logger.exception("GitLab error during auth for %s", repo_name)
+            return jsonify({"error": "GitLab error during authentication: " + str(ge)}), 404
     else:
         gl = gitlab.Gitlab('https://gitlab.com', api_version=4)
 
@@ -832,7 +838,8 @@ def open_git_lab_file():
 
         return jsonify({"data": json_data, "credentialsIgnored": credentials_ignored})
     else:
-        return jsonify({"data": raw_data, "credentialsIgnored": credentials_ignored})
+        raw_str = raw_data if isinstance(raw_data, str) else raw_data.decode("utf-8")
+        return jsonify({"data": raw_str, "credentialsIgnored": credentials_ignored})
 
 
 @app.route("/deleteRemoteGitlabFile", methods=["POST"])

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1019,7 +1019,7 @@ export class Eagle {
                 this.errorsMode(Errors.Mode.Loading);
                 Utils.showErrorsModal("Loading File");
             } else {
-                Utils.showNotification("Warning", "File (" + fileName + ") loaded successfully but contains one or more warnings or errors.", "warning");
+                Utils.showNotification("Warning", "File (" + fileName + ") loaded successfully from " + service + " but contains one or more warnings or errors.", "warning");
             }
         } else {
             Utils.showNotification("Success", fileName + " has been loaded from " + service + ".", "success");

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -136,7 +136,11 @@ export class GitHub {
 
             // warn if credentials were ignored (bad token, fell back to anonymous access)
             if (data.credentialsIgnored){
-                Utils.showNotification("GitHub Access Token", "The GitHub access token is invalid and was ignored. The repository was accessed anonymously.", "warning");
+                Utils.showNotification(
+                    "GitHub Access Token",
+                    "The GitHub access token is invalid and was ignored while loading " + repository.name + " / " + path + ". The repository was accessed anonymously.",
+                    "warning"
+                );
             }
 
             // flag as fetched and expand by default
@@ -232,7 +236,11 @@ export class GitHub {
 
             // warn if credentials were ignored (bad token, fell back to anonymous access)
             if (data.credentialsIgnored){
-                Utils.showNotification("GitHub Access Token", "The GitHub access token is invalid and was ignored. The file was loaded from a public repository.", "warning");
+                Utils.showNotification(
+                    "GitHub Access Token",
+                    "The GitHub access token is invalid and was ignored while loading " + repositoryName + " / " + repositoryBranch + " / " + fullFileName + ". The file was loaded from a public repository.",
+                    "warning"
+                );
             }
 
             resolve(data.data);

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -134,15 +134,6 @@ export class GitHub {
                 return;
             }
 
-            // warn if credentials were ignored (bad token, fell back to anonymous access)
-            if (data.credentialsIgnored){
-                Utils.showNotification(
-                    "GitHub Access Token",
-                    "The GitHub access token is invalid and was ignored while loading " + repository.name + " / " + path + ". The repository was accessed anonymously.",
-                    "warning"
-                );
-            }
-
             // flag as fetched and expand by default
             location.fetched(true);
             location.expanded(true);

--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -134,6 +134,11 @@ export class GitHub {
                 return;
             }
 
+            // warn if credentials were ignored (bad token, fell back to anonymous access)
+            if (data.credentialsIgnored){
+                Utils.showNotification("GitHub Access Token", "The GitHub access token is invalid and was ignored. The repository was accessed anonymously.", "warning");
+            }
+
             // flag as fetched and expand by default
             location.fetched(true);
             location.expanded(true);
@@ -142,7 +147,7 @@ export class GitHub {
             location.files.removeAll();
             location.folders.removeAll();
 
-            const fileNames : string[] = data[""];
+            const fileNames : string[] = data.files[""];
 
             // sort the fileNames
             fileNames.sort(Repository.fileSortFunc);
@@ -156,7 +161,7 @@ export class GitHub {
             }
 
             // add folders to repo
-            for (const path in data){
+            for (const path in data.files){
                 // skip the root directory
                 if (path === ""){
                     continue;
@@ -224,7 +229,13 @@ export class GitHub {
                 reject(error);
                 return;
             }
-            resolve(data);
+
+            // warn if credentials were ignored (bad token, fell back to anonymous access)
+            if (data.credentialsIgnored){
+                Utils.showNotification("GitHub Access Token", "The GitHub access token is invalid and was ignored. The file was loaded from a public repository.", "warning");
+            }
+
+            resolve(data.data);
         });
     }
 

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -103,6 +103,11 @@ export class GitLab {
                 return;
             }
 
+            // warn if credentials were ignored (bad token, fell back to anonymous access)
+            if (data.credentialsIgnored){
+                Utils.showNotification("GitLab Access Token", "The GitLab access token is invalid and was ignored. The repository was accessed anonymously.", "warning");
+            }
+
             // flag as fetched and expand by default
             location.fetched(true);
             location.expanded(true);
@@ -111,7 +116,7 @@ export class GitLab {
             location.files.removeAll();
             location.folders.removeAll();
 
-            const fileNames : string[] = data[""];
+            const fileNames : string[] = data.files[""];
 
             // sort the fileNames
             fileNames.sort(Repository.fileSortFunc);
@@ -125,7 +130,7 @@ export class GitLab {
             }
 
             // add folders to repo
-            for (const path in data){
+            for (const path in data.files){
                 // skip the root directory
                 if (path === ""){
                     continue;
@@ -194,7 +199,13 @@ export class GitLab {
                 reject(error);
                 return;
             }
-            resolve(data);
+
+            // warn if credentials were ignored (bad token, fell back to anonymous access)
+            if (data.credentialsIgnored){
+                Utils.showNotification("GitLab Access Token", "The GitLab access token is invalid and was ignored. The file was loaded from a public repository.", "warning");
+            }
+
+            resolve(data.data);
         });
     }
 

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -103,15 +103,6 @@ export class GitLab {
                 return;
             }
 
-            // warn if credentials were ignored (bad token, fell back to anonymous access)
-            if (data.credentialsIgnored){
-                Utils.showNotification(
-                    "GitLab Access Token",
-                    "The GitLab access token is invalid and was ignored while loading " + repository.name + " / " + path + ". The repository was accessed anonymously.",
-                    "warning"
-                );
-            }
-
             // flag as fetched and expand by default
             location.fetched(true);
             location.expanded(true);

--- a/src/GitLab.ts
+++ b/src/GitLab.ts
@@ -105,7 +105,11 @@ export class GitLab {
 
             // warn if credentials were ignored (bad token, fell back to anonymous access)
             if (data.credentialsIgnored){
-                Utils.showNotification("GitLab Access Token", "The GitLab access token is invalid and was ignored. The repository was accessed anonymously.", "warning");
+                Utils.showNotification(
+                    "GitLab Access Token",
+                    "The GitLab access token is invalid and was ignored while loading " + repository.name + " / " + path + ". The repository was accessed anonymously.",
+                    "warning"
+                );
             }
 
             // flag as fetched and expand by default
@@ -202,7 +206,11 @@ export class GitLab {
 
             // warn if credentials were ignored (bad token, fell back to anonymous access)
             if (data.credentialsIgnored){
-                Utils.showNotification("GitLab Access Token", "The GitLab access token is invalid and was ignored. The file was loaded from a public repository.", "warning");
+                Utils.showNotification(
+                    "GitLab Access Token",
+                    "The GitLab access token is invalid and was ignored while loading " + repositoryName + " / " + repositoryBranch + " / " + fullFileName + ". The file was loaded from a public repository.",
+                    "warning"
+                );
             }
 
             resolve(data.data);


### PR DESCRIPTION
If the user has not set their github/gitlab credentials, and tries to load a file from a git repo, then EAGLE used to fail.

Now the eagleServer will fall back to attempting to fetch the file anonymously, which should work fine for public repositories.

You can test this by temporarily removing your github/gitlab keys (or making them incorrect). NOTE: you'll pretty quickly hit the github API limit for anonymous access.

## Summary by Sourcery

Allow anonymous access to public GitHub and GitLab repositories when configured credentials are missing or invalid, and surface this behavior to the user interface.

New Features:
- Fallback to anonymous access for public GitHub repositories when an access token is missing or invalid while listing files or opening a file.
- Fallback to anonymous access for public GitLab repositories when an access token is missing or invalid while listing files or opening a file.

Enhancements:
- Include a credentialsIgnored flag in GitHub and GitLab API responses so the UI can indicate when invalid credentials were bypassed.
- Update the GitHub and GitLab front-end clients to handle the new response shape and display warning notifications when tokens are ignored.
- Clarify file-load warning notifications to mention the originating service (GitHub or GitLab) in addition to the filename.