### PR TITLE
EAGLE-1659: Helper function for drawing edges in playwright tests

### DIFF
--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -183,6 +183,12 @@ export class TestHelpers {
         });
     }
 
+    static async getEdgeCount(page: Page): Promise<number> {
+        return await page.evaluate( () => {
+            return (window as any).eagle.logicalGraph().getNumEdges();
+        });
+    }
+
     static async undo(page: Page): Promise<void> {
         return await page.press('body','z');
     }

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -225,6 +225,17 @@ export class TestHelpers {
         });
     }
 
+    static async waitForNotificationAndDismiss(page: Page): Promise<void> {
+        await page.locator('div[data-notify="container"]').first().waitFor({state: 'attached'});
+        await page.locator('button[data-notify="dismiss"]').first().click();
+        await page.locator('div[data-notify="container"]').first().waitFor({state: 'detached'});
+    }
+
+    static async openGraphMenuAndSelect(page: Page, menuItemId: string): Promise<void> {
+        await page.locator('#navbarDropdownGraph').click();
+        await page.locator('#' + menuItemId).click();
+    }
+
     static async dragEdge(page: Page, sourceNodeName: string, destNodeName: string): Promise<void> {
         // draw an edge from HelloWorldApp output to File input
         const srcPort = page.locator('#' + sourceNodeName + ' .outputPort');

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -243,7 +243,7 @@ export class TestHelpers {
     }
 
     static async dragEdge(page: Page, sourceNodeName: string, destNodeName: string): Promise<void> {
-        // draw an edge from HelloWorldApp output to File input
+        // draw an edge from source output to destination input
         const srcPort = page.locator('#' + sourceNodeName + ' .outputPort');
         const destPort = page.locator('#' + destNodeName + ' .inputPort');
     
@@ -260,7 +260,7 @@ export class TestHelpers {
             requireBox(await destPort.boundingBox(), 'destination port should have a bounding box before dragging')
         ];
     
-        await page.dragAndDrop('#' + sourceNodeName + ' .outputPort', '#' + destNodeName + ' .inputPort', {
+        await srcPort.dragTo(destPort, {
             sourcePosition: { x: srcPortBox.width / 2, y: srcPortBox.height / 2 },
             targetPosition: { x: destPortBox.width / 2, y: destPortBox.height / 2 }
         });

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -3,6 +3,7 @@ import https from 'https';
 import http from 'http';
 import path from 'path';
 import type { Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 export class TestHelpers {
     // Set the specified UI mode
@@ -221,6 +222,30 @@ export class TestHelpers {
     static async getNumWarningsErrors(page: Page): Promise<number> {
         return await page.evaluate(() => {
             return (window as any).eagle.graphWarnings().length + (window as any).eagle.graphErrors().length;
+        });
+    }
+
+    static async dragEdge(page: Page, sourceNodeName: string, destNodeName: string): Promise<void> {
+        // draw an edge from HelloWorldApp output to File input
+        const srcPort = page.locator('#' + sourceNodeName + ' .outputPort');
+        const destPort = page.locator('#' + destNodeName + ' .inputPort');
+    
+        await expect(srcPort, 'source port should be visible before dragging').toBeVisible();
+        await expect(destPort, 'destination port should be visible before dragging').toBeVisible();
+    
+        const requireBox = (box: { width: number; height: number } | null, message: string) => {
+            expect(box, message).not.toBeNull();
+            return box as { width: number; height: number };
+        };
+    
+        const [srcPortBox, destPortBox] = [
+            requireBox(await srcPort.boundingBox(), 'source port should have a bounding box before dragging'),
+            requireBox(await destPort.boundingBox(), 'destination port should have a bounding box before dragging')
+        ];
+    
+        await page.dragAndDrop('#' + sourceNodeName + ' .outputPort', '#' + destNodeName + ' .inputPort', {
+            sourcePosition: { x: srcPortBox.width / 2, y: srcPortBox.height / 2 },
+            targetPosition: { x: destPortBox.width / 2, y: destPortBox.height / 2 }
         });
     }
 }

--- a/e2e/cloneLogicalGraph.spec.ts
+++ b/e2e/cloneLogicalGraph.spec.ts
@@ -31,16 +31,10 @@ test('LogicalGraph.clone() does not share references with original', async ({ pa
     await page.waitForTimeout(500);
 
     // verify we have nodes and edges to clone
-    const preCheck = await page.evaluate(() => {
-        const eagle = (<any>window).eagle;
-        const lg = eagle.logicalGraph();
-        return {
-            numNodes: lg.getNumNodes(),
-            numEdges: lg.getNumEdges()
-        };
-    });
-    expect(preCheck.numNodes).toBeGreaterThanOrEqual(2);
-    expect(preCheck.numEdges).toBeGreaterThanOrEqual(1);
+    const preCheckNodes = await TestHelpers.getNodeCount(page);
+    const preCheckEdges = await TestHelpers.getEdgeCount(page);
+    expect(preCheckNodes).toBeGreaterThanOrEqual(2);
+    expect(preCheckEdges).toBeGreaterThanOrEqual(1);
 
     // clone the graph and verify no shared references
     const result = await page.evaluate(() => {

--- a/e2e/cloneLogicalGraph.spec.ts
+++ b/e2e/cloneLogicalGraph.spec.ts
@@ -26,26 +26,8 @@ test('LogicalGraph.clone() does not share references with original', async ({ pa
     await page.getByRole('button', { name: 'filter_center_focus' }).click();
 
     // draw an edge from HelloWorldApp output to File input
-    const srcPort = page.locator('#HelloWorldApp .outputPort');
-    const destPort = page.locator('#File .inputPort');
+    await TestHelpers.dragEdge(page, 'HelloWorldApp', 'File');
 
-    await expect(srcPort, 'source port should be visible before dragging').toBeVisible();
-    await expect(destPort, 'destination port should be visible before dragging').toBeVisible();
-
-    const requireBox = (box: { width: number; height: number } | null, message: string) => {
-        expect(box, message).not.toBeNull();
-        return box as { width: number; height: number };
-    };
-
-    const [srcPortBox, destPortBox] = [
-        requireBox(await srcPort.boundingBox(), 'source port should have a bounding box before dragging'),
-        requireBox(await destPort.boundingBox(), 'destination port should have a bounding box before dragging')
-    ];
-
-    await page.dragAndDrop('#HelloWorldApp .outputPort', '#File .inputPort', {
-        sourcePosition: { x: srcPortBox.width / 2, y: srcPortBox.height / 2 },
-        targetPosition: { x: destPortBox.width / 2, y: destPortBox.height / 2 }
-    });
     await page.waitForTimeout(500);
 
     // verify we have nodes and edges to clone

--- a/e2e/creatingASimpleGraph.spec.ts
+++ b/e2e/creatingASimpleGraph.spec.ts
@@ -46,22 +46,7 @@ test('Creating a Simple Graph', async ({ page }) => {
   await page.waitForTimeout(250);
 
   //drag an edge from helloWorldApp -> File
-  //use center positions instead of edge coordinates for more reliable dragging
-  const srcPortBox = await page.locator('#HelloWorldApp .outputPort').boundingBox();
-  const destPortBox = await page.locator('#File .inputPort').boundingBox();
-  
-  if (srcPortBox && destPortBox) {
-    const srcCenterX = srcPortBox.width / 2;
-    const srcCenterY = srcPortBox.height / 2;
-    const destCenterX = destPortBox.width / 2;
-    const destCenterY = destPortBox.height / 2;
-    
-    await page.dragAndDrop('#HelloWorldApp .outputPort', '#File .inputPort', {
-      sourcePosition: { x: srcCenterX, y: srcCenterY },
-      targetPosition: { x: destCenterX, y: destCenterY }
-    });
-  }
-  
+  await TestHelpers.dragEdge(page, 'HelloWorldApp', 'File');
   await page.waitForTimeout(500);
 
   //click on the input port of the file to open the parameter table modal and highlight the port

--- a/e2e/creatingASimpleGraph.spec.ts
+++ b/e2e/creatingASimpleGraph.spec.ts
@@ -63,9 +63,7 @@ test('Creating a Simple Graph', async ({ page }) => {
   await page.locator('.closeBottomWindowBtn').getByRole('button').click();
 
   // check that the graph has the expected number of nodes
-  const numNodesPreDelete = await page.evaluate(() => {
-    return (<any>window).eagle.logicalGraph().getNumNodes();
-  });
+  const numNodesPreDelete = await TestHelpers.getNodeCount(page);
 
   await expect(numNodesPreDelete).toBe(2);
 
@@ -83,9 +81,7 @@ test('Creating a Simple Graph', async ({ page }) => {
   await page.waitForTimeout(500);
 
   // check that the graph has the expected number of nodes
-  const numNodesPostDelete = await page.evaluate(() => {
-    return (<any>window).eagle.logicalGraph().getNumNodes();
-  });
+  const numNodesPostDelete = await TestHelpers.getNodeCount(page);
 
   await expect(numNodesPostDelete).toBe(2);
 

--- a/e2e/loadSaveJsonMatch.spec.ts
+++ b/e2e/loadSaveJsonMatch.spec.ts
@@ -1,7 +1,4 @@
 import { test, expect } from '@playwright/test';
-import fs from 'fs';
-import https from 'https';
-import path from 'path';
 import { TestHelpers } from './TestHelpers';
 
 const INPUT_GRAPH_LOCATION: string = "data/LoopWithBranch.graph";

--- a/e2e/validatingGraphs.spec.ts
+++ b/e2e/validatingGraphs.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { TestHelpers } from './TestHelpers';
 
 const GRAPHS = [
   // SDP Pipelines
@@ -15,18 +16,11 @@ test('Validating Graphs', async ({ page }) => {
   for (const graphUrl of GRAPHS){
     await page.goto('http://localhost:8888/?tutorial=none&service=Url&url='+graphUrl);
 
-    // wait for the 'graph load success' notification to be shown
-    await page.locator('div[data-notify="container"]').waitFor({state: 'attached'});
-
-    // dismiss notification
-    await page.locator('button[data-notify="dismiss"]').click();
-
-    // wait for the 'graph load success' notification to be dismissed
-    await page.locator('div[data-notify="container"]').waitFor({state: 'detached'});
+    // wait for the 'graph load success' notification to be shown, then dismiss it
+    await TestHelpers.waitForNotificationAndDismiss(page);
 
     // navigate menus and click the "validate" item
-    await page.locator('#navbarDropdownGraph').click();
-    await page.locator('#validateGraph').click();
+    await TestHelpers.openGraphMenuAndSelect(page, 'validateGraph');
 
     // wait for the validation
     await page.locator('div[data-notify="container"]').waitFor({state: 'attached'});

--- a/e2e_tutorialVideos/recordingSimpleTutorial.spec.ts
+++ b/e2e_tutorialVideos/recordingSimpleTutorial.spec.ts
@@ -1,6 +1,7 @@
 // import { test } from '@playwright/test';
 import { test, expect,chromium, Page,Browser } from '@playwright/test';
 import { enableMouseCursor, explainElement, moveMouseCursor, textNotification } from '../playwrightHelpers';
+import { TestHelpers } from '../e2e/TestHelpers';
 
 test.use({ 
   viewport: { width: 2560, height: 1440 },
@@ -149,7 +150,8 @@ test('Hello World Tutorial Video', async ({ page }) => {
   await explainElement(page, inputPort, 'down', 'And this is the input port of the File node.',3000)
   await explainElement(page, outputPort, 'down', 'Drag and drop from one port to the other to create a connection.',4000)
   await moveMouseCursor(page, inputPort)
-  await page.dragAndDrop('#HelloWorldApp .outputPort', '#File .inputPort',{sourcePosition:{x:2,y:2},targetPosition:{x:2,y:2}})
+  await TestHelpers.dragEdge(page, 'HelloWorldApp', 'File');
+  
   await explainElement(page, inputPort, 'down', 'The output of the Hello World App will now be saved to disk as a file.',4000)
 
   //end notification


### PR DESCRIPTION
Added TestHelpers:

- dragEdge()
- getEdgeCount()
- waitForNotificationAndDismiss()
- openGraphMenuAndSelect()

Replaced similar usage in playwright unit tests.

## Summary by Sourcery

Introduce shared Playwright test helpers for graph interactions and apply them across existing end-to-end tests.

Enhancements:
- Add reusable helpers for edge dragging, graph edge counting, notification handling, and graph menu selection in Playwright tests.

Tests:
- Refactor end-to-end and tutorial video Playwright specs to use the new graph interaction helpers instead of duplicating locator and drag-and-drop logic.