### PR TITLE
EAGLE-1671: Better modal input validation

### DIFF
--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -281,11 +281,21 @@ export class TestHelpers {
     }
 
     static async closeInputModalWithoutCompleting(page: Page): Promise<void> {
-        if (await page.locator('#inputModal').isVisible()) {
-            await page.locator('#inputModal button.btn-close').click();
-            await page.waitForTimeout(100);
+        const inputModal = page.locator('#inputModal');
 
-            if (await page.locator('#inputModal').isVisible()) {
+        if (page.isClosed()) {
+            return;
+        }
+
+        if (await inputModal.isVisible()) {
+            await page.locator('#inputModal button.btn-close').click();
+            await inputModal.waitFor({state: 'hidden'}).catch(() => {});
+
+            if (page.isClosed()) {
+                return;
+            }
+
+            if (await inputModal.isVisible().catch(() => false)) {
                 await page.evaluate(() => {
                     const $ = (window as any).$;
                     const modal = $('#inputModal');
@@ -294,7 +304,9 @@ export class TestHelpers {
                 });
             }
 
-            await expect(page.locator('#inputModal')).toBeHidden();
+            if (!page.isClosed()) {
+                await expect(inputModal).toBeHidden();
+            }
         }
     }
 }

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -288,8 +288,13 @@ export class TestHelpers {
         }
 
         if (await inputModal.isVisible()) {
-            await page.locator('#inputModal button.btn-close').click();
-            await inputModal.waitFor({state: 'hidden'}).catch(() => {});
+            await page.evaluate(() => {
+                const $ = (window as any).$;
+                const modal = $('#inputModal');
+                modal.data('completed', false);
+                modal.modal('hide');
+            });
+            await inputModal.waitFor({state: 'hidden', timeout: 1500}).catch(() => {});
 
             if (page.isClosed()) {
                 return;
@@ -302,6 +307,7 @@ export class TestHelpers {
                     modal.data('completed', false);
                     modal.modal('hide');
                 });
+                await inputModal.waitFor({state: 'hidden', timeout: 2000}).catch(() => {});
             }
 
             if (!page.isClosed()) {

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -279,4 +279,22 @@ export class TestHelpers {
             targetPosition: { x: destPortBox.width / 2, y: destPortBox.height / 2 }
         });
     }
+
+    static async closeInputModalWithoutCompleting(page: Page): Promise<void> {
+        if (await page.locator('#inputModal').isVisible()) {
+            await page.locator('#inputModal button.btn-close').click();
+            await page.waitForTimeout(100);
+
+            if (await page.locator('#inputModal').isVisible()) {
+                await page.evaluate(() => {
+                    const $ = (window as any).$;
+                    const modal = $('#inputModal');
+                    modal.data('completed', false);
+                    modal.modal('hide');
+                });
+            }
+
+            await expect(page.locator('#inputModal')).toBeHidden();
+        }
+    }
 }

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -184,33 +184,69 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
   await expect(page.locator(baseRepoHTMLId + '-create-branch')).toBeVisible();
   await expect(page.locator(baseRepoHTMLId + '-delete-branch')).toBeVisible();
 
-  // verify create branch flow via UI
-  await page.locator(baseRepoHTMLId + '-create-branch').click()
-  const createBranchDialog = page.getByRole('dialog', { name: 'Create Branch' });
-  await expect(createBranchDialog).toBeVisible();
+  const openCreateBranchModal = async (): Promise<void> => {
+    const createBranchAction = page.locator(baseRepoHTMLId + '-create-branch');
+    let clicked = false;
+
+    for (let attempt = 0; attempt < 4; attempt++) {
+      await page.locator('.repoContainer').filter({has:page.locator(baseRepoHTMLId)}).hover()
+      await page.locator('.repoContainer').filter({has:page.locator(baseRepoHTMLId)}).locator('button.repoTripleDot').click()
+
+      const isVisible = await createBranchAction.isVisible().catch(() => false);
+      if (!isVisible) {
+        await createBranchAction.waitFor({state: 'visible', timeout: 1500}).catch(() => {});
+      }
+
+      if (await createBranchAction.isVisible().catch(() => false)) {
+        await createBranchAction.click();
+        clicked = true;
+        break;
+      }
+    }
+
+    if (!clicked) {
+      throw new Error('Could not open Create Branch action menu item after multiple attempts');
+    }
+
+    await expect(page.locator('#inputModal')).toBeVisible();
+    await expect(page.locator('#inputModalInput')).toBeVisible();
+  };
 
   // invalid branch names stay blocked and show validation feedback
+  await openCreateBranchModal();
   await page.locator('#inputModalInput').fill('   ')
-  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await page.locator('#inputModal button.affirmativeBtn').click()
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Branch name cannot be empty.')
+  await expect(createBranchCallCount).toBe(0);
+  await TestHelpers.closeInputModalWithoutCompleting(page);
 
+  await openCreateBranchModal();
   await page.locator('#inputModalInput').fill('bad branch')
-  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await page.locator('#inputModal button.affirmativeBtn').click()
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Branch name cannot contain whitespace.')
+  await expect(createBranchCallCount).toBe(0);
+  await TestHelpers.closeInputModalWithoutCompleting(page);
 
+  await openCreateBranchModal();
   await page.locator('#inputModalInput').fill('bad..branch')
-  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await page.locator('#inputModal button.affirmativeBtn').click()
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText("Branch name cannot contain '..'.")
   await expect(createBranchCallCount).toBe(0);
+  await TestHelpers.closeInputModalWithoutCompleting(page);
 
+  // verify successful create branch flow via UI
+  await openCreateBranchModal();
   await page.locator('#inputModalInput').fill(CREATED_BRANCH)
-  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await page.locator('#inputModal button.affirmativeBtn').click()
+
+  const createBranchDialog = page.getByRole('dialog', { name: 'Create Branch' });
+  const inputModal = page.locator('#inputModal');
 
   // some runs keep the modal visible after first click; retry closure through UI.
   if (await createBranchDialog.isVisible()) {
@@ -220,7 +256,7 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
     await finalizeInputModalAffirmative(page);
   }
 
-  await expect(page.locator('#inputModal')).toBeHidden();
+  await expect(inputModal).toBeHidden();
   await expect.poll(() => createBranchCallCount).toBe(1);
   await page.waitForTimeout(500);
   await expect(createBranchCallCount).toBe(1);

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -88,6 +88,24 @@ async function finalizeConfirmModalAffirmative(page: Page): Promise<void> {
   }
 }
 
