### PR TITLE
EAGLE-1151: Handle empty/malformed graph version safely

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1669,14 +1669,19 @@ export class Utils {
         return Eagle.FileType.Unknown;
     }
 
-    static determineEagleVersion(data: any): string {
-        if (typeof data.modelData !== 'undefined'){
-            const eagleVersion = data.modelData.eagleVersion;
+    static determineEagleVersion(data: { modelData?: { eagleVersion?: unknown, generatorVersion?: unknown } } | null | undefined): string {
+        if (typeof data !== 'object' || data === null){
+            return "Unknown";
+        }
+
+        const modelData = data.modelData;
+        if (typeof modelData === 'object' && modelData !== null){
+            const eagleVersion = modelData.eagleVersion;
             if (typeof eagleVersion === 'string' && eagleVersion.trim() !== ""){
                 return eagleVersion.trim();
             }
 
-            const generatorVersion = data.modelData.generatorVersion;
+            const generatorVersion = modelData.generatorVersion;
             if (typeof generatorVersion === 'string' && generatorVersion.trim() !== ""){
                 return generatorVersion.trim();
             }
@@ -1685,7 +1690,7 @@ export class Utils {
         return "Unknown";
     }
 
-    private static _parseEagleVersion(version: string): number[] | null {
+    private static _parseEagleVersion(version: string | undefined | null): number[] | null {
         if (typeof version !== 'string'){
             return null;
         }
@@ -1704,7 +1709,7 @@ export class Utils {
     }
 
     // return true iff version0 is newer than version1
-    static newerEagleVersion(version0: string, version1: string){
+    static newerEagleVersion(version0: string | undefined | null, version1: string | undefined | null){
         const v0 = Utils._parseEagleVersion(version0);
         const v1 = Utils._parseEagleVersion(version1);
         if (v0 === null || v1 === null){

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1671,22 +1671,45 @@ export class Utils {
 
     static determineEagleVersion(data: any): string {
         if (typeof data.modelData !== 'undefined'){
-            if (typeof data.modelData.eagleVersion !== 'undefined'){
-                return data.modelData.eagleVersion;
+            const eagleVersion = data.modelData.eagleVersion;
+            if (typeof eagleVersion === 'string' && eagleVersion.trim() !== ""){
+                return eagleVersion.trim();
+            }
+
+            const generatorVersion = data.modelData.generatorVersion;
+            if (typeof generatorVersion === 'string' && generatorVersion.trim() !== ""){
+                return generatorVersion.trim();
             }
         }
 
-        return "v-1.-1.-1";
+        return "Unknown";
+    }
+
+    private static _parseEagleVersion(version: string): number[] | null {
+        if (typeof version !== 'string'){
+            return null;
+        }
+
+        const normalizedVersion = version.trim();
+        if (normalizedVersion === "" || normalizedVersion.toLowerCase() === "unknown"){
+            return null;
+        }
+
+        const versionMatch = normalizedVersion.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+        if (versionMatch === null){
+            return null;
+        }
+
+        return [Number(versionMatch[1]), Number(versionMatch[2]), Number(versionMatch[3])];
     }
 
     // return true iff version0 is newer than version1
     static newerEagleVersion(version0: string, version1: string){
-        if (version0 === "Unknown" || version1 === "Unknown"){
+        const v0 = Utils._parseEagleVersion(version0);
+        const v1 = Utils._parseEagleVersion(version1);
+        if (v0 === null || v1 === null){
             return false;
         }
-
-        const v0 = version0.split('v')[1].split('.').map(Number);
-        const v1 = version1.split('v')[1].split('.').map(Number);
 
         return (
             v0[0] > v1[0] ||


### PR DESCRIPTION
Updated Utils.determineEagleVersion to handle undefined and empty strings, and fall back to "generatorVersion" is the eagleVersion is not present.

Updated Utils._parseEagleVersion to handle undefined, null, empty string, "unknown", and versions with no "v" prefix.

Fixes hanging bug that used to occur when loading a graph with no "eagleVersion".

## Summary by Sourcery

Improve Eagle version handling to robustly support missing or malformed version metadata and avoid hangs when loading graphs.

Bug Fixes:
- Prevent application hangs when loading graphs that lack a valid eagleVersion field.

Enhancements:
- Make determineEagleVersion resilient to undefined, empty, or missing eagleVersion values by falling back to generatorVersion or a default value.
- Introduce a centralized eagle version parser that safely handles null, undefined, empty, "unknown", and unprefixed version strings before comparing versions.