### PR TITLE
EAGLE-1639: Discourage users for saving files in old OJS format

### DIFF
--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -2442,10 +2442,17 @@ export class Eagle {
         return new Promise(async(resolve, reject) => {
             console.log("saveDiagramToGit() repositoryName", file.repository.name, "fileType", file.type, "filePath", file.path, "fileName", file.name, "commitMessage", commitMessage);
 
+            // get version (hoisted for OJS format check)
+            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
+
+            // warn if saving in older OJS format (not applicable to GraphConfig which has no version-dependent serialization)
+            if (file.type !== Eagle.FileType.GraphConfig && version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
+                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
+                if (!confirmed) { resolve(); return; }
+            }
+
             const clone: LogicalGraph | Palette | GraphConfig = obj.clone();
             clone.fileInfo().updateEagleInfo();
-
-            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             let jsonString: string = "";
             switch (file.type){
@@ -3084,6 +3091,7 @@ export class Eagle {
         Setting.setValue(Setting.CONFIRM_DISCARD_CHANGES,true)
         Setting.setValue(Setting.CONFIRM_NODE_CATEGORY_CHANGES,true)
         Setting.setValue(Setting.CONFIRM_REMOVE_REPOSITORIES,true)
+        Setting.setValue(Setting.CONFIRM_OJS_FORMAT, true)
         Utils.showNotification("Success", "Confirmation message pop ups re-enabled", "success");
     }
 
@@ -3097,13 +3105,19 @@ export class Eagle {
                 fileName = sanitizedName.length > 0 ? sanitizedName : "palette";
             }
 
+            // get version (hoisted for OJS format check)
+            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
+
+            // warn if saving in older OJS format
+            if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
+                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
+                if (!confirmed) { resolve(); return; }
+            }
+
             // clone the palette and remove github info ready for local save
             const p_clone : Palette = palette.clone();
             p_clone.fileInfo().removeGitInfo();
             p_clone.fileInfo().updateEagleInfo();
-
-            // get version
-            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             // convert to json
             const jsonString: string = Palette.toJsonString(p_clone, version);
@@ -3156,13 +3170,19 @@ export class Eagle {
                 return;
             }
 
+            // get version (hoisted for OJS format check)
+            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
+
+            // warn if saving in older OJS format
+            if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
+                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
+                if (!confirmed) { resolve(); return; }
+            }
+
             // clone the logical graph and remove github info ready for local save
             const lg_clone : LogicalGraph = this.logicalGraph().clone();
             lg_clone.fileInfo().removeGitInfo();
             lg_clone.fileInfo().updateEagleInfo();
-
-            // get version
-            const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             // convert to json
             const jsonString: string = LogicalGraph.toJsonString(lg_clone, false, version);
@@ -3272,6 +3292,15 @@ export class Eagle {
     savePaletteToGit = async (palette: Palette): Promise<void> => {
         console.log("savePaletteToGit()", palette.fileInfo().name, palette.fileInfo().type);
 
+        // get version (hoisted for OJS format check)
+        const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
+
+        // warn if saving in older OJS format
+        if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
+            const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
+            if (!confirmed) return;
+        }
+
         const defaultRepository: Repository = new Repository(palette.fileInfo().location.repositoryService(), palette.fileInfo().location.repositoryName(), palette.fileInfo().location.repositoryBranch(), false);
 
         let commit: RepositoryCommit;
@@ -3313,9 +3342,6 @@ export class Eagle {
         // clone the palette
         const p_clone : Palette = palette.clone();
         p_clone.fileInfo().updateEagleInfo();
-
-        // get version
-        const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
         // convert to json
         const jsonString: string = Palette.toJsonString(p_clone, version);

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -202,6 +202,26 @@ export class Eagle {
         return Eagle._instance;
     }
 
+    /**
+     * Centralized confirmation for saving in legacy OJS format.
+     * Returns true if the save should proceed, false if the user cancels.
+     */
+    static async confirmOjsSave(version: Setting.SchemaVersion): Promise<boolean> {
+        if (version !== Setting.SchemaVersion.OJS) {
+            return true;
+        }
+        if (!Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
+            return true;
+        }
+        return Utils.requestUserConfirm(
+            "Older Format Warning",
+            "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?",
+            "Continue",
+            "Cancel",
+            Setting.find(Setting.CONFIRM_OJS_FORMAT)
+        );
+    }
+
     areAnyFilesModified = () : boolean => {
         // check the logical graph
         if (this.logicalGraph().fileInfo().modified){
@@ -2446,9 +2466,8 @@ export class Eagle {
             const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             // warn if saving in older OJS format (not applicable to GraphConfig which has no version-dependent serialization)
-            if (file.type !== Eagle.FileType.GraphConfig && version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
-                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
-                if (!confirmed) { resolve(); return; }
+            if (file.type !== Eagle.FileType.GraphConfig) {
+                if (!await Eagle.confirmOjsSave(version)) { resolve(); return; }
             }
 
             const clone: LogicalGraph | Palette | GraphConfig = obj.clone();
@@ -3109,10 +3128,7 @@ export class Eagle {
             const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             // warn if saving in older OJS format
-            if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
-                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
-                if (!confirmed) { resolve(); return; }
-            }
+            if (!await Eagle.confirmOjsSave(version)) { resolve(); return; }
 
             // clone the palette and remove github info ready for local save
             const p_clone : Palette = palette.clone();
@@ -3174,10 +3190,7 @@ export class Eagle {
             const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
             // warn if saving in older OJS format
-            if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
-                const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
-                if (!confirmed) { resolve(); return; }
-            }
+            if (!await Eagle.confirmOjsSave(version)) { resolve(); return; }
 
             // clone the logical graph and remove github info ready for local save
             const lg_clone : LogicalGraph = this.logicalGraph().clone();
@@ -3296,10 +3309,7 @@ export class Eagle {
         const version: Setting.SchemaVersion = Setting.findValue<Setting.SchemaVersion>(Setting.DALIUGE_SCHEMA_VERSION, Setting.SchemaVersion.Unknown);
 
         // warn if saving in older OJS format
-        if (version === Setting.SchemaVersion.OJS && Setting.findValue<boolean>(Setting.CONFIRM_OJS_FORMAT, true)) {
-            const confirmed = await Utils.requestUserConfirm("Older Format Warning", "You are saving in the older OJS format. The newer V4 format is recommended. Continue saving in OJS format?", "Continue", "Cancel", Setting.find(Setting.CONFIRM_OJS_FORMAT));
-            if (!confirmed) return;
-        }
+        if (!await Eagle.confirmOjsSave(version)) return;
 
         const defaultRepository: Repository = new Repository(palette.fileInfo().location.repositoryService(), palette.fileInfo().location.repositoryName(), palette.fileInfo().location.repositoryBranch(), false);
 

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -352,6 +352,7 @@ export class Setting {
     static readonly CONFIRM_REMOVE_REPOSITORIES : string = "ConfirmRemoveRepositories";
     static readonly CONFIRM_DELETE_FILES : string = "ConfirmDeleteFiles";
     static readonly CONFIRM_DELETE_OBJECTS : string = "ConfirmDeleteObjects";
+    static readonly CONFIRM_OJS_FORMAT : string = "ConfirmOjsFormat";
     static readonly TEST_TRANSLATE_MODE : string = "TestTranslateMode";
 
     static readonly SHOW_DEVELOPER_NOTIFICATIONS: string = "ShowDeveloperNotifications";
@@ -451,6 +452,7 @@ const settings : SettingsGroup[] = [
             new Setting(false, "Confirm Remove Repositories", Setting.CONFIRM_REMOVE_REPOSITORIES, "Prompt user to confirm removing a repository from the list of known repositories.",false , Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Confirm Delete Files", Setting.CONFIRM_DELETE_FILES, "Prompt user to confirm when deleting files from a repository.", false, Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Confirm Delete Objects", Setting.CONFIRM_DELETE_OBJECTS, "Prompt user to confirm when deleting node(s) or edge(s) from a graph.",false , Setting.Type.Boolean, true,true,true,true,true),
+            new Setting(false, "Warn On OJS Format Save", Setting.CONFIRM_OJS_FORMAT, "Warn user when saving in the older OJS format that the newer V4 format is recommended.", false, Setting.Type.Boolean, true,true,true,true,true),
             new Setting(false, "Open " + Palette.BUILTIN_PALETTE_NAME + " Palette on Startup", Setting.OPEN_BUILTIN_PALETTE, "Open the '" + Palette.BUILTIN_PALETTE_NAME + "' palette on startup.", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(false, "Open " + Palette.TEMPLATE_PALETTE_NAME + " Palette on Startup", Setting.OPEN_TEMPLATE_PALETTE, "Open the '" + Palette.TEMPLATE_PALETTE_NAME + "' palette on startup.", true, Setting.Type.Boolean, false, false, false, false, false),
             new Setting(true, "Disable JSON Validation", Setting.DISABLE_JSON_VALIDATION, "Allow EAGLE to load/save/send-to-translator graphs and palettes that would normally fail validation against schema.", false, Setting.Type.Boolean, false,false,false,false,false),


### PR DESCRIPTION
Before saving to git or disk, we now check the Setting.DALIUGE_SCHEMA_VERSION setting. If the setting is not V4, we popup a confirmation dialog checking that the user actually wants to save using the older format.

Users can click the "Don't ask me again" checkbox to avoid being asked repeatedly if they want to continue using the old format. (Setting.CONFIRM_OJS_FORMAT).

## Summary by Sourcery

Add user confirmation when saving files using the legacy OJS schema format and provide a setting to control this warning.

New Features:
- Prompt users before saving graphs and palettes in the older OJS format when a newer V4 format is available.
- Introduce a configurable setting to suppress or re-enable warnings about saving in the OJS format.

Enhancements:
- Reset the new OJS format confirmation setting alongside other confirmation pop-up settings.