+async function closeInputModalWithoutCompleting(page: Page): Promise<void> {
+  if (await page.locator('#inputModal').isVisible()) {
+    await page.locator('#inputModal button.btn-close').click();
+    await page.waitForTimeout(100);
+
+    if (await page.locator('#inputModal').isVisible()) {
+      await page.evaluate(() => {
+        const $ = (window as any).$;
+        const modal = $('#inputModal');
+        modal.data('completed', false);
+        modal.modal('hide');
+      });
+    }
+
+    await expect(page.locator('#inputModal')).toBeHidden();
+  }
+}
+
 test('Adding and Removing Repositories', async ({ page }) => {
 
   await page.goto('http://localhost:8888/?tutorial=none');
@@ -248,6 +266,37 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
   // reset any repositories created during this test.
   await removeCustomRepositoryIfPresent(page, baseRepoHTMLId, false);
   await removeCustomRepositoryIfPresent(page, protectedRepoHTMLId, false);
+
+  await page.close();
+});
+
+test('requestUserString validator UX for URL and Save As', async ({ page }) => {
+
+  await page.goto('http://localhost:8888/?tutorial=none');
+  await expect(page).toHaveTitle(/EAGLE/);
+
+  // verify URL prompt blocks invalid URL input with inline feedback
+  await page.locator('#navbarDropdownGraph').click();
+  await page.locator('#createNewGraphFromUrl').click();
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await page.locator('#inputModalInput').fill('not-a-valid-url');
+  await page.locator('#inputModal button.affirmativeBtn').click();
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/);
+  await expect(page.locator('#inputModalInvalidFeedback')).toContainText('URL is not a valid URL.');
+  await closeInputModalWithoutCompleting(page);
+
+  // verify Save As prompt blocks empty filename with inline feedback
+  await page.locator('#navbarDropdownGraph').click();
+  await page.getByText('Local Storage').first().hover();
+  await page.locator('#saveAsGraph').click();
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await page.locator('#inputModalInput').fill('   ');
+  await page.locator('#inputModal button.affirmativeBtn').click();
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/);
+  await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Filename cannot be empty.');
+  await closeInputModalWithoutCompleting(page);
 
   await page.close();
 });

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -187,6 +187,21 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
   await page.locator(baseRepoHTMLId + '-create-branch').click()
   const createBranchDialog = page.getByRole('dialog', { name: 'Create Branch' });
   await expect(createBranchDialog).toBeVisible();
+
+  // optional coverage: invalid branch names stay blocked and show validation feedback
+  await page.locator('#inputModalInput').fill('   ')
+  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
+  await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Branch name cannot be empty.')
+
+  await page.locator('#inputModalInput').fill('bad branch')
+  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
+  await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Branch name cannot contain whitespace.')
+  await expect(createBranchCallCount).toBe(0);
+
   await page.locator('#inputModalInput').fill(CREATED_BRANCH)
   await createBranchDialog.getByRole('button', { name: 'OK' }).click()
 

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { TestHelpers } from './TestHelpers';
 
 async function removeCustomRepositoryIfPresent(page: Page, repoHTMLId: string, failIfStillPresent: boolean = true): Promise<void> {
   const maxAttempts = 5;
@@ -85,24 +86,6 @@ async function finalizeConfirmModalAffirmative(page: Page): Promise<void> {
         $('body').removeClass('modal-open').css('padding-right', '');
       });
     }
-  }
-}
-
-async function closeInputModalWithoutCompleting(page: Page): Promise<void> {
-  if (await page.locator('#inputModal').isVisible()) {
-    await page.locator('#inputModal button.btn-close').click();
-    await page.waitForTimeout(100);
-
-    if (await page.locator('#inputModal').isVisible()) {
-      await page.evaluate(() => {
-        const $ = (window as any).$;
-        const modal = $('#inputModal');
-        modal.data('completed', false);
-        modal.modal('hide');
-      });
-    }
-
-    await expect(page.locator('#inputModal')).toBeHidden();
   }
 }
 
@@ -284,7 +267,7 @@ test('requestUserString validator UX for URL and Save As', async ({ page }) => {
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/);
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText('URL is not a valid URL.');
-  await closeInputModalWithoutCompleting(page);
+  await TestHelpers.closeInputModalWithoutCompleting(page);
 
   // verify Save As prompt blocks empty filename with inline feedback
   await page.locator('#navbarDropdownGraph').click();
@@ -296,7 +279,7 @@ test('requestUserString validator UX for URL and Save As', async ({ page }) => {
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/);
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Filename cannot be empty.');
-  await closeInputModalWithoutCompleting(page);
+  await TestHelpers.closeInputModalWithoutCompleting(page);
 
   await page.close();
 });

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -325,3 +325,35 @@ test('requestUserString validator UX for URL and Save As', async ({ page }) => {
 
   await page.close();
 });
+
+test('gitCommit filename validator UX', async ({ page }) => {
+  await page.goto('http://localhost:8888/?tutorial=none');
+  await expect(page).toHaveTitle(/EAGLE/);
+
+  // Open modal in a controlled state so only filename validation is under test.
+  await page.evaluate(() => {
+    const w = window as any;
+    const $ = w.$;
+    const graphFileType = w.Eagle?.FileType?.Graph ?? 'Graph';
+
+    $('#gitCommitModal').data('fileType', graphFileType);
+    $('#gitCommitModalFileNameInput').val('invalid-name.txt');
+    $('#gitCommitModal').modal('show');
+    $('#gitCommitModalFileNameInput').trigger('input');
+  });
+
+  await expect(page.locator('#gitCommitModal')).toBeVisible();
+  await expect(page.locator('#gitCommitModalFileNameInput')).toHaveClass(/is-invalid/);
+  await expect(page.locator('#validationFeedback')).toContainText("File name must end with '.graph'.");
+  await expect(page.locator('#gitCommitModalAffirmativeButton')).toBeDisabled();
+
+  // A valid extension should clear invalid state and re-enable commit.
+  await page.locator('#gitCommitModalFileNameInput').fill('valid-name.graph');
+  await expect(page.locator('#gitCommitModalFileNameInput')).toHaveClass(/is-valid/);
+  await expect(page.locator('#gitCommitModalAffirmativeButton')).toBeEnabled();
+
+  await page.locator('#gitCommitModalNegativeButton').click();
+  await expect(page.locator('#gitCommitModal')).toBeHidden();
+
+  await page.close();
+});

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -201,6 +201,12 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
   await expect(page.locator('#inputModal')).toBeVisible();
   await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
   await expect(page.locator('#inputModalInvalidFeedback')).toContainText('Branch name cannot contain whitespace.')
