### PR TITLE
EAGLE-740: Warnings/Errors still appear in navbar after Undo 

### DIFF
--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -836,15 +836,21 @@ export class TestHelpers {
     }
 
     static async getNumWarningsErrors(page: Page): Promise<number> {
-        // if button#checkEagleWarnings is visible, then there are some warnings or errors, so return the sum of the counts in each span.badge
         const checkButton = page.locator('#checkEagleWarnings');
-        if (await checkButton.isVisible()) {
-            const warningCount = await page.locator('#checkEagleWarnings span.badge').nth(0).innerText();
-            const errorCount = await page.locator('#checkEagleWarnings span.badge').nth(1).innerText();
-            return parseInt(warningCount) + parseInt(errorCount);
-        } else {
+        if (!(await checkButton.isVisible())) {
             return 0;
         }
+
+        const warningBadge = page.locator('#checkEagleWarnings span.badge.bg-warning:visible').first();
+        const errorBadge = page.locator('#checkEagleWarnings span.badge.bg-danger:visible').first();
+
+        const warningText = (await warningBadge.count()) > 0 ? (await warningBadge.textContent()) : null;
+        const errorText = (await errorBadge.count()) > 0 ? (await errorBadge.textContent()) : null;
+
+        const warningCount = parseInt((warningText ?? '0').trim(), 10) || 0;
+        const errorCount = parseInt((errorText ?? '0').trim(), 10) || 0;
+
+        return warningCount + errorCount;
     }
 
     // Expand a palette accordion by index

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -567,27 +567,108 @@ export class TestHelpers {
     }
 
     static async setShortDescription(page: Page, description: string): Promise<void> {
-        await page.evaluate( (description: string) => {
-            (window as any).eagle.logicalGraph().fileInfo().shortDescription = description;
-            (window as any).eagle.checkEagle();
-        }, description);
+        // open the graph model data modal, and check it is visible
+        await page.locator('#openGraphModelDataModal').click();
+        await page.locator('#modelDataModal').waitFor({ state: 'visible' });
+
+        // hover over the #modelDataShortDescription
+        await page.locator('#modelDataShortDescription').hover();
+
+        // check the button.modelDataTableEditParam is visible
+        //await page.locator('#modelDataShortDescription .modelDataTableEditParam').waitFor({ state: 'visible' });
+        await page.waitForTimeout(2000);
+
+        // click the button.modelDataTableEditParam
+        await page.locator('#modelDataShortDescription .modelDataTableEditParam').click();
+
+        // wait for the #inputMarkdownModal to be visible
+        //await page.locator('#inputMarkdownModal').waitFor({ state: 'visible' });
+        await page.waitForTimeout(2000);
+
+        // check the state of the #editInputMarkdownModalInput form-switch, if enabled, do nothing, if disabled, click it to enable it
+        const formSwitch = await page.locator('#editMarkdownSwitchCheck');
+        if (!(await formSwitch.isChecked())) {
+            await formSwitch.click();
+        }
+
+        // fill the code mirror editor with the description
+        await page.evaluate(TestHelpers.setMarkdownModalContent, description);
+
+        // click the save button
+        await page.locator('#inputMarkdownModal button.affirmativeBtn').click();
+
+        // wait for the #inputMarkdownModal to be hidden
+        //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
+        await page.waitForTimeout(2000);
+
+        // click the close button on the #modelDataModal
+        await page.locator('#modelDataModalOKButton').click();
+
+        // wait until the #modelDataModal is hidden
+        //await page.locator('#modelDataModal').waitFor({ state: 'hidden' });
+        await page.waitForTimeout(2000);
     }
 
     static async setDetailedDescription(page: Page, description: string): Promise<void> {
-        await page.evaluate( (description: string) => {
-            (window as any).eagle.logicalGraph().fileInfo().detailedDescription = description;
-            (window as any).eagle.checkEagle();
-        }, description);
+        // open the graph model data modal, and check it is visible
+        await page.locator('#openGraphModelDataModal').click();
+        await page.locator('#modelDataModal').waitFor({ state: 'visible' });
+
+        // hover over the #modelDataDetailedDescription
+        await page.locator('#modelDataDetailedDescription').hover();
+
+        // check the button.modelDataTableEditParam is visible
+        //await page.locator('#modelDataDetailedDescription .modelDataTableEditParam').waitFor({ state: 'visible' });
+        await page.waitForTimeout(2000);
+
+        // click the button.modelDataTableEditParam
+        await page.locator('#modelDataDetailedDescription .modelDataTableEditParam').click();
+
+        // wait for the #inputMarkdownModal to be visible
+        //await page.locator('#inputMarkdownModal').waitFor({ state: 'visible' });
+        await page.waitForTimeout(2000);
+
+        // check the state of the #editInputMarkdownModalInput form-switch, if enabled, do nothing, if disabled, click it to enable it
+        const formSwitch = await page.locator('#editMarkdownSwitchCheck');
+        if (!(await formSwitch.isChecked())) {
+            await formSwitch.click();
+        }
+
+        await page.evaluate(TestHelpers.setMarkdownModalContent, description);
+
+        // click the save button
+        await page.locator('#inputMarkdownModal button.affirmativeBtn').click();
+
+        // wait for the #inputMarkdownModal to be hidden
+        //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
+        await page.waitForTimeout(2000);
+
+        // click the close button on the #modelDataModal
+        await page.locator('#modelDataModalOKButton').click();
+
+        // wait until the #modelDataModal is hidden
+        //await page.locator('#modelDataModal').waitFor({ state: 'hidden' });
+        await page.waitForTimeout(2000);
+    }
+
+    static setMarkdownModalContent(content: string): void {
+        const editor = ($('#inputMarkdownModal') as JQuery<HTMLElement>).data('editor');
+        editor.setValue(content);
+    }
+
+    static getMarkdownModalContent(): string {
+        const editor = ($('#inputMarkdownModal') as JQuery<HTMLElement>).data('editor');
+        return editor.getValue();
     }
 
     // Set the content of the editor in the modal
-    static setEditorContent(content: string): void {
+    static setCodeModalContent(content: string): void {
         const editor = ($('#inputCodeModal') as JQuery<HTMLElement>).data('editor');
         editor.setValue(content);
     }
 
     // Get the content of the editor in the modal
-    static getEditorContent(): string {
+    static getCodeModalContent(): string {
         const editor = ($('#inputCodeModal') as JQuery<HTMLElement>).data('editor');
         return editor.getValue();
     }
@@ -639,7 +720,7 @@ export class TestHelpers {
         await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // set the content of the editor in the modal
-        await page.evaluate(TestHelpers.setEditorContent, s);
+        await page.evaluate(TestHelpers.setCodeModalContent, s);
         await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click 'OK' to save the graph
@@ -663,7 +744,7 @@ export class TestHelpers {
         await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // set the content of the editor in the modal
-        await page.evaluate(TestHelpers.setEditorContent, s);
+        await page.evaluate(TestHelpers.setCodeModalContent, s);
         await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click 'OK' to save the graph
@@ -686,7 +767,7 @@ export class TestHelpers {
             await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
             // get JSON from modal
-            const outputOJS: string = await page.evaluate(TestHelpers.getEditorContent);
+            const outputOJS: string = await page.evaluate(TestHelpers.getCodeModalContent);
 
             await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
             await page.locator('#inputCodeModal button.affirmativeBtn').click()
@@ -755,9 +836,15 @@ export class TestHelpers {
     }
 
     static async getNumWarningsErrors(page: Page): Promise<number> {
-        return await page.evaluate(() => {
-            return (window as any).eagle.graphWarnings().length + (window as any).eagle.graphErrors().length;
-        });
+        // if button#checkEagleWarnings is visible, then there are some warnings or errors, so return the sum of the counts in each span.badge
+        const checkButton = page.locator('#checkEagleWarnings');
+        if (await checkButton.isVisible()) {
+            const warningCount = await page.locator('#checkEagleWarnings span.badge').nth(0).innerText();
+            const errorCount = await page.locator('#checkEagleWarnings span.badge').nth(1).innerText();
+            return parseInt(warningCount) + parseInt(errorCount);
+        } else {
+            return 0;
+        }
     }
 
     // Expand a palette accordion by index

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -8,6 +8,7 @@ export class TestHelpers {
     //How many times we will attempt to run a tutorial step before failing the test.
     private static readonly MAX_ATTEMPTS_PER_STEP = 5;
     public static readonly UI_SETTLE_TIMEOUT = 500;
+    public static readonly UI_SETTLE_TIMEOUT_LONG = 1000;
     public static readonly SHORT_TIMEOUT = 5000;
     public static readonly LONG_TIMEOUT = 10000;
     // Counts how many times we have opened the canvas context menu.
@@ -599,7 +600,7 @@ export class TestHelpers {
 
         // wait for the #inputMarkdownModal to be hidden
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT_LONG);
 
         // click the close button on the #modelDataModal
         await page.locator('#modelDataModalOKButton').click();
@@ -641,7 +642,7 @@ export class TestHelpers {
 
         // wait for the #inputMarkdownModal to be hidden
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT_LONG);
 
         // click the close button on the #modelDataModal
         await page.locator('#modelDataModalOKButton').click();

--- a/e2e/TestHelpers.ts
+++ b/e2e/TestHelpers.ts
@@ -576,14 +576,14 @@ export class TestHelpers {
 
         // check the button.modelDataTableEditParam is visible
         //await page.locator('#modelDataShortDescription .modelDataTableEditParam').waitFor({ state: 'visible' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click the button.modelDataTableEditParam
         await page.locator('#modelDataShortDescription .modelDataTableEditParam').click();
 
         // wait for the #inputMarkdownModal to be visible
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'visible' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // check the state of the #editInputMarkdownModalInput form-switch, if enabled, do nothing, if disabled, click it to enable it
         const formSwitch = await page.locator('#editMarkdownSwitchCheck');
@@ -599,14 +599,14 @@ export class TestHelpers {
 
         // wait for the #inputMarkdownModal to be hidden
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click the close button on the #modelDataModal
         await page.locator('#modelDataModalOKButton').click();
 
         // wait until the #modelDataModal is hidden
         //await page.locator('#modelDataModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
     }
 
     static async setDetailedDescription(page: Page, description: string): Promise<void> {
@@ -619,14 +619,14 @@ export class TestHelpers {
 
         // check the button.modelDataTableEditParam is visible
         //await page.locator('#modelDataDetailedDescription .modelDataTableEditParam').waitFor({ state: 'visible' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click the button.modelDataTableEditParam
         await page.locator('#modelDataDetailedDescription .modelDataTableEditParam').click();
 
         // wait for the #inputMarkdownModal to be visible
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'visible' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // check the state of the #editInputMarkdownModalInput form-switch, if enabled, do nothing, if disabled, click it to enable it
         const formSwitch = await page.locator('#editMarkdownSwitchCheck');
@@ -641,14 +641,14 @@ export class TestHelpers {
 
         // wait for the #inputMarkdownModal to be hidden
         //await page.locator('#inputMarkdownModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
 
         // click the close button on the #modelDataModal
         await page.locator('#modelDataModalOKButton').click();
 
         // wait until the #modelDataModal is hidden
         //await page.locator('#modelDataModal').waitFor({ state: 'hidden' });
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TestHelpers.UI_SETTLE_TIMEOUT);
     }
 
     static setMarkdownModalContent(content: string): void {

--- a/e2e/addingAndRemovingRepositories.spec.ts
+++ b/e2e/addingAndRemovingRepositories.spec.ts
@@ -330,19 +330,17 @@ test('gitCommit filename validator UX', async ({ page }) => {
   await page.goto('http://localhost:8888/?tutorial=none');
   await expect(page).toHaveTitle(/EAGLE/);
 
-  // Open modal in a controlled state so only filename validation is under test.
-  await page.evaluate(() => {
-    const w = window as any;
-    const $ = w.$;
-    const graphFileType = w.Eagle?.FileType?.Graph ?? 'Graph';
-
-    $('#gitCommitModal').data('fileType', graphFileType);
-    $('#gitCommitModalFileNameInput').val('invalid-name.txt');
-    $('#gitCommitModal').modal('show');
-    $('#gitCommitModalFileNameInput').trigger('input');
-  });
+  // Open git commit modal via UI interactions.
+  await TestHelpers.setUIMode(page, 'Expert');
+  await TestHelpers.createNewGraph(page);
+  await page.locator('#navbarDropdownGraph').click();
+  await page.getByText('Git Storage').first().hover();
+  await page.locator('#commitToGitAsGraph').click();
 
   await expect(page.locator('#gitCommitModal')).toBeVisible();
+
+  // Invalid extension should show inline feedback and disable commit.
+  await page.locator('#gitCommitModalFileNameInput').fill('invalid-name.txt');
   await expect(page.locator('#gitCommitModalFileNameInput')).toHaveClass(/is-invalid/);
   await expect(page.locator('#validationFeedback')).toContainText("File name must end with '.graph'.");
   await expect(page.locator('#gitCommitModalAffirmativeButton')).toBeDisabled();
@@ -352,8 +350,18 @@ test('gitCommit filename validator UX', async ({ page }) => {
   await expect(page.locator('#gitCommitModalFileNameInput')).toHaveClass(/is-valid/);
   await expect(page.locator('#gitCommitModalAffirmativeButton')).toBeEnabled();
 
-  await page.locator('#gitCommitModalNegativeButton').click();
-  await expect(page.locator('#gitCommitModal')).toBeHidden();
+  const gitCommitModal = page.locator('#gitCommitModal');
+  const gitCommitCancelButton = page.locator('#gitCommitModalNegativeButton');
+
+  // Modal close is animated and can be flaky across browsers; assert transition states before final hidden check.
+  await expect(gitCommitCancelButton).toBeVisible();
+  await expect(gitCommitCancelButton).toBeEnabled();
+  await gitCommitCancelButton.click();
+
+  // First ensure bootstrap removed the "show" state, then confirm backdrop is gone and modal is hidden.
+  await expect(gitCommitModal).not.toHaveClass(/show/);
+  await expect(page.locator('.modal-backdrop.show')).toHaveCount(0);
+  await expect(gitCommitModal).toBeHidden({ timeout: TestHelpers.LONG_TIMEOUT });
 
   await page.close();
 });

--- a/e2e/undoRedo.spec.ts
+++ b/e2e/undoRedo.spec.ts
@@ -73,3 +73,30 @@ test('Undo', async ({ page }) => {
     // close the browser
     await page.close();
 });
+
+test('Undo recomputes navbar graph issues state', async ({ page }) => {
+    await page.goto('http://localhost:8888/?tutorial=none');
+
+    await TestHelpers.setUIMode(page, 'Expert');
+
+    await TestHelpers.createNewGraph(page);
+    await TestHelpers.setShortDescription(page, 'Undo regression graph');
+    await TestHelpers.setDetailedDescription(page, 'Graph used to verify navbar issue recomputation after undo.');
+
+    await expect.poll(async () => await TestHelpers.getNumWarningsErrors(page)).toBe(0);
+    await expect(page.locator('#checkEagleDone')).toBeVisible();
+
+    await TestHelpers.setShortDescription(page, '');
+    const warningCountAfterMutation = await TestHelpers.getNumWarningsErrors(page);
+
+    expect(warningCountAfterMutation).toBeGreaterThan(0);
+    await expect(page.locator('#checkEagleWarnings')).toBeVisible();
+
+    await TestHelpers.undo(page);
+
+    await expect.poll(async () => await TestHelpers.getNumWarningsErrors(page)).toBe(0);
+    await expect(page.locator('#checkEagleDone')).toBeVisible();
+    await expect(page.locator('#checkEagleWarnings')).toBeHidden();
+
+    await page.close();
+});

--- a/src/Eagle.ts
+++ b/src/Eagle.ts
@@ -5185,6 +5185,7 @@ export class Eagle {
 
         // check graph (hopefully the 'missing short description' warning will go away)
         this.checkEagle();
+        this.undo().pushSnapshot(this, `Edit ${fileInfo.type} short description`);
     }
 
     editDetailedDescription = async(fileInfo: FileInfo): Promise<void> => {
@@ -5203,6 +5204,7 @@ export class Eagle {
 
         // check graph (hopefully the 'missing detailed description' warning will go away)
         this.checkEagle();
+        this.undo().pushSnapshot(this, `Edit ${fileInfo.type} detailed description`);
     }
 
     editNodeDescription = async (node?: Node): Promise<void> => {


### PR DESCRIPTION
The fix was to make EAGLE take an Undo snapshot after editing the short/detailed graph description(s). So just a two-line fix in Eagle.ts

Otherwise I improved a few existing tests by moving code out of page.evaluate(), and more robust waiting for correct results of test actions.

Added a new test for the bug scenario:

1. New Graph
2. Set both short and detailed graph descriptions to valid values
3. Check for no graph errors
4. Set short description to an empty string
5. Check there is an error
6. Undo
7. Check that there are no errors

## Summary by Sourcery

Ensure undo operations correctly recompute navbar warning/error state after editing graph descriptions and strengthen related end-to-end coverage.

New Features:
- Add undo regression test verifying navbar warning/error badges are updated after undoing short description changes.

Bug Fixes:
- Record undo snapshots when editing short and detailed graph descriptions so undo clears related graph warnings/errors in the navbar.

Enhancements:
- Refine test helpers to interact with description and code modals via realistic UI flows and more robust timing, including reading badge counts from the navbar.
- Improve git commit filename validation UX test to use real UI interactions and assert modal close behavior more reliably.

Tests:
- Extend undo/redo e2e suite with a scenario covering navbar graph issue state after undoing description edits.
- Refactor existing e2e helpers and specs to reduce direct page.evaluate usage and rely on UI-driven interactions and explicit modal state assertions.