+
+  await page.locator('#inputModalInput').fill('bad..branch')
+  await createBranchDialog.getByRole('button', { name: 'OK' }).click()
+  await expect(page.locator('#inputModal')).toBeVisible();
+  await expect(page.locator('#inputModalInput')).toHaveClass(/is-invalid/)
+  await expect(page.locator('#inputModalInvalidFeedback')).toContainText("Branch name cannot contain '..'.")
   await expect(createBranchCallCount).toBe(0);
 
   await page.locator('#inputModalInput').fill(CREATED_BRANCH)

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -189,7 +189,7 @@ test('Create Branch and Delete Branch Actions', async ({ page }) => {
   const createBranchDialog = page.getByRole('dialog', { name: 'Create Branch' });
   await expect(createBranchDialog).toBeVisible();
 
-  // optional coverage: invalid branch names stay blocked and show validation feedback
+  // invalid branch names stay blocked and show validation feedback
   await page.locator('#inputModalInput').fill('   ')
   await createBranchDialog.getByRole('button', { name: 'OK' }).click()
   await expect(page.locator('#inputModal')).toBeVisible();

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -33,7 +33,7 @@ async function addCustomRepository(page: Page, name: string, branch: string): Pr
 
   await page.getByRole('button',{name:'Add Repository'}).click()
   await page.waitForTimeout(500);
-  await page.locator('input#gitCustomRepositoryModalRepositoryNameInput').pressSequentially(name)
+  await page.locator('input#gitCustomRepositoryModalRepositorySlugInput').pressSequentially(name)
   await page.locator('input#gitCustomRepositoryModalRepositoryBranchInput').pressSequentially(branch)
   await page.locator('button#gitCustomRepositoryModalAffirmativeButton').click()
   await page.waitForTimeout(1000);
@@ -114,7 +114,7 @@ test('Adding and Removing Repositories', async ({ page }) => {
   await page.waitForTimeout(500);
 
   //fill out the add repository modal information and confirm the modal
-  await page.locator('input#gitCustomRepositoryModalRepositoryNameInput').pressSequentially(REPO_NAME)
+  await page.locator('input#gitCustomRepositoryModalRepositorySlugInput').pressSequentially(REPO_NAME)
   await page.locator('input#gitCustomRepositoryModalRepositoryBranchInput').pressSequentially(REPO_BRANCH)
   await page.locator('button#gitCustomRepositoryModalAffirmativeButton').click()
 

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -456,6 +456,11 @@ def create_branch():
     if not service or not repo_name or not source_branch or not new_branch:
         return jsonify({"error": "Missing required parameters."})
 
+    if new_branch.strip() == "":
+        return jsonify({"error": "Branch name cannot be empty."})
+    if any(char.isspace() for char in new_branch):
+        return jsonify({"error": "Branch name cannot contain whitespace."})
+
     try:
         if service.lower() == "github":
             g = github.Github(token) if token else github.Github()

--- a/eagleServer/eagleServer.py
+++ b/eagleServer/eagleServer.py
@@ -460,6 +460,25 @@ def create_branch():
         return jsonify({"error": "Branch name cannot be empty."})
     if any(char.isspace() for char in new_branch):
         return jsonify({"error": "Branch name cannot contain whitespace."})
+    if new_branch.startswith("-"):
+        return jsonify({"error": "Branch name cannot start with '-'."})
+    if new_branch == "@":
+        return jsonify({"error": "Branch name cannot be '@'."})
+    if "@{" in new_branch:
+        return jsonify({"error": "Branch name cannot contain '@{'."})
+    if ".." in new_branch:
+        return jsonify({"error": "Branch name cannot contain '..'."})
+    if new_branch.startswith("/") or new_branch.endswith("/") or "//" in new_branch:
+        return jsonify({"error": "Branch name cannot contain empty path segments."})
+    if new_branch.endswith("."):
+        return jsonify({"error": "Branch name cannot end with '.'."})
+    if new_branch.endswith(".lock"):
+        return jsonify({"error": "Branch name cannot end with '.lock'."})
+    if any(segment.startswith(".") for segment in new_branch.split("/")):
+        return jsonify({"error": "Branch name cannot have path segments starting with '.'."})
+    invalid_characters = set("~^:?*[\\")
+    if any(ord(char) < 32 or ord(char) == 127 or char in invalid_characters for char in new_branch):
+        return jsonify({"error": "Branch name contains invalid characters."})
 
     try:
         if service.lower() == "github":

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -1686,7 +1686,7 @@ export class Eagle {
     loadFileFromUrl = async(fileType: Eagle.FileType): Promise<void> => {
         let url: string;
         try {
-            url = await Utils.requestUserString("Url", "Enter Url of " + fileType + " to load", "", false);
+            url = await Utils.requestUserString("Url", "Enter Url of " + fileType + " to load", "", false, Utils.httpUrlStringValidator("URL"));
         } catch(error){
             console.error(error);
             return;
@@ -3268,16 +3268,15 @@ export class Eagle {
 
         let userString: string;
         try {
-            userString = await Utils.requestUserString("Save As", "Please enter a filename for the " + file.fileInfo().type, defaultFilename, false);
+            userString = await Utils.requestUserString(
+                "Save As",
+                "Please enter a filename for the " + file.fileInfo().type,
+                defaultFilename,
+                false,
+                Utils.nonEmptyStringValidator("Filename")
+            );
         } catch (error) {
             console.error(error);
-            return;
-        }
-
-        // abort if user entered empty string
-        if (userString === "") {
-            // abort and notify user
-            Utils.showNotification("Unable to save file with no name", "Please name the file before saving", "danger");
             return;
         }
 

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -15,6 +15,18 @@ export class Modals {
     static init(eagle : Eagle) : void {
         // #inputModal - requestUserInput()
         $('#inputModal .modal-footer button.affirmativeBtn').on('click', function(){
+            if ($('#inputModal').data('returnType') === "string"){
+                const validateInput = $('#inputModal').data('validateInput');
+                if (typeof validateInput === 'function'){
+                    validateInput();
+                }
+
+                const isValid = $('#inputModal').data('isValid');
+                if (isValid === false){
+                    return;
+                }
+            }
+
             $('#inputModal').data('completed', true);
         });
         $('#inputModal').on('hidden.bs.modal', function(){
@@ -46,7 +58,10 @@ export class Modals {
             }
 
             // remove data stored on modal
-            $('#inputModal').removeData(['callback', 'completed', 'returnType']);
+            $('#inputModal').removeData(['callback', 'completed', 'returnType', 'isValid', 'validateInput']);
+            $('#inputModalInput').removeClass('is-valid is-invalid');
+            $('#inputModalInvalidFeedback').hide().text('');
+            $('#inputModalInput').off('input.requestUserStringValidation');
         });
         $('#inputModal').on('shown.bs.modal', function(){
             $('#inputModalInput').trigger("focus");
@@ -54,6 +69,18 @@ export class Modals {
         $('#inputModalInput').on('keypress', function(e){
             if(TutorialSystem.activeTut === null){
                 if (e.key === "Enter"){
+                    if ($('#inputModal').data('returnType') === "string"){
+                        const validateInput = $('#inputModal').data('validateInput');
+                        if (typeof validateInput === 'function'){
+                            validateInput();
+                        }
+
+                        const isValid = $('#inputModal').data('isValid');
+                        if (isValid === false){
+                            return;
+                        }
+                    }
+
                     $('#inputModal').data('completed', true);
                     $('#inputModal').modal('hide');
                 }
@@ -650,6 +677,7 @@ export class Modals {
 
 export namespace Modals {
     export type UserStringCallback = (completed: boolean, userString: string) => void;
+    export type UserStringValidator = (userString: string) => string | null;
     export type UserTextCallback = (completed: boolean, userText: string) => void;
     export type UserFieldCallback = (field: Field | null) => void; // NOTE: completed is not required, since all changes happen to the field directly (immediately)
     export type UserConfirmCallback = (completed: boolean, confirmed: boolean) => void;

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -1,6 +1,5 @@
 import { Daliuge } from './Daliuge';
 import { Eagle } from './Eagle';
-import { Errors } from './Errors';
 import { Field } from './Field';
 import { FileLocation } from "./FileLocation";
 import { Repositories } from './Repositories';
@@ -547,11 +546,7 @@ export class Modals {
     static validateField(type: string, value: string) : Utils.ValidationResult {
         // make sure JSON fields are parse-able
         if (type === Daliuge.DataType.Json){
-            try {
-                JSON.parse(value);
-            } catch(e) {
-                return { isValid: false, message: "Invalid JSON: " + Errors.UnknownToError(e)};
-            }
+            return Utils.jsonStringValidator("JSON")(value);
         }
 
         return { isValid: true };
@@ -585,13 +580,9 @@ export class Modals {
 
         const fileTypeData = $('#gitCommitModal').data('fileType');
         const fileType: Eagle.FileType = fileTypeData ? fileTypeData : Eagle.FileType.Unknown;
-        
-        const isValid = (fileType === Eagle.FileType.Unknown) ||
-            (fileType === Eagle.FileType.Graph && inputElementValue.endsWith(".graph")) ||
-            (fileType === Eagle.FileType.Palette && inputElementValue.endsWith(".palette")) ||
-            (fileType === Eagle.FileType.GraphConfig && inputElementValue.endsWith(".graphConfig"));
 
-        const validationResult: Utils.ValidationResult = { isValid };
+        const validator = Utils.gitCommitFileNameStringValidator(fileType);
+        const validationResult = validator(inputElementValue);
 
         Modals.applyValidationState(inputElement, validationResult);
         $('#gitCommitModalAffirmativeButton').prop('disabled', !validationResult.isValid);
@@ -713,7 +704,7 @@ export class Modals {
 
 export namespace Modals {
     export type UserStringCallback = (completed: boolean, userString: string) => void;
-    export type UserStringValidator = (userString: string) => string | null;
+    export type UserStringValidator = (userString: string) => Utils.ValidationResult;
     export type UserTextCallback = (completed: boolean, userText: string) => void;
     export type UserFieldCallback = (field: Field | null) => void; // NOTE: completed is not required, since all changes happen to the field directly (immediately)
     export type UserConfirmCallback = (completed: boolean, confirmed: boolean) => void;

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -1,5 +1,6 @@
 import { Daliuge } from './Daliuge';
 import { Eagle } from './Eagle';
+import { Errors } from './Errors';
 import { Field } from './Field';
 import { FileLocation } from "./FileLocation";
 import { Repositories } from './Repositories';
@@ -394,7 +395,7 @@ export class Modals {
         });
 
         // #gitCustomRepositoryModal - requestUserAddCustomRepository()
-        $('#gitCustomRepositoryModalRepositoryNameInput, #gitCustomRepositoryModalRepositoryBranchInput').on('keyup', function(){
+        $('#gitCustomRepositoryModalRepositorySlugInput, #gitCustomRepositoryModalRepositoryBranchInput').on('keyup', function(){
             // show/hide OK button
             $('#gitCustomRepositoryModalAffirmativeButton').prop('disabled', !Utils.validateCustomRepository());
         });
@@ -406,8 +407,8 @@ export class Modals {
             $('#gitCustomRepositoryModal').data('completed', false);
         });
         $('#gitCustomRepositoryModal').on('shown.bs.modal', function(){
-            $('#gitCustomRepositoryModalRepositoryNameInput').removeClass('is-invalid');
-            $('#gitCustomRepositoryModalRepositoryBranchInput').removeClass('is-invalid');
+            Modals.applyValidationState($('#gitCustomRepositoryModalRepositorySlugInput'), null);
+            Modals.applyValidationState($('#gitCustomRepositoryModalRepositoryBranchInput'), null);
 
             $('#gitCustomRepositoryModalAffirmativeButton').prop('disabled', true);
             $('#gitCustomRepositoryModalAffirmativeButton').trigger("focus");
@@ -426,7 +427,7 @@ export class Modals {
 
                     // check selected option in select tag
                     const repositoryService : Repository.Service = <Repository.Service>Utils.getUIValue('#gitCustomRepositoryModalRepositoryServiceSelect', 'val', Repository.Service.Unknown);
-                    const repositoryName : string = Utils.getUIValue('#gitCustomRepositoryModalRepositoryNameInput', 'val', "");
+                    const repositoryName : string = Utils.getUIValue('#gitCustomRepositoryModalRepositorySlugInput', 'val', "");
                     const repositoryBranch : string = Utils.getUIValue('#gitCustomRepositoryModalRepositoryBranchInput', 'val', "");
 
                     callback(true, repositoryService, repositoryName, repositoryBranch);
@@ -543,6 +544,19 @@ export class Modals {
         });
     }
 
+    static validateField(type: string, value: string) : Utils.ValidationResult {
+        // make sure JSON fields are parse-able
+        if (type === Daliuge.DataType.Json){
+            try {
+                JSON.parse(value);
+            } catch(e) {
+                return { isValid: false, message: "Invalid JSON: " + Errors.UnknownToError(e)};
+            }
+        }
+
+        return { isValid: true };
+    }
+
     static validateFieldModalValueInputText(data: Field, event: Event): void {
         const type: string = data.getType()
         const eventTarget = event.target;
@@ -557,14 +571,12 @@ export class Modals {
 
         // only validate Json fields
         if (realType !== Daliuge.DataType.Json){
-            $(eventTarget).removeClass('is-valid');
-            $(eventTarget).removeClass('is-invalid');
+            Modals.applyValidationState($(eventTarget), null);
             return;
         }
 
-        const isValid = Utils.validateField(realType, value);
-
-        Modals._setValidClasses($(eventTarget), isValid);
+        const validationResult: Utils.ValidationResult = Modals.validateField(realType, value);
+        Modals.applyValidationState($(eventTarget), validationResult);
     }
 
     static validateCommitModalFileNameInputText(): void {
@@ -579,7 +591,10 @@ export class Modals {
             (fileType === Eagle.FileType.Palette && inputElementValue.endsWith(".palette")) ||
             (fileType === Eagle.FileType.GraphConfig && inputElementValue.endsWith(".graphConfig"));
 
-        Modals._setValidClasses(inputElement, isValid);
+        const validationResult: Utils.ValidationResult = { isValid };
+
+        Modals.applyValidationState(inputElement, validationResult);
+        $('#gitCommitModalAffirmativeButton').prop('disabled', !validationResult.isValid);
     }
 
     static showBrowseDockerHub(image: string, tag: string, callback: Modals.UserDockerHubCallback ) : void {
@@ -606,13 +621,31 @@ export class Modals {
         $('#browseDockerHubModal').modal("toggle");
     }
 
-    static _setValidClasses(target: JQuery<EventTarget>, isValid: boolean){
-        if (isValid){
+    static applyValidationState(target: JQuery<EventTarget>, validationResult: Utils.ValidationResult | null): void {
+        const feedback = target.siblings('.invalid-feedback').first();
+
+        // Neutral state: remove validation classes and clear inline feedback text.
+        if (validationResult === null){
+            target.removeClass('is-valid');
+            target.removeClass('is-invalid');
+            if (feedback.length > 0){
+                feedback.text('');
+            }
+            return;
+        }
+
+        if (validationResult.isValid){
             target.addClass('is-valid');
             target.removeClass('is-invalid');
         } else {
             target.removeClass('is-valid');
             target.addClass('is-invalid');
+        }
+
+        if (typeof validationResult.message !== 'undefined'){
+            if (feedback.length > 0){
+                feedback.text(validationResult.message);
+            }
         }
     }
 

--- a/src/Modals.ts
+++ b/src/Modals.ts
@@ -14,7 +14,7 @@ declare const CodeMirror: any;
 export class Modals {
     static init(eagle : Eagle) : void {
         // #inputModal - requestUserInput()
-        $('#inputModal .modal-footer button.affirmativeBtn').on('click', function(){
+        $('#inputModal .modal-footer button.affirmativeBtn').on('click', function(event){
             if ($('#inputModal').data('returnType') === "string"){
                 const validateInput = $('#inputModal').data('validateInput');
                 if (typeof validateInput === 'function'){
@@ -23,11 +23,14 @@ export class Modals {
 
                 const isValid = $('#inputModal').data('isValid');
                 if (isValid === false){
+                    event.preventDefault();
+                    event.stopPropagation();
                     return;
                 }
             }
 
             $('#inputModal').data('completed', true);
+            $('#inputModal').modal('hide');
         });
         $('#inputModal').on('hidden.bs.modal', function(){
             const returnType = $('#inputModal').data('returnType');

--- a/src/ParameterTable.ts
+++ b/src/ParameterTable.ts
@@ -456,18 +456,19 @@ export class ParameterTable {
             
             let configName: string;
             try {
-                configName = await Utils.requestUserString("New Configuration", "Enter a name for the new configuration", Utils.generateGraphConfigName(graphConfig), false);
+                configName = await Utils.requestUserString(
+                    "New Configuration",
+                    "Enter a name for the new configuration",
+                    Utils.generateGraphConfigName(graphConfig),
+                    false,
+                    Utils.nonEmptyStringValidator("Configuration name")
+                );
             } catch(error){
                 console.error(error);
                 return;
             }
 
             ParameterTable.openTable(Eagle.BottomWindowMode.NodeParameterTable, ParameterTable.SelectType.Normal);
-
-            if (configName === ""){
-                Utils.showNotification("Invalid name", "Please enter a name for the new object", "danger");
-                return;
-            }
 
             // set name
             graphConfig.fileInfo().name = configName;

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -67,18 +67,6 @@ export class Repositories {
         return Utils.buildUrl(repository.service, repository.name, repository.branch);
     }
 
-    static validateBranchName(branchName: string): string | null {
-        if (branchName.trim() === ""){
-            return "Branch name cannot be empty.";
-        }
-
-        if (/\s/.test(branchName)){
-            return "Branch name cannot contain whitespace.";
-        }
-
-        return null;
-    }
-
     static getWebUrl(repository: Repository): string {
         switch (repository.service){
             case Repository.Service.GitHub:
@@ -245,7 +233,7 @@ export class Repositories {
     promptCreateBranch = async (repository: Repository): Promise<void> => {
         let branchName: string;
         try {
-            branchName = await Utils.requestUserString("Create Branch", "Enter a name for the new branch", "", false, Repositories.validateBranchName);
+            branchName = await Utils.requestUserString("Create Branch", "Enter a name for the new branch", "", false, Utils.branchNameStringValidator("Branch name"));
         } catch {
             return; // user cancelled
         }

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -250,12 +250,6 @@ export class Repositories {
             return; // user cancelled
         }
 
-        const branchNameValidationError = Repositories.validateBranchName(branchName);
-        if (branchNameValidationError !== null){
-            Utils.showNotification("Error", branchNameValidationError, "danger");
-            return;
-        }
-
         try {
             await this.createBranch(repository, branchName);
             Utils.showNotification("Branch Created", `Successfully created branch '${branchName}'`, "success");

--- a/src/Repositories.ts
+++ b/src/Repositories.ts
@@ -67,6 +67,18 @@ export class Repositories {
         return Utils.buildUrl(repository.service, repository.name, repository.branch);
     }
 
+    static validateBranchName(branchName: string): string | null {
+        if (branchName.trim() === ""){
+            return "Branch name cannot be empty.";
+        }
+
+        if (/\s/.test(branchName)){
+            return "Branch name cannot contain whitespace.";
+        }
+
+        return null;
+    }
+
     static getWebUrl(repository: Repository): string {
         switch (repository.service){
             case Repository.Service.GitHub:
@@ -233,10 +245,17 @@ export class Repositories {
     promptCreateBranch = async (repository: Repository): Promise<void> => {
         let branchName: string;
         try {
-            branchName = await Utils.requestUserString("Create Branch", "Enter a name for the new branch", "", false);
+            branchName = await Utils.requestUserString("Create Branch", "Enter a name for the new branch", "", false, Repositories.validateBranchName);
         } catch {
             return; // user cancelled
         }
+
+        const branchNameValidationError = Repositories.validateBranchName(branchName);
+        if (branchNameValidationError !== null){
+            Utils.showNotification("Error", branchNameValidationError, "danger");
+            return;
+        }
+
         try {
             await this.createBranch(repository, branchName);
             Utils.showNotification("Branch Created", `Successfully created branch '${branchName}'`, "success");

--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -210,7 +210,7 @@ export class Translator {
 
         let userString: string;
         try {
-            userString = await Utils.requestUserString("Translator Url", "Enter the Translator Url", defaultUrl, false);
+            userString = await Utils.requestUserString("Translator Url", "Enter the Translator Url", defaultUrl, false, Utils.httpUrlStringValidator("Translator URL"));
         } catch (error){
             console.error(error);
             return;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -580,6 +580,58 @@ export class Utils {
         };
     }
 
+    static branchNameStringValidator(label: string = "Branch name"): Modals.UserStringValidator {
+        return (userString: string): string | null => {
+            const nonEmptyResult = Utils.nonEmptyStringValidator(label)(userString);
+            if (nonEmptyResult !== null){
+                return nonEmptyResult;
+            }
+
+            if (/\s/.test(userString)){
+                return label + " cannot contain whitespace.";
+            }
+
+            if (userString.startsWith("-") ){
+                return label + " cannot start with '-'.";
+            }
+
+            if (userString === "@"){
+                return label + " cannot be '@'.";
+            }
+
+            if (userString.includes("@{")){
+                return label + " cannot contain '@{'.";
+            }
+
+            if (userString.includes("..")){
+                return label + " cannot contain '..'.";
+            }
+
+            if (userString.startsWith("/") || userString.endsWith("/") || userString.includes("//")){
+                return label + " cannot contain empty path segments.";
+            }
+
+            if (userString.endsWith(".")){
+                return label + " cannot end with '.'.";
+            }
+
+            if (userString.endsWith(".lock")){
+                return label + " cannot end with '.lock'.";
+            }
+
+            const components = userString.split("/");
+            if (components.some(component => component.startsWith("."))){
+                return label + " cannot have path segments starting with '.'.";
+            }
+
+            if (/[\x00-\x1F\x7F~^:?*\[\\]/.test(userString)){
+                return label + " contains invalid characters.";
+            }
+
+            return null;
+        };
+    }
+
     static requestUserString(title : string, message : string, defaultString: string, isPassword: boolean, validator?: Modals.UserStringValidator): Promise<string> {
         return new Promise(async(resolve, reject) => {
             $('#inputModalTitle').text(title);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -549,138 +549,178 @@ export class Utils {
     }
 
     static nonEmptyStringValidator(label: string): Modals.UserStringValidator {
-        return (userString: string): string | null => {
+        return (userString: string): Utils.ValidationResult => {
             if (userString.trim() === ""){
-                return label + " cannot be empty.";
+                return { isValid: false, message: label + " cannot be empty." };
             }
 
-            return null;
+            return { isValid: true };
         };
     }
 
     static httpUrlStringValidator(label: string = "URL"): Modals.UserStringValidator {
-        return (userString: string): string | null => {
+        return (userString: string): Utils.ValidationResult => {
             const trimmed = userString.trim();
             if (trimmed === ""){
-                return label + " cannot be empty.";
+                return { isValid: false, message: label + " cannot be empty." };
             }
 
             let parsedUrl: URL;
             try {
                 parsedUrl = new URL(trimmed);
             } catch (_error) {
-                return label + " is not a valid URL.";
+                return { isValid: false, message: label + " is not a valid URL." };
             }
 
             if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:"){
-                return label + " must start with http:// or https://.";
+                return { isValid: false, message: label + " must start with http:// or https://." };
             }
 
-            return null;
+            return { isValid: true };
         };
     }
 
     static repositorySlugStringValidator(label: string = "Repository name"): Modals.UserStringValidator {
-        return (userString: string): string | null => {
+        return (userString: string): Utils.ValidationResult => {
             const nonEmptyResult = Utils.nonEmptyStringValidator(label)(userString);
-            if (nonEmptyResult !== null){
+            if (!nonEmptyResult.isValid){
                 return nonEmptyResult;
             }
 
             const trimmed = userString.trim();
             if (trimmed !== userString){
-                return label + " cannot start or end with whitespace.";
+                return { isValid: false, message: label + " cannot start or end with whitespace." };
             }
 
             if (/\s/.test(trimmed)){
-                return label + " cannot contain whitespace.";
+                return { isValid: false, message: label + " cannot contain whitespace." };
             }
 
             if (trimmed.startsWith('http://') || trimmed.startsWith('https://')){
-                return label + " must be in the format 'owner/repository', not a URL.";
+                return { isValid: false, message: label + " must be in the format 'owner/repository', not a URL." };
             }
 
             if (trimmed.endsWith('.git')){
-                return label + " cannot end with '.git'.";
+                return { isValid: false, message: label + " cannot end with '.git'." };
             }
 
             if (trimmed.startsWith('/') || trimmed.endsWith('/') || trimmed.includes('//')){
-                return label + " must be in the format 'owner/repository'.";
+                return { isValid: false, message: label + " must be in the format 'owner/repository'." };
             }
 
             const components = trimmed.split('/');
             if (components.length !== 2){
-                return label + " must be in the format 'owner/repository'.";
+                return { isValid: false, message: label + " must be in the format 'owner/repository'." };
             }
 
             const [owner, repository] = components;
             const invalidChars = /[^A-Za-z0-9._-]/;
 
             if (invalidChars.test(owner) || invalidChars.test(repository)){
-                return label + " can only contain letters, numbers, '.', '_' and '-'.";
+                return { isValid: false, message: label + " can only contain letters, numbers, '.', '_' and '-'." };
             }
 
             if (owner === "." || owner === ".." || repository === "." || repository === ".."){
-                return label + " cannot contain '.' or '..' path components.";
+                return { isValid: false, message: label + " cannot contain '.' or '..' path components." };
             }
 
             if (owner.startsWith('.') || repository.startsWith('.')){
-                return label + " cannot have components starting with '.'.";
+                return { isValid: false, message: label + " cannot have components starting with '.'." };
             }
 
-            return null;
+            return { isValid: true };
         };
     }
 
     static branchNameStringValidator(label: string = "Branch name"): Modals.UserStringValidator {
-        return (userString: string): string | null => {
+        return (userString: string): Utils.ValidationResult => {
             const nonEmptyResult = Utils.nonEmptyStringValidator(label)(userString);
-            if (nonEmptyResult !== null){
+            if (!nonEmptyResult.isValid){
                 return nonEmptyResult;
             }
 
             if (/\s/.test(userString)){
-                return label + " cannot contain whitespace.";
+                return { isValid: false, message: label + " cannot contain whitespace." };
             }
 
             if (userString.startsWith("-") ){
-                return label + " cannot start with '-'.";
+                return { isValid: false, message: label + " cannot start with '-'." };
             }
 
             if (userString === "@"){
-                return label + " cannot be '@'.";
+                return { isValid: false, message: label + " cannot be '@'." };
             }
 
             if (userString.includes("@{")){
-                return label + " cannot contain '@{'.";
+                return { isValid: false, message: label + " cannot contain '@{'." };
             }
 
             if (userString.includes("..")){
-                return label + " cannot contain '..'.";
+                return { isValid: false, message: label + " cannot contain '..'." };
             }
 
             if (userString.startsWith("/") || userString.endsWith("/") || userString.includes("//")){
-                return label + " cannot contain empty path segments.";
+                return { isValid: false, message: label + " cannot contain empty path segments." };
             }
 
             if (userString.endsWith(".")){
-                return label + " cannot end with '.'.";
+                return { isValid: false, message: label + " cannot end with '.'." };
             }
 
             if (userString.endsWith(".lock")){
-                return label + " cannot end with '.lock'.";
+                return { isValid: false, message: label + " cannot end with '.lock'." };
             }
 
             const components = userString.split("/");
             if (components.some(component => component.startsWith("."))){
-                return label + " cannot have path segments starting with '.'.";
+                return { isValid: false, message: label + " cannot have path segments starting with '.'." };
             }
 
             if (/[\x00-\x1F\x7F~^:?*\[\\]/.test(userString)){
-                return label + " contains invalid characters.";
+                return { isValid: false, message: label + " contains invalid characters." };
             }
 
-            return null;
+            return { isValid: true };
+        };
+    }
+
+    static gitCommitFileNameStringValidator(fileType: Eagle.FileType, label: string = "File name"): Modals.UserStringValidator {
+        return (userString: string): Utils.ValidationResult => {
+            if (fileType === Eagle.FileType.Unknown){
+                return { isValid: true };
+            }
+
+            let requiredExtension: string | null = null;
+            switch (fileType){
+                case Eagle.FileType.Graph:
+                    requiredExtension = ".graph";
+                    break;
+                case Eagle.FileType.Palette:
+                    requiredExtension = ".palette";
+                    break;
+                case Eagle.FileType.GraphConfig:
+                    requiredExtension = ".graphConfig";
+                    break;
+                default:
+                    return { isValid: true };
+            }
+
+            if (userString.endsWith(requiredExtension)){
+                return { isValid: true };
+            }
+
+            return { isValid: false, message: label + " must end with '" + requiredExtension + "'." };
+        };
+    }
+
+    static jsonStringValidator(label: string = "JSON"): Modals.UserStringValidator {
+        return (userString: string): Utils.ValidationResult => {
+            try {
+                JSON.parse(userString);
+                return { isValid: true };
+            } catch (error) {
+                return { isValid: false, message: "Invalid " + label + ": " + Errors.UnknownToError(error) };
+            }
         };
     }
 
@@ -701,8 +741,8 @@ export class Utils {
                 }
 
                 const userString = Utils.getUIValue('#inputModalInput', 'val', "");
-                const reason = validator(userString);
-                const isValid = reason === null;
+                const validationResult = validator(userString);
+                const isValid = validationResult.isValid;
 
                 $('#inputModal').data('isValid', isValid);
                 $('#inputModalInput').toggleClass('is-valid', isValid);
@@ -711,7 +751,7 @@ export class Utils {
                 if (isValid){
                     $('#inputModalInvalidFeedback').hide().text('');
                 } else {
-                    $('#inputModalInvalidFeedback').show().text(reason);
+                    $('#inputModalInvalidFeedback').show().text(validationResult.message ?? 'Invalid value.');
                 }
 
                 return isValid;
@@ -1081,17 +1121,17 @@ export class Utils {
             return false;
         }
 
-        const repositoryNameValidationError = Utils.repositorySlugStringValidator("Repository name")(repositoryName);
-        if (repositoryNameValidationError !== null){
-            Modals.applyValidationState(repositoryNameInput, { isValid: false, message: repositoryNameValidationError });
+        const repositoryNameValidationResult = Utils.repositorySlugStringValidator("Repository name")(repositoryName);
+        if (!repositoryNameValidationResult.isValid){
+            Modals.applyValidationState(repositoryNameInput, repositoryNameValidationResult);
             return false;
         }
 
         Modals.applyValidationState(repositoryNameInput, { isValid: true });
 
-        const repositoryBranchValidationError = Utils.branchNameStringValidator("Repository branch")(repositoryBranch);
-        if (repositoryBranchValidationError !== null){
-            Modals.applyValidationState(repositoryBranchInput, { isValid: false, message: repositoryBranchValidationError });
+        const repositoryBranchValidationResult = Utils.branchNameStringValidator("Repository branch")(repositoryBranch);
+        if (!repositoryBranchValidationResult.isValid){
+            Modals.applyValidationState(repositoryBranchInput, repositoryBranchValidationResult);
             return false;
         }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -547,7 +547,7 @@ export class Utils {
         Utils.showNotification(action, message, "warning");
     }
 
-    static requestUserString(title : string, message : string, defaultString: string, isPassword: boolean): Promise<string> {
+    static requestUserString(title : string, message : string, defaultString: string, isPassword: boolean, validator?: Modals.UserStringValidator): Promise<string> {
         return new Promise(async(resolve, reject) => {
             $('#inputModalTitle').text(title);
             $('#inputModalMessage').html(Utils.markdown2html(message));
@@ -555,9 +555,35 @@ export class Utils {
 
             $('#inputModalInput').val(defaultString);
 
+            const validateInput = (): boolean => {
+                if (typeof validator === 'undefined'){
+                    $('#inputModalInput').removeClass('is-valid is-invalid');
+                    $('#inputModalInvalidFeedback').hide().text('');
+                    $('#inputModal').data('isValid', true);
+                    return true;
+                }
+
+                const userString = Utils.getUIValue('#inputModalInput', 'val', "");
+                const reason = validator(userString);
+                const isValid = reason === null;
+
+                $('#inputModal').data('isValid', isValid);
+                $('#inputModalInput').toggleClass('is-valid', isValid);
+                $('#inputModalInput').toggleClass('is-invalid', !isValid);
+
+                if (isValid){
+                    $('#inputModalInvalidFeedback').hide().text('');
+                } else {
+                    $('#inputModalInvalidFeedback').show().text(reason);
+                }
+
+                return isValid;
+            };
+
             // store data about the choices, callback, result on the modal HTML element
             // so that the info is available to event handlers
             $('#inputModal').data('completed', false);
+            $('#inputModal').data('isValid', true);
 
             const callback: Modals.UserStringCallback = (completed : boolean, userString : string) => {
                 if (!completed){
@@ -568,6 +594,14 @@ export class Utils {
             };
             $('#inputModal').data('callback', callback);
             $('#inputModal').data('returnType', "string");
+            $('#inputModal').data('validateInput', validateInput);
+
+            $('#inputModalInput').off('input.requestUserStringValidation');
+            $('#inputModalInput').on('input.requestUserStringValidation', function(){
+                validateInput();
+            });
+
+            validateInput();
 
             $('#inputModal').modal("show");
         });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -185,14 +185,15 @@ export class Utils {
 
             let userString;
             try {
-                userString = await Utils.requestUserString("New " + fileType, "Enter " + fileType + " name", defaultName, false);
+                userString = await Utils.requestUserString(
+                    "New " + fileType,
+                    "Enter " + fileType + " name",
+                    defaultName,
+                    false,
+                    Utils.nonEmptyStringValidator(fileType + " name")
+                );
             } catch(error) {
                 reject(error);
-                return;
-            }
-
-            if (userString === ""){
-                reject( "Specified name is not valid for new " + fileType);
                 return;
             }
 
@@ -545,6 +546,38 @@ export class Utils {
             message = fileType + " editing is not permitted in the current UI mode (" + uiMode + ")";
         }
         Utils.showNotification(action, message, "warning");
+    }
+
+    static nonEmptyStringValidator(label: string): Modals.UserStringValidator {
+        return (userString: string): string | null => {
+            if (userString.trim() === ""){
+                return label + " cannot be empty.";
+            }
+
+            return null;
+        };
+    }
+
+    static httpUrlStringValidator(label: string = "URL"): Modals.UserStringValidator {
+        return (userString: string): string | null => {
+            const trimmed = userString.trim();
+            if (trimmed === ""){
+                return label + " cannot be empty.";
+            }
+
+            let parsedUrl: URL;
+            try {
+                parsedUrl = new URL(trimmed);
+            } catch (_error) {
+                return label + " is not a valid URL.";
+            }
+
+            if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:"){
+                return label + " must start with http:// or https://.";
+            }
+
+            return null;
+        };
     }
 
     static requestUserString(title : string, message : string, defaultString: string, isPassword: boolean, validator?: Modals.UserStringValidator): Promise<string> {
@@ -1980,7 +2013,7 @@ export class Utils {
     }
 
     static async userEnterCommitMessage(modalMessage: string) : Promise<string> {
-        return Utils.requestUserString("Saving to git", modalMessage, "", false);
+        return Utils.requestUserString("Saving to git", modalMessage, "", false, Utils.nonEmptyStringValidator("Commit message"));
     }
 
     // TODO: could we return a list of KeyboardShortcut here?

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -580,6 +580,58 @@ export class Utils {
         };
     }
 
+    static repositorySlugStringValidator(label: string = "Repository name"): Modals.UserStringValidator {
+        return (userString: string): string | null => {
+            const nonEmptyResult = Utils.nonEmptyStringValidator(label)(userString);
+            if (nonEmptyResult !== null){
+                return nonEmptyResult;
+            }
+
+            const trimmed = userString.trim();
+            if (trimmed !== userString){
+                return label + " cannot start or end with whitespace.";
+            }
+
+            if (/\s/.test(trimmed)){
+                return label + " cannot contain whitespace.";
+            }
+
+            if (trimmed.startsWith('http://') || trimmed.startsWith('https://')){
+                return label + " must be in the format 'owner/repository', not a URL.";
+            }
+
+            if (trimmed.endsWith('.git')){
+                return label + " cannot end with '.git'.";
+            }
+
+            if (trimmed.startsWith('/') || trimmed.endsWith('/') || trimmed.includes('//')){
+                return label + " must be in the format 'owner/repository'.";
+            }
+
+            const components = trimmed.split('/');
+            if (components.length !== 2){
+                return label + " must be in the format 'owner/repository'.";
+            }
+
+            const [owner, repository] = components;
+            const invalidChars = /[^A-Za-z0-9._-]/;
+
+            if (invalidChars.test(owner) || invalidChars.test(repository)){
+                return label + " can only contain letters, numbers, '.', '_' and '-'.";
+            }
+
+            if (owner === "." || owner === ".." || repository === "." || repository === ".."){
+                return label + " cannot contain '.' or '..' path components.";
+            }
+
+            if (owner.startsWith('.') || repository.startsWith('.')){
+                return label + " cannot have components starting with '.'.";
+            }
+
+            return null;
+        };
+    }
+
     static branchNameStringValidator(label: string = "Branch name"): Modals.UserStringValidator {
         return (userString: string): string | null => {
             const nonEmptyResult = Utils.nonEmptyStringValidator(label)(userString);
@@ -995,7 +1047,7 @@ export class Utils {
 
     static requestUserAddCustomRepository(): Promise<Repository> {
         return new Promise(async(resolve, reject) => {
-            $('#gitCustomRepositoryModalRepositoryNameInput').val("");
+            $('#gitCustomRepositoryModalRepositorySlugInput').val("");
             $('#gitCustomRepositoryModalRepositoryBranchInput').val("");
 
             $('#gitCustomRepositoryModal').data('completed', false);
@@ -1015,34 +1067,35 @@ export class Utils {
 
     static validateCustomRepository() : boolean {
         const repositoryService : string = Utils.getUIValue('#gitCustomRepositoryModalRepositoryServiceSelect', 'val', "");
-        const repositoryName : string = Utils.getUIValue('#gitCustomRepositoryModalRepositoryNameInput', 'val', "");
+        const repositoryName : string = Utils.getUIValue('#gitCustomRepositoryModalRepositorySlugInput', 'val', "");
         const repositoryBranch : string = Utils.getUIValue('#gitCustomRepositoryModalRepositoryBranchInput', 'val', "");
 
-        $('#gitCustomRepositoryModalRepositoryNameInput').removeClass('is-invalid');
-        $('#gitCustomRepositoryModalRepositoryBranchInput').removeClass('is-invalid');
+        const repositoryNameInput = $('#gitCustomRepositoryModalRepositorySlugInput');
+        const repositoryBranchInput = $('#gitCustomRepositoryModalRepositoryBranchInput');
+
+        Modals.applyValidationState(repositoryNameInput, null);
+        Modals.applyValidationState(repositoryBranchInput, null);
 
         // check service
         if (repositoryService.trim() !== Repository.Service.GitHub && repositoryService.trim() !== Repository.Service.GitLab){
             return false;
         }
 
-        // check if name is empty
-        if (repositoryName.trim() == ""){
-            $('#gitCustomRepositoryModalRepositoryNameInput').addClass('is-invalid');
+        const repositoryNameValidationError = Utils.repositorySlugStringValidator("Repository name")(repositoryName);
+        if (repositoryNameValidationError !== null){
+            Modals.applyValidationState(repositoryNameInput, { isValid: false, message: repositoryNameValidationError });
             return false;
         }
 
-        // check if name starts with http:// or https://, or ends with .git
-        if (repositoryName.startsWith('http://') || repositoryName.startsWith('https://') || repositoryName.endsWith('.git')){
-            $('#gitCustomRepositoryModalRepositoryNameInput').addClass('is-invalid');
+        Modals.applyValidationState(repositoryNameInput, { isValid: true });
+
+        const repositoryBranchValidationError = Utils.branchNameStringValidator("Repository branch")(repositoryBranch);
+        if (repositoryBranchValidationError !== null){
+            Modals.applyValidationState(repositoryBranchInput, { isValid: false, message: repositoryBranchValidationError });
             return false;
         }
 
-        // check if branch is empty
-        if (repositoryBranch.trim() == ""){
-            $('#gitCustomRepositoryModalRepositoryBranchInput').addClass('is-invalid');
-            return false;
-        }
+        Modals.applyValidationState(repositoryBranchInput, { isValid: true });
 
         return true;
     }
@@ -1952,41 +2005,6 @@ export class Utils {
         return {valid: valid, errors: ajv.errorsText(ajv.errors)};
     }
 
-    static isAlpha(ch: string){
-        return /^[A-Z]$/i.test(ch);
-    }
-
-    static isNumeric(ch: string){
-        return /^[0-9]$/i.test(ch);
-    }
-
-    static validateField(type: string, value: string) : boolean {
-        let valid: boolean = true;
-
-        // make sure JSON fields are parse-able
-        if (type === Daliuge.DataType.Json){
-            try {
-                JSON.parse(value);
-            } catch(e) {
-                valid = false;
-            }
-        }
-
-        return valid;
-    }
-
-    static validateType(type: string) : boolean {
-        if (typeof(type) === "undefined"){
-            return false;
-        }
-
-        if (type.trim() === ""){
-            return false;
-        }
-
-        return true;
-    }
-
     static async downloadFile(data : string, fileName : string) : Promise<void> {
         return new Promise(async(resolve) => {
             // NOTE: this stuff is a hacky way of saving a file locally
@@ -2003,6 +2021,17 @@ export class Utils {
         });
     }
 
+    static validateType(type: string) : boolean {
+        if (typeof(type) === "undefined"){
+            return false;
+        }
+
+        if (type.trim() === ""){
+            return false;
+        }
+
+        return true;
+    }
 
     static nodesOverlap(n0x: number, n0y: number, n0radius: number, n1x: number, n1y: number, n1radius: number) : boolean {
         const dx = n0x - n1x;
@@ -3522,4 +3551,11 @@ export class Utils {
 
         return url;
     }
+}
+
+export namespace Utils {
+    export type ValidationResult = {
+        isValid: boolean;
+        message?: string;
+    };
 }

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -10,7 +10,7 @@
                 <span id="messageModalMessage">Message</span>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary affirmativeBtn" data-bs-dismiss="modal">OK</button>
+                <button type="button" class="btn btn-primary affirmativeBtn">OK</button>
             </div>
         </div>
     </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -31,8 +31,9 @@
                     </div>
                     <div class="row">
                         <div class="col">
-                            <div class="input-group mb-3">
+                            <div class="input-group mb-3 has-validation">
                                 <input type="text" class="form-control" id="inputModalInput">
+                                <div class="invalid-feedback" id="inputModalInvalidFeedback"></div>
                             </div>
                         </div>
                     </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -336,11 +336,12 @@
                     </div>
                     <div class="row">
                         <div class="col-3">
-                            <p>Name *</p>
+                            <p>Slug *</p>
                         </div>
                         <div class="col">
                             <div class="input-group mb-3 has-validation">
-                                <input type="text" class="form-control" id="gitCustomRepositoryModalRepositoryNameInput" placeholder="example-username/example-graph-repository">
+                                <input type="text" class="form-control" id="gitCustomRepositoryModalRepositorySlugInput" placeholder="owner/repository-name">
+                                <div class="invalid-feedback" id="gitCustomRepositoryModalRepositorySlugInputInvalidFeedback"></div>
                             </div>
                         </div>
                     </div>
@@ -351,6 +352,7 @@
                         <div class="col">
                             <div class="input-group mb-3 has-validation">
                                 <input type="text" class="form-control" id="gitCustomRepositoryModalRepositoryBranchInput" placeholder="master">
+                                <div class="invalid-feedback" id="gitCustomRepositoryModalRepositoryBranchInputInvalidFeedback"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Updated the following modals/inputs:

- Add custom repository
- Git commit filename
- Create branch
- Create new graph from URL
- Save As
- New Configuration (name)
- Translator URL

## Summary by Sourcery

Introduce reusable client-side validators and UX improvements for text input modals, and apply them across repository, branch, URL, filename, and configuration name flows, with matching server-side validation for branch creation.

New Features:
- Add a generic validation mechanism to the shared input modal, including inline feedback messaging for invalid values.
- Introduce specific validators for non-empty strings, HTTP URLs, repository slugs, branch names, git commit filenames, and JSON fields, and wire them into relevant flows.

Bug Fixes:
- Ensure invalid inputs in create-branch, URL, Save As, git commit filename, and configuration name dialogs are blocked and clearly reported instead of silently failing or proceeding.
- Align backend branch-name validation with frontend rules to prevent invalid branches from being created via the API.

Enhancements:
- Refine the custom repository modal to validate repository slug and branch using shared utilities and show inline error messages.
- Standardize modal closing behavior so affirmative actions only proceed when input is valid, and clean up validation state when modals are hidden.
- Improve the robustness of branch creation UI interactions in end-to-end tests and add helpers for reliably closing the generic input modal.

Tests:
- Extend and adjust Playwright end-to-end tests to cover custom repository slug input, branch-name validation UX, URL and Save As modal validation, and git commit filename validation behavior.